### PR TITLE
Early Scala 2.10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: scala
 scala:
 - 2.11.4
+- 2.10.5
 jdk:
 - oraclejdk7
 - oraclejdk8

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ publishTo := Some(Resolver.file("Unused transient repository", file("target/unus
 
 val sharedSettings = Seq(
   scalaVersion := "2.11.5",
+  crossScalaVersions := Seq("2.11.5", "2.10.5"),
   organization := "com.lihaoyi",
   version := "0.2.4",
   libraryDependencies += "com.lihaoyi" %% "utest" % "0.3.0" % "test",
@@ -43,6 +44,15 @@ lazy val pprint = project
   .settings(sharedSettings:_*)
   .settings(
     name := "ammonite-pprint",
+    libraryDependencies ++= {
+      if (scalaVersion.value startsWith "2.10.")
+        Seq(
+          "org.scalamacros" %% "quasiquotes" % "2.0.1",
+          compilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)
+        )
+      else
+        Seq()
+    },
     sourceGenerators in Compile <+= sourceManaged in Compile map { dir =>
       val file = dir/"ammonite"/"pprint"/"PPrintGen.scala"
       val tuples = (1 to 22).map{ i =>
@@ -98,7 +108,9 @@ lazy val repl = project
       "com.lihaoyi" %% "scala-parser" % "0.1.1"
     ),
     javaOptions += "-Xmx2G",
-    fork in (Test, testOnly) := true
+    fork in (Test, testOnly) := true,
+    // Will not be necessary with sbt 0.13.8
+    unmanagedSourceDirectories in Compile += (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"
   )
 
 lazy val readme = project

--- a/ops/src/main/scala/ammonite/ops/Shellout.scala
+++ b/ops/src/main/scala/ammonite/ops/Shellout.scala
@@ -15,7 +15,7 @@ import scala.language.dynamics
 object % extends %(Vector.empty){
   def execute(cmd: Seq[String]): CommandResult = {
     import scala.sys.process._
-    CommandResult(cmd.lineStream)
+    CommandResult(cmd.lines) // Should be lineStream instead of lines in 2.11, doing this for 2.10 compatibility
 //    %git                    %.git
 //    %git %diff              %.git(%).diff
 //    %git "clean"            %.git("clean")

--- a/pprint/src/main/scala/ammonite/pprint/PPrint.scala
+++ b/pprint/src/main/scala/ammonite/pprint/PPrint.scala
@@ -224,7 +224,8 @@ object Internals {
   }
 
   object LowerPriPPrint {
-    def FinalRepr[T: c.WeakTypeTag](c: scala.reflect.macros.blackbox.Context) = c.Expr[PPrint[T]] {
+    // Should use blackbox.Context in 2.11, doing this for 2.10 compatibility
+    def FinalRepr[T: c.WeakTypeTag](c: scala.reflect.macros.Context) = c.Expr[PPrint[T]] {
       import c.universe._
 
       val tpe = c.weakTypeOf[T]

--- a/repl/src/main/scala-2.10/ammonite/repl/interp/CompilerCompatibility.scala
+++ b/repl/src/main/scala-2.10/ammonite/repl/interp/CompilerCompatibility.scala
@@ -1,0 +1,20 @@
+package ammonite.repl.interp
+
+import scala.tools.nsc.Global
+import scala.tools.nsc.interactive.{ Global => InteractiveGlobal }
+import scala.tools.nsc.typechecker.Analyzer
+
+object CompilerCompatibility {
+  def analyzer(g: Global): Analyzer { val global: g.type } =
+    new { val global: g.type = g } with Analyzer {
+      override lazy val macroClassloader = new ClassLoader(this.getClass.getClassLoader) {}
+    }
+
+  type InteractiveAnalyzer = Analyzer
+
+  def interactiveAnalyzer(g: InteractiveGlobal): InteractiveAnalyzer { val global: g.type } =
+    analyzer(g)
+
+  def trees(g: Global)(parser: g.syntaxAnalyzer.UnitParser): Seq[Global#Tree] =
+    parser.templateStats() ++ parser.topStatSeq()
+}

--- a/repl/src/main/scala-2.11/ammonite/repl/interp/CompilerCompatibility.scala
+++ b/repl/src/main/scala-2.11/ammonite/repl/interp/CompilerCompatibility.scala
@@ -1,0 +1,22 @@
+package ammonite.repl.interp
+
+import scala.tools.nsc.Global
+import scala.tools.nsc.interactive.{ Global => InteractiveGlobal }
+import scala.tools.nsc.typechecker.Analyzer
+
+object CompilerCompatibility {
+  def analyzer(g: Global): Analyzer { val global: g.type } =
+    new { val global: g.type = g } with Analyzer {
+      override def findMacroClassLoader() = new ClassLoader(this.getClass.getClassLoader){}
+    }
+
+  type InteractiveAnalyzer = scala.tools.nsc.interactive.InteractiveAnalyzer
+
+  def interactiveAnalyzer(g: InteractiveGlobal): InteractiveAnalyzer { val global: g.type } =
+    new { val global: g.type = g } with InteractiveAnalyzer {
+      override def findMacroClassLoader() = new ClassLoader(this.getClass.getClassLoader) {}
+    }
+
+  def trees(g: Global)(parser: g.syntaxAnalyzer.UnitParser): Seq[Global#Tree] =
+    parser.parseStatsOrPackages()
+}

--- a/repl/src/main/scala/ammonite/repl/IvyThing.scala
+++ b/repl/src/main/scala/ammonite/repl/IvyThing.scala
@@ -14,7 +14,7 @@ object IvyConstructor extends IvyConstructor
 trait IvyConstructor{
   implicit class GroupIdExt(groupId: String){
     def %(artifactId: String) = (groupId, artifactId)
-    def %%(artifactId: String) = (groupId, artifactId + "_2.11")
+    def %%(artifactId: String) = (groupId, artifactId + "_" + IvyThing.scalaBinaryVersion)
   }
   implicit class ArtifactIdExt(t: (String, String)){
     def %(version: String) = (t._1, t._2, version)
@@ -29,6 +29,9 @@ trait IvyConstructor{
  * And transliterated into Scala. I have no idea how or why it works.
  */
 object IvyThing {
+  val scalaBinaryVersion = scala.util.Properties.versionString
+    .stripPrefix("version ").split('.').take(2).mkString(".")
+
   def resolveArtifact(groupId: String, artifactId: String, version: String) = {
     //url resolver for configuration of maven repo
     val resolver = {

--- a/tools/src/main/scala/ammonite/tools/Tools.scala
+++ b/tools/src/main/scala/ammonite/tools/Tools.scala
@@ -22,7 +22,7 @@ object Grepper{
   }
   implicit object Str extends Grepper[String] {
     def apply[V: ammonite.pprint.PPrint](t: String, s: V) = {
-      Regex.apply(scala.util.matching.Regex.quote(t).r, s)
+      Regex.apply(java.util.regex.Pattern.quote(t).r, s)
     }
   }
 


### PR DESCRIPTION
This PR adds support for Scala 2.10, if it's something you'd like to have in Ammonite.

Don't merge now !!!
Some tests don't pass, for various reasons (some Ivy dependencies not available in 2.10, ...), but I would see clearer in them if they all would pass in 2.11 :P

Basic repl interaction is ok though (results display, autocompletion, Ivy deps, ...)