### PR TITLE
Made Evaluator a trait

### DIFF
--- a/repl/src/main/scala/ammonite/repl/eval/Compiler.scala
+++ b/repl/src/main/scala/ammonite/repl/eval/Compiler.scala
@@ -34,6 +34,17 @@ object Compiler{
     singleFile
   }
 }
+
+trait Compiler {
+  import ammonite.repl.eval.Compiler._
+
+  def parse(line: String): Parsed
+  def complete(index: Int, allCode: String): (Int, Seq[String])
+  def compile(src: Array[Byte]): Output
+  def importsFor(wrapperName: String, allCode: String): Seq[(String, String)]
+  def askShutdown(): Unit
+}
+
 /**
  * Encapsulates (almost) all the ickiness of Scalac so it doesn't leak into
  * the rest of the codebase.
@@ -42,10 +53,10 @@ object Compiler{
  * classfile per source-string (e.g. inner classes, or lambdas). Also lets
  * you query source strings using an in-built presentation compiler
  */
-class Compiler(jarDeps: Seq[java.io.File],
+class ScalaCompiler(jarDeps: Seq[java.io.File],
                dirDeps: Seq[java.io.File],
                dynamicClasspath: VirtualDirectory,
-               logger: String => Unit) {
+               logger: String => Unit) extends Compiler {
   import ammonite.repl.eval.Compiler._
 
   /**
@@ -74,6 +85,9 @@ class Compiler(jarDeps: Seq[java.io.File],
       }
     }
   }
+
+  def askShutdown(): Unit =
+    pressy.askShutdown()
 
   val (vd, reporter, compiler) = {
     val (settings, reporter, vd, jcp) = initGlobalBits(logger, scala.Console.RED)

--- a/repl/src/main/scala/ammonite/repl/eval/Preprocessor.scala
+++ b/repl/src/main/scala/ammonite/repl/eval/Preprocessor.scala
@@ -10,12 +10,16 @@ object Preprocessor{
   case class Output(code: String, printer: String)
 }
 
+trait Preprocessor {
+  def apply(code: String, wrapperId: Int): Result[Preprocessor.Output]
+}
+
 /**
  * Converts REPL-style snippets into full-fledged Scala source files,
  * ready to feed into the compiler. Each source-string is turned into
  * three things:
  */
-class Preprocessor(parse: String => Parsed){
+class ScalaPreprocessor(parse: String => Parsed) extends Preprocessor {
   
 
   def Processor(cond: PartialFunction[(String, String, Global#Tree), Preprocessor.Output]) = {

--- a/repl/src/test/scala/ammonite/repl/AutocompleteTests.scala
+++ b/repl/src/test/scala/ammonite/repl/AutocompleteTests.scala
@@ -17,7 +17,7 @@ object AutocompleteTests extends TestSuite{
       val prevImports = check.eval.previousImportBlock
       val prev = prevImports + "\n" + "object Foo{\n"
       import collection.JavaConversions._
-      val (index, completions) = check.compiler.complete(
+      val (index, completions) = check.eval.complete(
         cursor + prev.length,
         prev + buf + "\n}"
       )

--- a/repl/src/test/scala/ammonite/repl/Checker.scala
+++ b/repl/src/test/scala/ammonite/repl/Checker.scala
@@ -2,53 +2,41 @@ package ammonite.repl
 
 import java.io.File
 
-import ammonite.repl.eval
-import ammonite.repl.eval.{Classpath, Evaluator, Compiler, Preprocessor}
-import ammonite.repl.frontend.{FullReplAPI, ReplAPI, ReplAPIHolder}
+import ammonite.repl.eval._
+import ammonite.repl.frontend.FullReplAPI
 import utest._
 
-import scala.collection.mutable
 import scala.reflect.runtime.universe._
 import scala.reflect.io.VirtualDirectory
 
 
 class Checker {
   val dynamicClasspath = new VirtualDirectory("(memory)", None)
-  val compiler = new Compiler(Classpath.jarDeps, Classpath.dirDeps, dynamicClasspath, println)
-  val preprocess = new Preprocessor(compiler.parse)
-  val eval = new Evaluator(
+  val eval: Evaluator = new ScalaEvaluator(
     Thread.currentThread().getContextClassLoader,
     Nil,
-    preprocess.apply,
-    compiler.compile,
-    compiler.importsFor
-  ){
-    override val previousImports = mutable.Map(
-      "PPrintConfig" -> "import ammonite.pprint.Config.Defaults.PPrintConfig"
-    )
-  }
-  compiler.importsFor("", eval.replBridgeCode)
-  val cls = eval.evalClass(eval.replBridgeCode, "ReplBridge")
-
-  ReplAPI.initReplBridge(
-    cls.asInstanceOf[Result.Success[Class[ReplAPIHolder]]].s,
-    new FullReplAPI {
-      def help: String = "Hello!"
-      def history: Seq[String] = Seq("1")
-      def shellPPrint[T: WeakTypeTag](value: => T, ident: String) = {
-        ident + ": " + weakTypeOf[T].toString
-      }
-      def shellPrintDef(definitionLabel: String, ident: String) = {
-        s"defined $definitionLabel $ident"
-      }
-      var shellPrompt = "scala>"
-
-      // Not needed for tests
-      def load(jar: File) = ()
-      def newCompiler() = ()
-      def loadIvy(groupId: String, artifactId: String, version: String) = ()
-    }
+    Seq("PPrintConfig" -> "import ammonite.pprint.Config.Defaults.PPrintConfig")
   )
+
+  eval.setJars(Classpath.jarDeps, Classpath.dirDeps, dynamicClasspath)
+
+  eval.initReplBridge(new FullReplAPI {
+    def help: String = "Hello!"
+    def history: Seq[String] = Seq("1")
+    def shellPPrint[T: WeakTypeTag](value: => T, ident: String) = {
+      ident + ": " + weakTypeOf[T].toString
+    }
+    def shellPrintDef(definitionLabel: String, ident: String) = {
+      s"defined $definitionLabel $ident"
+    }
+    var shellPrompt = "scala>"
+
+    // Not needed for tests
+    def load(jar: File) = ()
+    def newCompiler() = ()
+    def loadIvy(groupId: String, artifactId: String, version: String) = ()
+  })
+
   def apply(input: String, expected: String = null) = {
     print(".")
     val processed = eval.processLine(input)


### PR DESCRIPTION
Hi,
I'm thinking about plugging some other evaluators on your repl. For that, this PR tries to abstract away the `Evaluator` API. Would you be ok with keeping a distinct `Evaluator` trait like this? Ideally, with no too low level methods on it, like `evalClass` and the like.