### PR TITLE
Less verbose Ivy

### DIFF
--- a/repl/src/main/scala/ammonite/repl/IvyThing.scala
+++ b/repl/src/main/scala/ammonite/repl/IvyThing.scala
@@ -5,6 +5,7 @@ import org.apache.ivy.core.module.descriptor.{DefaultDependencyDescriptor, Defau
 import org.apache.ivy.core.module.id.ModuleRevisionId
 import org.apache.ivy.core.resolve.ResolveOptions
 import org.apache.ivy.core.settings.IvySettings
+import org.apache.ivy.util._
 
 import org.apache.ivy.plugins.resolver.IBiblioResolver
 import acyclic.file
@@ -29,6 +30,19 @@ trait IvyConstructor{
 object IvyThing {
   val scalaBinaryVersion = scala.util.Properties.versionString
     .stripPrefix("version ").split('.').take(2).mkString(".")
+
+  Message.setDefaultLogger(new AbstractMessageLogger {
+    val maxLevel = 1
+    def doEndProgress(msg: String) = Console.err.println("Done")
+    def doProgress()               = Console.err.print(".")
+    def log(msg: String, level: Int)    =
+      if (level <= maxLevel &&
+          msg != ":: problems summary ::" &&
+          msg.trim.nonEmpty &&
+          !msg.trim.startsWith("unknown resolver "))
+        Console.err.println(msg)
+    def rawlog(msg: String, level: Int) = log(msg, level)
+  })
 
   def resolveArtifact(groupId: String, artifactId: String, version: String) = {
 


### PR DESCRIPTION
This almost shuts Ivy, except in case of error.

It can be made more verbose again by increasing `maxLevel` here:
https://github.com/lihaoyi/Ammonite/commit/fe609776aa4dd33df161dbb09457a7fce3e2cb5b#diff-0c45674fa431da1de377ef0cd36e5af7R35
but at `maxLevel = 2`, it's actually quite similar to what it currently is. There seems to be no middle ground (except by manually filtering the most annoying messages :-)

Fixes https://github.com/lihaoyi/Ammonite/issues/54