### PR TITLE
SBT plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,19 +4,18 @@ publishArtifact := false
 
 publishTo := Some(Resolver.file("Unused transient repository", file("target/unusedrepo")))
 
-val sharedSettings = Seq(
-  scalaVersion := "2.11.5",
-  organization := "com.lihaoyi",
-  version := "0.2.4",
-  libraryDependencies += "com.lihaoyi" %% "utest" % "0.3.0" % "test",
-  testFrameworks += new TestFramework("utest.runner.Framework"),
-  scalacOptions += "-target:jvm-1.7",
+val acyclicSettings = Seq(
   autoCompilerPlugins := true,
   addCompilerPlugin("com.lihaoyi" %% "acyclic" % "0.1.2"),
   libraryDependencies ++= Seq(
-    "com.lihaoyi" %% "acyclic" % "0.1.2" % "provided",
-    "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided"
-  ),
+    "com.lihaoyi" %% "acyclic" % "0.1.2" % "provided"
+  )
+)
+
+val publishingSettings = Seq(
+  organization := "com.lihaoyi",
+  version := "0.2.4",
+  scalacOptions += "-target:jvm-1.7",
   publishTo := Some("releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2"),
   pomExtra :=
     <url>https://github.com/lihaoyi/Ammonite</url>
@@ -38,6 +37,15 @@ val sharedSettings = Seq(
         </developer>
       </developers>
 )
+
+val sharedSettings = Seq(
+  scalaVersion := "2.11.5",
+  libraryDependencies += "com.lihaoyi" %% "utest" % "0.3.0" % "test",
+  testFrameworks += new TestFramework("utest.runner.Framework"),
+  libraryDependencies ++= Seq(
+    "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided"
+  )
+) ++ acyclicSettings ++ publishingSettings
 
 lazy val pprint = project
   .settings(sharedSettings:_*)
@@ -107,3 +115,10 @@ lazy val readme = project
     libraryDependencies += "com.lihaoyi" %% "scalatex-site" % "0.1.1",
     scalaVersion := "2.11.4"
 )
+
+lazy val plugin = project.in(file("sbt-plugin")).copy(id = "sbt-plugin")
+  .settings(acyclicSettings ++ publishingSettings: _*)
+  .settings(
+    name := "ammonite-sbt",
+    sbtPlugin := true
+  )

--- a/sbt-plugin/src/main/scala/ammonite/AmmonitePlugin.scala
+++ b/sbt-plugin/src/main/scala/ammonite/AmmonitePlugin.scala
@@ -1,0 +1,45 @@
+package ammonite
+
+import sbt._, Keys._
+
+object AmmonitePlugin extends AutoPlugin {
+
+  // Inspired by https://github.com/alexarchambault/sbt-notebook
+
+  lazy val Ammonite = config("ammonite") extend (Compile, Runtime)
+
+  object autoImport {
+    val ammoniteVersion = settingKey[String]("Ammonite version")
+    val repl = taskKey[Unit]("Run an Ammonite REPL")
+  }
+
+  import autoImport._
+
+  override def trigger = allRequirements
+
+  override lazy val projectSettings = inConfig(Ammonite)(
+    Defaults.compileSettings ++ Defaults.runnerSettings ++ Classpaths.ivyBaseSettings ++
+    Seq(
+      /* Overriding run and runMain defined by compileSettings so that they use the scoped fullClasspath */
+      run <<= Defaults.runTask(fullClasspath, mainClass in run, runner in run),
+      runMain <<= Defaults.runMainTask(fullClasspath, runner in run),
+      /* Overriding classDirectory defined by compileSettings so that we are given
+        the classDirectory of the default scope in runMain below */
+      classDirectory := crossTarget.value / "classes",
+      /* Adding ammonite-repl dependency */
+      libraryDependencies += "com.lihaoyi" %% "ammonite-repl" % (ammoniteVersion in Runtime).value,
+      connectInput := true
+    )
+  ) ++ Seq(
+    ammoniteVersion := "0.2.4",
+    repl <<= Def.taskDyn {
+      /* Compiling the root project, so that its build products and those of its dependency sub-projects are available
+         in the classpath */
+      (compile in Runtime).value
+
+      val mainClass = "ammonite.repl.Repl"
+      (runMain in Ammonite).toTask(s" $mainClass")
+    }
+  )
+
+}


### PR DESCRIPTION
Use it by adding
```scala
addSbtPlugin("com.lihaoyi" %% "ammonite-sbt" % "0.2.4")
```
to `project/plugins.sbt` or globally in `~/.sbt/0.13/plugins/build.sbt`.

At the sbt prompt of a sbt project, type `repl` and an Ammonite repl with the project dependencies and build products in the classpath will be launched.

Requires sbt >= 0.13.5 (for auto plugins).