### PR TITLE
More generic interpreter API

### DIFF
--- a/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -28,7 +28,7 @@ class Repl(input: InputStream,
     initialHistory
   )
 
-  val interp: Interpreter = new Interpreter(
+  val interp: Interpreter.Console = Interpreter.console(
     frontEnd.update,
     shellPrompt,
     pprintConfig.copy(maxWidth = frontEnd.width),

--- a/repl/src/main/scala/ammonite/repl/Util.scala
+++ b/repl/src/main/scala/ammonite/repl/Util.scala
@@ -75,8 +75,9 @@ case class Catching(handler: PartialFunction[Throwable, Res.Failing]) {
     try Res.Success(t(())) catch handler
 }
 
-case class Evaluated(wrapper: String,
-                     imports: Seq[ImportData])
+case class Evaluated[T](wrapper: String,
+                        imports: Seq[ImportData],
+                        value: T)
 
 case class ImportData(fromName: String,
                       toName: String,

--- a/repl/src/main/scala/ammonite/repl/frontend/JLineFrontend.scala
+++ b/repl/src/main/scala/ammonite/repl/frontend/JLineFrontend.scala
@@ -18,7 +18,7 @@ trait JLineFrontend{
    */
   def width: Int
   def action(buffered: String): Res[String]
-  def update(buffered: String, r: Res[Evaluated]): Unit
+  def update(buffered: String, r: Res[Evaluated[_]]): Unit
 }
 object JLineFrontend{
   def apply(input: InputStream,
@@ -78,7 +78,7 @@ object JLineFrontend{
 
     } yield buffered + res
 
-    def update(buffered: String, r: Res[Evaluated]) = r match{
+    def update(buffered: String, r: Res[Evaluated[_]]) = r match{
 
       case Res.Buffer(line) =>
         /**

--- a/repl/src/main/scala/ammonite/repl/frontend/ReplAPI.scala
+++ b/repl/src/main/scala/ammonite/repl/frontend/ReplAPI.scala
@@ -5,7 +5,7 @@ import java.io.File
 import scala.reflect.runtime.universe._
 import acyclic.file
 
-import scala.util.control.ControlThrowable
+import ammonite.repl.interp.Evaluator.Exit
 
 
 class ReplAPIHolder {
@@ -13,16 +13,11 @@ class ReplAPIHolder {
   lazy val shell = shell0
 }
 
-/**
- * Thrown to exit the REPL cleanly
- */
-case object ReplExit extends ControlThrowable
-
 trait ReplAPI {
   /**
    * Exit the Ammonite REPL. You can also use Ctrl-D to exit
    */
-  def exit = throw ReplExit
+  def exit = throw Exit
 
   /**
    * Clears the screen of the REPL

--- a/repl/src/main/scala/ammonite/repl/interp/AmmonitePlugin.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/AmmonitePlugin.scala
@@ -28,7 +28,11 @@ class AmmonitePlugin(g: scala.tools.nsc.Global, output: Seq[ImportData] => Unit)
           (sym, sym.decodedName, sym.decodedName, "")
         }
         def apply(unit: g.CompilationUnit): Unit = {
-          val stats = unit.body.children.last.asInstanceOf[g.ModuleDef].impl.body
+          val stats = unit.body.children.last match {
+            case m: g.ModuleDef => m.impl.body
+            case c: g.ClassDef => c.impl.body
+            case other => throw new IllegalArgumentException(s"Unsupported wrapper definition: $other")
+          }
           val symbols = stats.foldLeft(List.empty[(g.Symbol, String, String, String)]){
             // These are all the ways we want to import names from previous
             // executions into the current one. Most are straightforward, except

--- a/repl/src/main/scala/ammonite/repl/interp/Evaluator.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Evaluator.scala
@@ -41,6 +41,7 @@ trait Evaluator[-A, +B] {
   def addJar(url: URL): Unit
   def newClassloader(): Unit
   def evalClassloader: ClassLoader
+  def classes: Map[String, Array[Byte]]
 }
 
 object Evaluator{
@@ -69,6 +70,7 @@ object Evaluator{
      * classloader can get at them.
      */
     val newFileDict = mutable.Map.empty[String, Array[Byte]]
+    def classes = newFileDict.toMap
 
     /**
      * Imports which are required by earlier commands to the REPL. Imports

--- a/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
@@ -34,7 +34,8 @@ class Interpreter[A,B](handleResult: => (String, Res[Evaluated[_]]) => Unit,
 
   def processLine[C](line: String,
                      saveHistory: (String => Unit, String) => Unit,
-                     printer: B => C) = for{
+                     printer: B => C,
+                     useClassWrapper: Boolean = false) = for{
     _ <- Catching { case Ex(x@_*) =>
       val Res.Failure(trace) = Res.Failure(x)
       Res.Failure(trace + "\nSomething unexpected went wrong =(")
@@ -44,7 +45,7 @@ class Interpreter[A,B](handleResult: => (String, Res[Evaluated[_]]) => Unit,
     oldClassloader = Thread.currentThread().getContextClassLoader
     out <- try{
       Thread.currentThread().setContextClassLoader(eval.evalClassloader)
-      eval.processLine(p, printer)
+      eval.processLine(p, printer, useClassWrapper)
     } finally Thread.currentThread().setContextClassLoader(oldClassloader)
   } yield out
 

--- a/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
@@ -135,6 +135,8 @@ class Interpreter(handleResult: => (String, Res[Evaluated[_]]) => Unit,
 
   val eval = Evaluator[Preprocessor.Output, Iterator[String]](
     mainThread.getContextClassLoader,
+    Evaluator.namesFor[ReplAPI].map(n => n -> ImportData(n, n, "", "ReplBridge.shell")).toSeq ++
+      Evaluator.namesFor[ammonite.repl.IvyConstructor].map(n => n -> ImportData(n, n, "", "ammonite.repl.IvyConstructor")).toSeq,
     preprocess.apply,
     {
       (p: Preprocessor.Output, previousImportBlock: String, wrapperName: String) =>

--- a/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
@@ -13,7 +13,7 @@ import scala.reflect.io.VirtualDirectory
  * to interpret Scala code. Doesn't attempt to provide any
  * real encapsulation for now.
  */
-class Interpreter(handleResult: => (String, Res[Evaluated]) => Unit,
+class Interpreter(handleResult: => (String, Res[Evaluated[_]]) => Unit,
                   shellPrompt0: => Ref[String],
                   pprintConfig: pprint.Config = pprint.Config.Defaults.PPrintConfig,
                   colors0: ColorSet = ColorSet.BlackWhite,
@@ -42,7 +42,7 @@ class Interpreter(handleResult: => (String, Res[Evaluated]) => Unit,
     } finally Thread.currentThread().setContextClassLoader(oldClassloader)
   } yield out
 
-  def handleOutput(res: Res[Evaluated]) = {
+  def handleOutput(res: Res[Evaluated[_]]) = {
     handleResult(buffered, res)
 
     res match{

--- a/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
@@ -7,18 +7,24 @@ import ammonite.repl._
 import ammonite.repl.frontend._
 
 import scala.reflect.io.VirtualDirectory
+import scala.tools.nsc.Global
 
 /**
  * A convenient bundle of all the functionality necessary
  * to interpret Scala code. Doesn't attempt to provide any
  * real encapsulation for now.
  */
-class Interpreter(handleResult: => (String, Res[Evaluated[_]]) => Unit,
-                  shellPrompt0: => Ref[String],
-                  pprintConfig: pprint.Config = pprint.Config.Defaults.PPrintConfig,
-                  colors0: ColorSet = ColorSet.BlackWhite,
-                  stdout: String => Unit,
-                  initialHistory: Seq[String]){ interp =>
+class Interpreter[A,B](handleResult: => (String, Res[Evaluated[_]]) => Unit,
+                       stdout: String => Unit,
+                       initialHistory: Seq[String],
+                       initialImports: Seq[(String, ImportData)],
+                       preprocessor: (Unit => (String => Either[String, scala.Seq[Global#Tree]])) => (String, Int) => Res[A],
+                       wrap: (A, String, String) => String,
+                       bridgeInit: String,
+                       bridgeInitName: String,
+                       bridgeInitClass: (Interpreter[A,B], Class[_]) => Unit,
+                       jarDeps: Seq[File],
+                       dirDeps: Seq[File]){ interp =>
 
   val dynamicClasspath = new VirtualDirectory("(memory)", None)
   var extraJars = Seq[java.io.File]()
@@ -26,19 +32,19 @@ class Interpreter(handleResult: => (String, Res[Evaluated[_]]) => Unit,
   val history = initialHistory.to[collection.mutable.Buffer]
   var buffered = ""
 
-  def processLine(line: String,
-                  saveHistory: (String => Unit, String) => Unit,
-                  printer: Iterator[String] => Unit) = for{
+  def processLine[C](line: String,
+                     saveHistory: (String => Unit, String) => Unit,
+                     printer: B => C) = for{
     _ <- Catching { case Ex(x@_*) =>
       val Res.Failure(trace) = Res.Failure(x)
       Res.Failure(trace + "\nSomething unexpected went wrong =(")
     }
-    output <- preprocess(line, eval.getCurrentLine)
+    p <- preprocess(line, eval.getCurrentLine)
     _ = saveHistory(history.append(_), line)
     oldClassloader = Thread.currentThread().getContextClassLoader
     out <- try{
       Thread.currentThread().setContextClassLoader(eval.evalClassloader)
-      eval.processLine(output, printer)
+      eval.processLine(p, printer)
     } finally Thread.currentThread().setContextClassLoader(oldClassloader)
   } yield out
 
@@ -69,88 +75,120 @@ class Interpreter(handleResult: => (String, Res[Evaluated[_]]) => Unit,
     }
   }
 
-  lazy val replApi: ReplAPI = new DefaultReplAPI {
-    def imports = interp.eval.previousImportBlock
-    def colors = colors0
-    def shellPrompt: String = shellPrompt0()
-    def shellPrompt_=(s: String) = shellPrompt0() = s
-    object load extends Load{
-
-      def apply(line: String) = handleOutput(processLine(
-        line,
-        (_, _) => (), // Discard history of load-ed lines,
-        _.foreach(print)
-      ))
-
-      def handleJar(jar: File): Unit = {
-        extraJars = extraJars ++ Seq(jar)
-        eval.addJar(jar.toURI.toURL)
-      }
-      def jar(jar: File): Unit = {
-        eval.newClassloader()
-        handleJar(jar)
-        init()
-      }
-      def ivy(coordinates: (String, String, String)): Unit ={
-        val (groupId, artifactId, version) = coordinates
-        eval.newClassloader()
-        IvyThing.resolveArtifact(groupId, artifactId, version)
-          .map(handleJar)
-        init()
-      }
-    }
-    implicit def pprintConfig = interp.pprintConfig
-    def clear() = ()
-    def newCompiler() = init()
-    def history = interp.history.toVector.dropRight(1)
-  }
-
   var compiler: Compiler = _
   var pressy: Pressy = _
   def init() = {
     compiler = Compiler(
-      Classpath.jarDeps ++ extraJars,
-      Classpath.dirDeps,
+      jarDeps ++ extraJars,
+      dirDeps,
       dynamicClasspath,
       () => pressy.shutdownPressy()
     )
     pressy = Pressy(
-      Classpath.jarDeps ++ extraJars,
-      Classpath.dirDeps,
+      jarDeps ++ extraJars,
+      dirDeps,
       dynamicClasspath
     )
 
-    val cls = eval.evalClass(
-      "object ReplBridge extends ammonite.repl.frontend.ReplAPIHolder{}",
-      "ReplBridge"
-    )
-    ReplAPI.initReplBridge(
-      cls.map(_._1).asInstanceOf[Res.Success[Class[ReplAPIHolder]]].s,
-      replApi
-    )
+    val cls = eval.evalClass(bridgeInit, bridgeInitName)
+    bridgeInitClass(interp, cls.map(_._1).asInstanceOf[Res.Success[Class[_]]].s)
   }
 
   val mainThread = Thread.currentThread()
-  val preprocess = Preprocessor(compiler.parse)
+  val preprocess = preprocessor(_ => compiler.parse)
 
-  val eval = Evaluator[Preprocessor.Output, Iterator[String]](
+  val eval = Evaluator[A, B](
     mainThread.getContextClassLoader,
-    Evaluator.namesFor[ReplAPI].map(n => n -> ImportData(n, n, "", "ReplBridge.shell")).toSeq ++
-      Evaluator.namesFor[ammonite.repl.IvyConstructor].map(n => n -> ImportData(n, n, "", "ammonite.repl.IvyConstructor")).toSeq,
+    initialImports,
     preprocess.apply,
-    {
-      (p: Preprocessor.Output, previousImportBlock: String, wrapperName: String) =>
-        s"""$previousImportBlock
-
-            object $wrapperName{
-              ${p.code}
-              def $$main() = {${p.printer.reduceOption(_ + "++ Iterator(\"\\n\") ++" + _).getOrElse("Iterator()")}}
-            }
-         """
-    },
+    wrap,
     compiler.compile,
     stdout
   )
 
   init()
+}
+
+object Interpreter {
+  type Console = Interpreter[Preprocessor.Output, Iterator[String]]
+
+  def consoleInitialImports =
+    Evaluator.namesFor[ReplAPI].map(n => n -> ImportData(n, n, "", "ReplBridge.shell")).toSeq ++
+      Evaluator.namesFor[ammonite.repl.IvyConstructor].map(n => n -> ImportData(n, n, "", "ammonite.repl.IvyConstructor")).toSeq
+
+  def console(handleResult: => (String, Res[Evaluated[_]]) => Unit,
+              shellPrompt0: => Ref[String],
+              pprintConfig0: pprint.Config = pprint.Config.Defaults.PPrintConfig,
+              colors0: ColorSet = ColorSet.BlackWhite,
+              stdout: String => Unit,
+              initialHistory: Seq[String]): Console = {
+    var replApi: ReplAPI = null
+
+    def initReplApi(intp: Console) = {
+      replApi = new DefaultReplAPI {
+        def imports = intp.eval.previousImportBlock
+        def colors = colors0
+        def shellPrompt: String = shellPrompt0()
+        def shellPrompt_=(s: String) = shellPrompt0() = s
+        object load extends Load{
+
+          def apply(line: String) = intp.handleOutput(intp.processLine(
+            line,
+            (_, _) => (), // Discard history of load-ed lines,
+            _.foreach(print)
+          ))
+
+          def handleJar(jar: File): Unit = {
+            intp.extraJars = intp.extraJars ++ Seq(jar)
+            intp.eval.addJar(jar.toURI.toURL)
+          }
+          def jar(jar: File): Unit = {
+            intp.eval.newClassloader()
+            handleJar(jar)
+            intp.init()
+          }
+          def ivy(coordinates: (String, String, String)): Unit ={
+            val (groupId, artifactId, version) = coordinates
+            intp.eval.newClassloader()
+            IvyThing.resolveArtifact(groupId, artifactId, version)
+              .map(handleJar)
+            intp.init()
+          }
+        }
+        implicit def pprintConfig = pprintConfig0
+        def clear() = ()
+        def newCompiler() = intp.init()
+        def history = intp.history.toVector.dropRight(1)
+      }
+    }
+
+    new Interpreter[Preprocessor.Output, Iterator[String]](
+      handleResult, stdout, initialHistory,
+      consoleInitialImports,
+      f => Preprocessor(f()).apply,
+      {
+        (p: Preprocessor.Output, previousImportBlock: String, wrapperName: String) =>
+          s"""$previousImportBlock
+
+              object $wrapperName{
+                ${p.code}
+                def $$main() = {${p.printer.reduceOption(_ + "++ Iterator(\"\\n\") ++" + _).getOrElse("Iterator()")}}
+              }
+           """
+      },
+      "object ReplBridge extends ammonite.repl.frontend.ReplAPIHolder{}",
+      "ReplBridge",
+      {
+        (intp, cls) =>
+          if (replApi == null) initReplApi(intp)
+
+          ReplAPI.initReplBridge(
+            cls.asInstanceOf[Class[ReplAPIHolder]],
+            replApi
+          )
+      },
+      Classpath.jarDeps,
+      Classpath.dirDeps
+    )
+  }
 }

--- a/repl/src/main/scala/ammonite/repl/interp/Preprocessor.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Preprocessor.scala
@@ -11,14 +11,14 @@ import scala.tools.nsc.{Global => G}
  * ready to feed into the compiler. Each source-string is turned into
  * three things:
  */
-trait Preprocessor{
-  def apply(code: String, wrapperId: Int): Res[Preprocessor.Output]
+trait Preprocessor[T] {
+  def apply(code: String, wrapperId: Int): Res[T]
 }
 object Preprocessor{
 
   case class Output(code: String, printer: Seq[String])
 
-  def apply(parse: => String => Either[String, Seq[G#Tree]]): Preprocessor = new Preprocessor{
+  def apply(parse: => String => Either[String, Seq[G#Tree]]): Preprocessor[Output] = new Preprocessor[Output] {
 
     def Processor(cond: PartialFunction[(String, String, G#Tree), Preprocessor.Output]) = {
       (code: String, name: String, tree: G#Tree) => cond.lift(name, code, tree)

--- a/repl/src/test/scala/ammonite/repl/Checker.scala
+++ b/repl/src/test/scala/ammonite/repl/Checker.scala
@@ -7,7 +7,7 @@ import utest._
 
 class Checker {
   var allOutput = ""
-  val interp = new Interpreter(
+  val interp = Interpreter.console(
     (_, _) => (),
     Ref[String](""),
     stdout = allOutput += _,

--- a/repl/src/test/scala/ammonite/repl/Checker.scala
+++ b/repl/src/test/scala/ammonite/repl/Checker.scala
@@ -76,7 +76,7 @@ class Checker {
     }
   }
 
-  def result(input: String, expected: Res[Evaluated]) = {
+  def result(input: String, expected: Res[Evaluated[_]]) = {
     val (processed, printed) = run(input)
     assert(processed == expected)
   }


### PR DESCRIPTION
This PR contains the changes I had to make to re-use Ammonite's `Interpreter` to write a kernel for Jupyter / IPython (https://github.com/alexarchambault/jupyter-scala).

They mainly bring the ability to:
- use a different "bridge" object,
- use different wrapper code,
- wrap the code inside a class rather than an object (required for a Spark)

It also enhances the class loader of `Evaluator` by:
- making it provide the resources corresponding to the classes (resources in `*.class`), which requires having it...
- ...put the generated classes on disk upon demand (this is *on demand*, thus it incurs no cost compared to the current situation if the resources are not requested).

(These are for Spark too.)

These are pretty big changes to the internal API, anything can be discussed. Tests are ok.