### PR TITLE
Truncating long PPrint output

### DIFF
--- a/pprint/src/main/scala/ammonite/pprint/Core.scala
+++ b/pprint/src/main/scala/ammonite/pprint/Core.scala
@@ -23,7 +23,7 @@ case class Config(maxWidth: Int = 100,
                   renames: Map[String, String] = Config.defaultRenames)
   extends GenConfig[Config]{
   def deeper = copy(depth = depth + 1)
-  def long = copy(maxHeight = 0)
+  def full = copy(maxHeight = 0)
   def rename(s: String) = renames.getOrElse(s, s)
   object color{
     def apply(s: String, c: String) = {

--- a/pprint/src/main/scala/ammonite/pprint/Core.scala
+++ b/pprint/src/main/scala/ammonite/pprint/Core.scala
@@ -15,7 +15,7 @@ import acyclic.file
  *                TupleN *
  */
 case class Config(maxWidth: Int = 100,
-                  maxHeight: Int = 15,
+                  maxHeight: Int = 0,
                   depth: Int = 0,
                   indent: Int = 2,
                   literalColor: String = null,

--- a/pprint/src/main/scala/ammonite/pprint/Core.scala
+++ b/pprint/src/main/scala/ammonite/pprint/Core.scala
@@ -13,6 +13,7 @@ import acyclic.file
  *                TupleN *
  */
 case class Config(maxWidth: Int = 100,
+                  maxHeight: Int = 15,
                   depth: Int = 0,
                   indent: Int = 2,
                   literalColor: String = null,

--- a/pprint/src/main/scala/ammonite/pprint/Core.scala
+++ b/pprint/src/main/scala/ammonite/pprint/Core.scala
@@ -7,6 +7,8 @@ import acyclic.file
  *
  * @param maxWidth Controls how far to the right a line will go before
  *                 it tries to wrap
+ * @param maxHeight Controls how many lines can be printed at once. 
+ *                  Will print all lines if set to 0
  * @param depth How much the current item being printed should be indented
  * @param renames A map used to rename things to more common names, e.g.
  *                renamig `WrappedArray` to `Array` or getting rid of
@@ -21,6 +23,7 @@ case class Config(maxWidth: Int = 100,
                   renames: Map[String, String] = Config.defaultRenames)
   extends GenConfig[Config]{
   def deeper = copy(depth = depth + 1)
+  def long = copy(maxHeight = 0)
   def rename(s: String) = renames.getOrElse(s, s)
   object color{
     def apply(s: String, c: String) = {

--- a/pprint/src/main/scala/ammonite/pprint/PPrint.scala
+++ b/pprint/src/main/scala/ammonite/pprint/PPrint.scala
@@ -221,8 +221,8 @@ object Internals {
   def takeFirstLines(lines: Int, iter: Iterator[String]):Iterator[String]={
     @tailrec
     def inner(lines: Int, iter: Iterator[String], begin: Iterator[String]): Iterator[String]={
-      if(lines==0) return begin ++ Iterator("...")
       if(!iter.hasNext || lines < 0) return begin
+      if(lines==0) return begin ++ Iterator("...")
       val head = iter.next()
       val remainingLines = if(head.contains('\n')) lines-1 else lines
       inner(remainingLines,iter,begin ++ Iterator(head))

--- a/pprint/src/main/scala/ammonite/pprint/PPrint.scala
+++ b/pprint/src/main/scala/ammonite/pprint/PPrint.scala
@@ -17,6 +17,12 @@ object PPrint extends Internals.LowPriPPrint{
     pprint.render(t)
   }
 
+  def long[T: PPrint](t: T): Iterator[String] = {
+    val pprint = implicitly[PPrint[T]]
+    pprint.renderLong(t)
+  }
+
+
   /**
    * Helper to make implicit resolution behave right
    */
@@ -31,7 +37,16 @@ object PPrint extends Internals.LowPriPPrint{
 case class PPrint[A](a: PPrinter[A], cfg: Config){
   def render(t: A): Iterator[String] = {
     if (t == null) Iterator("null")
-    else takeFirstLines(cfg,a.render(t, cfg))
+    else {
+      if(cfg.maxHeight > 0) takeFirstLines(cfg, a.render(t, cfg))
+      else a.render(t, cfg)
+    }
+  }
+  def renderLong(t: A): Iterator[String] = {
+    if (t == null) Iterator("null")
+    else {
+      a.render(t, cfg)
+    }
   }
   def map(f: String => String) = a.map(f)
 
@@ -42,12 +57,12 @@ case class PPrint[A](a: PPrinter[A], cfg: Config){
       if(lines==0) return begin ++ Iterator(cfg.color.prefix("..."))
       val head = iter.next()
       if(lines < head.length/cfg.maxWidth){
-        return begin ++ Iterator(head.substring(0,lines*cfg.maxWidth),cfg.color.prefix("..."))
+        return begin ++ Iterator(head.substring(0, lines*cfg.maxWidth), cfg.color.prefix("..."))
       }
       val remainingLines = if(head.contains('\n')) lines-1 else lines - head.length/cfg.maxWidth
-      inner(remainingLines,iter,begin ++ Iterator(head))
+      inner(remainingLines, iter, begin ++ Iterator(head))
     }
-    inner(cfg.maxHeight,iter,Iterator.empty)
+    inner(cfg.maxHeight, iter, Iterator.empty)
   }
 
 }

--- a/pprint/src/test/scala/ammonite/pprint/PPrintTests.scala
+++ b/pprint/src/test/scala/ammonite/pprint/PPrintTests.scala
@@ -490,11 +490,27 @@ object PPrintTests extends TestSuite{
       'long_line_truncated{
         implicit val cfg = Config.Defaults.PPrintConfig.copy(
           maxWidth = 100,
-          maxHeight = 1
+          maxHeight = 3
         )
         check(
           "a" * 1000,
-          """"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa..."""
+          """"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa..."""
+        )
+      }
+
+      'stream{
+        implicit val cfg = Config.Defaults.PPrintConfig.copy(
+          maxHeight = 5
+        )
+        check(
+          Stream.continually("foo"),
+          """Stream(
+            |  "foo",
+            |  "foo",
+            |  "foo",
+            |  "foo",
+            |...
+          """.stripMargin
         )
       }
     }

--- a/pprint/src/test/scala/ammonite/pprint/PPrintTests.scala
+++ b/pprint/src/test/scala/ammonite/pprint/PPrintTests.scala
@@ -424,9 +424,8 @@ object PPrintTests extends TestSuite{
         * - check("a"*1000, "\"" + "a"*1000 + "\"")
         * - check(List(1,2,3,4), "List(1, 2, 3, 4)")
         * - check(
-          List.fill(14)("asdfghjklqwertz"),
+          List.fill(13)("asdfghjklqwertz"),
           """List(
-            |  "asdfghjklqwertz",
             |  "asdfghjklqwertz",
             |  "asdfghjklqwertz",
             |  "asdfghjklqwertz",

--- a/pprint/src/test/scala/ammonite/pprint/PPrintTests.scala
+++ b/pprint/src/test/scala/ammonite/pprint/PPrintTests.scala
@@ -523,6 +523,8 @@ object PPrintTests extends TestSuite{
         "1234567890\n"*10,
         "\"\"\"\n1234567890\n1234567890\n..."
       )
+      // The result looks like 10 wide 3 deep, but because of the wrapping
+      // (maxWidth = 8) it is actually 8 wide and 5 deep.
     }
   }
 

--- a/pprint/src/test/scala/ammonite/pprint/PPrintTests.scala
+++ b/pprint/src/test/scala/ammonite/pprint/PPrintTests.scala
@@ -514,6 +514,17 @@ object PPrintTests extends TestSuite{
         )
       }
     }
+
+    'wrapped_lines{
+      implicit val cfg = Config.Defaults.PPrintConfig.copy(
+        maxWidth = 8,
+        maxHeight = 5
+      )
+      check(
+        "1234567890\n"*10,
+        "\"\"\"\n1234567890\n1234567890\n..."
+      )
+    }
   }
 
   

--- a/pprint/src/test/scala/ammonite/pprint/PPrintTests.scala
+++ b/pprint/src/test/scala/ammonite/pprint/PPrintTests.scala
@@ -378,5 +378,127 @@ object PPrintTests extends TestSuite{
       )
     }
 
+    'Truncation{
+      'long_no_truncation{
+        implicit val cfg = Config.Defaults.PPrintConfig
+          * - check("a" * 10000,"\""+"a" * 10000+"\"")
+          * - check(
+            List.fill(30)(100),
+            """List(
+              |  100,
+              |  100,
+              |  100,
+              |  100,
+              |  100,
+              |  100,
+              |  100,
+              |  100,
+              |  100,
+              |  100,
+              |  100,
+              |  100,
+              |  100,
+              |  100,
+              |  100,
+              |  100,
+              |  100,
+              |  100,
+              |  100,
+              |  100,
+              |  100,
+              |  100,
+              |  100,
+              |  100,
+              |  100,
+              |  100,
+              |  100,
+              |  100,
+              |  100,
+              |  100
+              |)""".stripMargin
+            )
+      }
+
+      'short_non_truncated{
+        implicit val cfg = Config.Defaults.PPrintConfig.copy(maxHeight = 15)
+        * - check("a"*1000, "\"" + "a"*1000 + "\"")
+        * - check(List(1,2,3,4), "List(1, 2, 3, 4)")
+        * - check(
+          List.fill(14)("asdfghjklqwertz"),
+          """List(
+            |  "asdfghjklqwertz",
+            |  "asdfghjklqwertz",
+            |  "asdfghjklqwertz",
+            |  "asdfghjklqwertz",
+            |  "asdfghjklqwertz",
+            |  "asdfghjklqwertz",
+            |  "asdfghjklqwertz",
+            |  "asdfghjklqwertz",
+            |  "asdfghjklqwertz",
+            |  "asdfghjklqwertz",
+            |  "asdfghjklqwertz",
+            |  "asdfghjklqwertz",
+            |  "asdfghjklqwertz",
+            |  "asdfghjklqwertz"
+            |)
+          """.stripMargin
+        )
+      }
+
+      'short_lines_truncated{
+        implicit val cfg = Config.Defaults.PPrintConfig.copy(maxHeight = 15)
+        * - check(
+          List.fill(15)("foobarbaz"),
+          """List(
+            |  "foobarbaz",
+            |  "foobarbaz",
+            |  "foobarbaz",
+            |  "foobarbaz",
+            |  "foobarbaz",
+            |  "foobarbaz",
+            |  "foobarbaz",
+            |  "foobarbaz",
+            |  "foobarbaz",
+            |  "foobarbaz",
+            |  "foobarbaz",
+            |  "foobarbaz",
+            |  "foobarbaz",
+            |  "foobarbaz",
+            |...""".stripMargin
+        )
+        * - check(
+        List.fill(150)("foobarbaz"),
+          """List(
+            |  "foobarbaz",
+            |  "foobarbaz",
+            |  "foobarbaz",
+            |  "foobarbaz",
+            |  "foobarbaz",
+            |  "foobarbaz",
+            |  "foobarbaz",
+            |  "foobarbaz",
+            |  "foobarbaz",
+            |  "foobarbaz",
+            |  "foobarbaz",
+            |  "foobarbaz",
+            |  "foobarbaz",
+            |  "foobarbaz",
+            |...""".stripMargin
+        )
+      }
+
+      'long_line_truncated{
+        implicit val cfg = Config.Defaults.PPrintConfig.copy(
+          maxWidth = 100,
+          maxHeight = 1
+        )
+        check(
+          "a" * 1000,
+          """"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa..."""
+        )
+      }
+    }
   }
+
+  
 }

--- a/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -31,7 +31,7 @@ class Repl(input: InputStream,
   val interp: Interpreter = new Interpreter(
     frontEnd.update,
     shellPrompt,
-    pprintConfig.copy(maxWidth = frontEnd.width),
+    pprintConfig.copy(maxWidth = frontEnd.width, maxHeight = 15),
     colorSet,
     stdout = new PrintStream(output).print,
     initialHistory = initialHistory,

--- a/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -59,9 +59,11 @@ class Repl(input: InputStream,
 }
 
 object Repl{
-  val defaultPredef = """"""
+  val defaultPredef = """
+    def full[A](a: A) = ammonite.pprint.Full(a)
+  """
   def main(args: Array[String]) = run()
-  def run(predef: String = "") = {
+  def run(predef: String = defaultPredef) = {
     println("Loading Ammonite Repl...")
 
     val saveFile = new java.io.File(System.getProperty("user.home")) + "/.amm"

--- a/repl/src/test/scala/ammonite/repl/EulerTests.scala
+++ b/repl/src/test/scala/ammonite/repl/EulerTests.scala
@@ -317,8 +317,6 @@ object EulerTests extends TestSuite{
                    |53503534226472524250874054075591789781264330331690""".stripMargin.replace("\n", " ")
       check.session(s"""
         @ val s = "$data"
-        s: java.lang.String = "$data"
-
         @ s.split("${"""\\s+"""}").map(_.take(11).toLong).sum.toString.take(10).toLong
         res1: Long = 5537376230L
       """)

--- a/repl/src/test/scala/ammonite/repl/EulerTests.scala
+++ b/repl/src/test/scala/ammonite/repl/EulerTests.scala
@@ -317,6 +317,7 @@ object EulerTests extends TestSuite{
                    |53503534226472524250874054075591789781264330331690""".stripMargin.replace("\n", " ")
       check.session(s"""
         @ val s = "$data"
+     
         @ s.split("${"""\\s+"""}").map(_.take(11).toLong).sum.toString.take(10).toLong
         res1: Long = 5537376230L
       """)


### PR DESCRIPTION
This will fix issue #48. PPrinters created with PPrinter.apply are now truncating thier outputs. Values wrapped in the type Full[T] will print normally with all output.