### PR TITLE
Add suport for predefs in REPL

### DIFF
--- a/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -48,15 +48,14 @@ class Repl(input: InputStream,
   }
 
   def run() = {
-    @tailrec
-    def loop(): Unit = {
-      val res = action(frontEnd.action(interp.buffered), true)
-      if (interp.handleOutput(res)) loop()
-    }
-
     for (line <- predef.lines map (_.trim) if !line.isEmpty) {
       val res = action(Res.Success(line), false)
       interp.handleOutput(res)
+    }
+
+    @tailrec def loop(): Unit = {
+      val res = action(frontEnd.action(interp.buffered), true)
+      if (interp.handleOutput(res)) loop()
     }
     loop()
   }

--- a/repl/src/main/scala/ammonite/repl/frontend/JLineFrontend.scala
+++ b/repl/src/main/scala/ammonite/repl/frontend/JLineFrontend.scala
@@ -107,7 +107,8 @@ object JLineFrontend{
 
       case Res.Success(ev) =>
         val last = reader.getHistory.size()-1
-        reader.getHistory.set(last, buffered + reader.getHistory.get(last))
+        if (last >= 0)
+          reader.getHistory.set(last, buffered + reader.getHistory.get(last))
 
       case Res.Exit =>
         // Otherwise the terminal gets left in a funny


### PR DESCRIPTION
This is my stab at adding support for predefined commands that are automatically executed when running a REPL with a nonempty `predef` argument.

One possible drawback is that the predefined commands are not written to the history, but maybe this is even desired?
