### PR TITLE
Allowing to add Ivy resolvers

### DIFF
--- a/repl/src/main/scala/ammonite/repl/IvyThing.scala
+++ b/repl/src/main/scala/ammonite/repl/IvyThing.scala
@@ -1,12 +1,20 @@
 package ammonite.repl
 
-import org.apache.ivy.Ivy
-import org.apache.ivy.core.module.descriptor.{DefaultDependencyDescriptor, DefaultModuleDescriptor}
-import org.apache.ivy.core.module.id.ModuleRevisionId
-import org.apache.ivy.core.resolve.ResolveOptions
-import org.apache.ivy.core.settings.IvySettings
+import java.io.{IOException, File}
+import java.net.{URISyntaxException, URL}
+import java.util.Collections
 
-import org.apache.ivy.plugins.resolver.IBiblioResolver
+import org.apache.ivy.Ivy
+import org.apache.ivy.core.module.descriptor.{Artifact, DependencyDescriptor, DefaultDependencyDescriptor, DefaultModuleDescriptor}
+import org.apache.ivy.core.module.id.ModuleRevisionId
+import org.apache.ivy.core.resolve.{ResolveData, ResolveOptions}
+import org.apache.ivy.core.settings.IvySettings
+import org.apache.ivy.plugins.repository.{TransferEvent, RepositoryCopyProgressListener}
+import org.apache.ivy.plugins.repository.file.{FileRepository, FileResource}
+import org.apache.ivy.plugins.repository.url.URLRepository
+import org.apache.ivy.plugins.resolver._
+import org.apache.ivy.util._
+
 import acyclic.file
 object IvyConstructor extends IvyConstructor
 trait IvyConstructor{
@@ -85,5 +93,235 @@ object IvyThing {
     val report = ivy.resolve(md, options)
     //so you can get the jar libraries
     report.getAllArtifactsReports.map(_.getLocalFile)
+  }
+}
+
+
+/*
+ * ResolverHelpers and Resolver content is some sbt code, a tiny bit refactored
+ */
+
+object ResolverHelpers {
+
+  object ChecksumFriendlyURLResolver {
+    import java.lang.reflect.AccessibleObject
+    def reflectiveLookup[A <: AccessibleObject](f: Class[_] => A): Option[A] =
+      try {
+        val cls = classOf[RepositoryResolver]
+        val thing = f(cls)
+        import scala.language.reflectiveCalls
+        thing.setAccessible(true)
+        Some(thing)
+      } catch {
+        case (_: java.lang.NoSuchFieldException) |
+             (_: java.lang.SecurityException) |
+             (_: java.lang.NoSuchMethodException) => None
+      }
+    val signerNameField: Option[java.lang.reflect.Field] =
+      reflectiveLookup(_.getDeclaredField("signerName"))
+    val putChecksumMethod: Option[java.lang.reflect.Method] =
+      reflectiveLookup(_.getDeclaredMethod("putChecksum",
+        classOf[Artifact], classOf[File], classOf[String],
+        classOf[Boolean], classOf[String]))
+    val putSignatureMethod: Option[java.lang.reflect.Method] =
+      reflectiveLookup(_.getDeclaredMethod("putSignature",
+        classOf[Artifact], classOf[File], classOf[String],
+        classOf[Boolean]))
+  }
+
+  trait ChecksumFriendlyURLResolver extends RepositoryResolver {
+    import ChecksumFriendlyURLResolver._
+    def signerName: String = signerNameField match {
+      case Some(field) => field.get(this).asInstanceOf[String]
+      case None        => null
+    }
+    override protected def put(artifact: Artifact, src: File, dest: String, overwrite: Boolean) = {
+      // verify the checksum algorithms before uploading artifacts!
+      val checksums = getChecksumAlgorithms
+      val repository = getRepository
+      for {
+        checksum <- checksums
+        if !ChecksumHelper.isKnownAlgorithm(checksum)
+      } throw new IllegalArgumentException("Unknown checksum algorithm: " + checksum)
+      repository.put(artifact, src, dest, overwrite)
+      // Fix for sbt#1156 - Artifactory will auto-generate MD5/sha1 files, so
+      // we need to overwrite what it has.
+      for (checksum <- checksums) {
+        putChecksumMethod match {
+          case Some(method) => method.invoke(this, artifact, src, dest, true: java.lang.Boolean, checksum)
+          case None         => // TODO - issue warning?
+        }
+      }
+      if (signerName != null) {
+        putSignatureMethod match {
+          case None         => ()
+          case Some(method) => method.invoke(artifact, src, dest, true: java.lang.Boolean)
+        }
+      }
+    }
+  }
+
+  trait DescriptorRequired extends BasicResolver {
+    override def getDependency(dd: DependencyDescriptor, data: ResolveData) = {
+      val prev = descriptorString(isAllownomd)
+      setDescriptor(descriptorString(hasExplicitURL(dd)))
+      try super.getDependency(dd, data) finally setDescriptor(prev)
+    }
+    def descriptorString(optional: Boolean) =
+      if (optional) BasicResolver.DESCRIPTOR_OPTIONAL else BasicResolver.DESCRIPTOR_REQUIRED
+    def hasExplicitURL(dd: DependencyDescriptor) =
+      dd.getAllDependencyArtifacts.exists(_.getUrl != null)
+  }
+
+  final class WarnOnOverwriteFileRepo extends FileRepository() {
+    override def put(source: java.io.File, destination: String, overwrite: Boolean) = {
+      try super.put(source, destination, overwrite)
+      catch {
+        case e: IOException if e.getMessage.contains("destination already exists") =>
+          Message.warn(s"Attempting to overwrite $destination\n\tThis usage is deprecated and will be removed in sbt 1.0.")
+          super.put(source, destination, true)
+      }
+    }
+  }
+
+  final class LocalIfFileRepo extends URLRepository {
+    val repo = new WarnOnOverwriteFileRepo()
+    val progress = new RepositoryCopyProgressListener(this)
+    override def getResource(source: String) = {
+      val url = new URL(source)
+      if (url.getProtocol == "file")
+        new FileResource(repo, try { new File(url.toURI) } catch { case _: URISyntaxException => new File(url.getPath) })
+      else
+        super.getResource(source)
+    }
+
+    override def put(source: File, destination: String, overwrite: Boolean) = {
+      val url = new URL(destination)
+      if (url.getProtocol != "file") super.put(source, destination, overwrite)
+      else {
+        // Here we duplicate the put method for files so we don't just bail on trying ot use Http handler
+        val resource = getResource(destination)
+        if (!overwrite && resource.exists()) {
+          throw new IOException("destination file exists and overwrite == false")
+        }
+        fireTransferInitiated(resource, TransferEvent.REQUEST_PUT)
+        try {
+          val totalLength = source.length
+          if (totalLength > 0) progress.setTotalLength(totalLength)
+          FileUtil.copy(source, new File(url.toURI), progress)
+        } catch {
+          case ex: IOException =>
+            fireTransferError(ex)
+            throw ex
+          case ex: RuntimeException =>
+            fireTransferError(ex)
+            throw ex
+        } finally {
+          progress.setTotalLength(null)
+        }
+      }
+    }
+  }
+
+  def resolvePattern(base: String, pattern: String): String = {
+    val normBase = base.replace('\\', '/')
+    if (normBase.endsWith("/") || pattern.startsWith("/")) normBase + pattern else normBase + "/" + pattern
+  }
+
+  val mavenStyleBasePattern = "[organisation]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[artifact]-[revision](-[classifier]).[ext]"
+
+  def initializeMavenStyle(resolver: IBiblioResolver, name: String, root: String) {
+    resolver.setName(name)
+    resolver.setM2compatible(true)
+    resolver.setRoot(root)
+  }
+
+  case class Patterns(ivyPatterns: Seq[String], artifactPatterns: Seq[String], isMavenCompatible: Boolean, descriptorOptional: Boolean = false, skipConsistencyCheck: Boolean = false)
+
+  def initializePatterns(resolver: AbstractPatternsBasedResolver, patterns: Patterns, settings: IvySettings = new IvySettings()) {
+    resolver.setM2compatible(patterns.isMavenCompatible)
+    resolver.setDescriptor(if (patterns.descriptorOptional) BasicResolver.DESCRIPTOR_OPTIONAL else BasicResolver.DESCRIPTOR_REQUIRED)
+    resolver.setCheckconsistency(!patterns.skipConsistencyCheck)
+    patterns.ivyPatterns.foreach(p => resolver.addIvyPattern(settings substitute p))
+    patterns.artifactPatterns.foreach(p => resolver.addArtifactPattern(settings substitute p))
+  }
+
+  val userHome = new File(System.getProperty("user.home"))
+
+  def mavenLocalDir: File = {
+    def loadHomeFromSettings(f: () => File): Option[File] =
+      try {
+        val file = f()
+        if (!file.exists) None
+        else (scala.xml.XML.loadFile(file) \ "localRepository").text match {
+          case ""    => None
+          case e @ _ => Some(new File(e))
+        }
+      } catch {
+        // Occurs inside File constructor when property or environment variable does not exist
+        case _: NullPointerException => None
+        // Occurs when File does not exist
+        case _: IOException          => None
+        case e: org.xml.sax.SAXParseException    => System.err.println(s"WARNING: Problem parsing ${f().getAbsolutePath}, ${e.getMessage}"); None
+      }
+    loadHomeFromSettings(() => new File(userHome, ".m2/settings.xml")) orElse
+      loadHomeFromSettings(() => new File(new File(System.getenv("M2_HOME")), "conf/settings.xml")) getOrElse
+      new File(userHome, ".m2/repository")
+  }
+
+  val SonatypeRepositoryRoot = "https://oss.sonatype.org/content/repositories"
+
+  def centralRepositoryRoot(secure: Boolean) = (if (secure) "https" else "http") + "://repo1.maven.org/maven2/"
+
+  def fileRepository(name: String, patterns: Patterns, isLocal: Boolean, isTransactional: Option[Boolean], settings: IvySettings = new IvySettings()): DependencyResolver = {
+    val resolver = new FileSystemResolver with DescriptorRequired {
+      // Workaround for #1156
+      // Temporarily in sbt 0.13.x we deprecate overwriting
+      // in local files for non-changing revisions.
+      // This will be fully enforced in sbt 1.0.
+      setRepository(new WarnOnOverwriteFileRepo())
+    }
+    resolver.setName(name)
+    initializePatterns(resolver, patterns, settings)
+    resolver.setLocal(isLocal)
+    isTransactional.foreach(value => resolver.setTransactional(value.toString))
+    resolver
+  }
+
+  val PluginPattern = "(scala_[scalaVersion]/)(sbt_[sbtVersion]/)"
+  val localBasePattern = "[organisation]/[module]/" + PluginPattern + "[revision]/[type]s/[artifact](-[classifier]).[ext]"
+
+  val ivyHome = new File(userHome, ".ivy2")
+}
+
+object Resolver {
+  import ResolverHelpers._
+
+  def mavenResolver(name: String, root: String): DependencyResolver = {
+    val pattern = Collections.singletonList(resolvePattern(root, mavenStyleBasePattern))
+    final class PluginCapableResolver extends IBiblioResolver with ChecksumFriendlyURLResolver with DescriptorRequired {
+      def setPatterns() {
+        // done this way for access to protected methods.
+        setArtifactPatterns(pattern)
+        setIvyPatterns(pattern)
+      }
+    }
+    val resolver = new PluginCapableResolver
+    resolver.setRepository(new LocalIfFileRepo)
+    initializeMavenStyle(resolver, name, root)
+    resolver.setPatterns() // has to be done after initializeMavenStyle, which calls methods that overwrite the patterns
+    resolver
+  }
+
+  val mavenLocal = mavenResolver("Maven2 Local", mavenLocalDir.toURI.toURL.toString)
+
+  val defaultMaven = mavenResolver("public", centralRepositoryRoot(secure = true))
+
+  def sonatypeRepo(status: String) = mavenResolver("sonatype-" + status, SonatypeRepositoryRoot + "/" + status)
+
+  lazy val localRepo = {
+    val id = "local"
+    val pList = List(s"${ivyHome.getAbsolutePath}/$id/$localBasePattern")
+    fileRepository(id, Patterns(pList, pList, isMavenCompatible = false), isLocal = true, isTransactional = None)
   }
 }

--- a/repl/src/main/scala/ammonite/repl/SbtChainResolver.scala
+++ b/repl/src/main/scala/ammonite/repl/SbtChainResolver.scala
@@ -1,0 +1,322 @@
+package ammonite.repl
+
+import java.io.File
+import java.text.ParseException
+import java.util.Date
+
+import org.apache.ivy.core.module.id.ModuleRevisionId
+import org.apache.ivy.core.settings.IvySettings
+import org.apache.ivy.core.{ IvyContext, LogOptions }
+import org.apache.ivy.core.module.descriptor.{ Artifact => IArtifact, DefaultModuleDescriptor, ModuleDescriptor, DependencyDescriptor }
+import org.apache.ivy.core.resolve.{ ResolvedModuleRevision, ResolveData }
+import org.apache.ivy.plugins.latest.LatestStrategy
+import org.apache.ivy.plugins.repository.file.{ FileRepository => IFileRepository, FileResource }
+import org.apache.ivy.plugins.repository.url.URLResource
+import org.apache.ivy.plugins.resolver._
+import org.apache.ivy.plugins.resolver.util.{ HasLatestStrategy, ResolvedResource }
+import org.apache.ivy.util.{ Message, StringUtils => IvyStringUtils }
+
+/*
+ * This is all cut-n-pasted from sbt
+ */
+
+case class SbtChainResolver(
+  name: String,
+  resolvers: Seq[DependencyResolver],
+  settings: IvySettings
+) extends ChainResolver {
+
+  private object IvySbt {
+    def hasImplicitClassifier(artifact: IArtifact): Boolean =
+    {
+      import collection.JavaConversions._
+      artifact.getQualifiedExtraAttributes.keys.exists(_.asInstanceOf[String] startsWith "m:")
+    }
+    def resetArtifactResolver(resolved: ResolvedModuleRevision): ResolvedModuleRevision =
+      if (resolved eq null)
+        null
+      else {
+        val desc = resolved.getDescriptor
+        val updatedDescriptor = desc
+        new ResolvedModuleRevision(resolved.getResolver, resolved.getResolver, updatedDescriptor, resolved.getReport, resolved.isForce)
+      }
+
+    def isChanging(mrid: ModuleRevisionId): Boolean =
+      mrid.getRevision endsWith "-SNAPSHOT"
+  }
+
+  override def equals(o: Any): Boolean = o match {
+    case o: SbtChainResolver =>
+      this.name == o.name &&
+        this.resolvers == o.resolvers &&
+        this.settings == o.settings
+    case _ => false
+  }
+
+  override def hashCode: Int =
+  {
+    var hash = 1
+    hash = hash * 31 + this.name.##
+    hash = hash * 31 + this.resolvers.##
+    hash = hash * 31 + this.settings.##
+    hash
+  }
+
+  // TODO - We need to special case the project resolver so it always "wins" when resolving with inter-project dependencies.
+
+  // Initialize ourselves.
+  setName(name)
+  setReturnFirst(true)
+  setCheckmodified(false)
+  // Here we append all the resolvers we were passed *AND* look for
+  // a project resolver, which we will special-case.
+  resolvers.foreach(add)
+
+  // Technically, this should be applied to module configurations.
+  // That would require custom subclasses of all resolver types in ConvertResolver (a delegation approach does not work).
+  // It would be better to get proper support into Ivy.
+  // A workaround is to configure the ModuleConfiguration resolver to be a ChainResolver.
+  //
+  // This method is only used by the pom parsing code in Ivy to find artifacts it doesn't know about.
+  // In particular, a) it looks up source and javadoc classifiers b) it looks up a main artifact for packaging="pom"
+  // sbt now provides the update-classifiers or requires explicitly specifying classifiers explicitly
+  // Providing a main artifact for packaging="pom" does not seem to be correct and the lookup can be expensive.
+  //
+  // Ideally this could just skip the lookup, but unfortunately several artifacts in practice do not follow the
+  // correct behavior for packaging="pom" and so it is only skipped for source/javadoc classifiers.
+  override def locate(artifact: IArtifact) = if (IvySbt.hasImplicitClassifier(artifact)) null else super.locate(artifact)
+
+  override def getDependency(dd: DependencyDescriptor, data: ResolveData) =
+  {
+    if (data.getOptions.getLog != LogOptions.LOG_QUIET)
+      Message.info("Resolving " + dd.getDependencyRevisionId + " ...")
+    val gd = doGetDependency(dd, data)
+    val mod = IvySbt.resetArtifactResolver(gd)
+    mod
+  }
+  // Modified implementation of ChainResolver#getDependency.
+  // When the dependency is changing, it will check all resolvers on the chain
+  // regardless of what the "latest strategy" is set, and look for the published date
+  // or the module descriptor to sort them.
+  // This implementation also skips resolution if "return first" is set to true,
+  // and if a previously resolved or cached revision has been found.
+  def doGetDependency(dd: DependencyDescriptor, data0: ResolveData): ResolvedModuleRevision =
+  {
+    // useLatest - Means we should always download the JARs from the internet, no matter what.
+    //             This will only be true *IF* the depenendency is dynamic/changing *and* latestSnapshots is true.
+    // If you find multiple candidates,
+    // - If `isReturnFirst` is true, you return the first value found
+    // - If not, we will ATTEMPT to look at the publish date, which is not correctly discovered for Maven modules and
+    //   leads to undefined behavior.
+    val useLatest = dd.isChanging || (IvySbt.isChanging(dd.getDependencyRevisionId))
+    if (useLatest) {
+      Message.verbose(s"${getName} is changing. Checking all resolvers on the chain")
+    }
+    val data = new ResolveData(data0, doValidate(data0))
+    // Returns the value if we've already been resolved from some other branch of the resolution tree.
+    val resolved = Option(data.getCurrentResolvedModuleRevision)
+    // If we don't have any previously resolved date, we try to pull the value from the cache.
+    val resolvedOrCached =
+      resolved orElse {
+        Message.verbose(getName + ": Checking cache for: " + dd)
+        Option(findModuleInCache(dd, data, true)) map { mr =>
+          Message.verbose(getName + ": module revision found in cache: " + mr.getId)
+          forcedRevision(mr)
+        }
+      }
+
+    // Default value for resolution.  We use this while we loop...
+    //  If useLatest is true, we want to try to download from the internet so we DO NOT start with a valid value.
+    var temp: Option[ResolvedModuleRevision] =
+      if (useLatest) None
+      else resolvedOrCached
+    // Cast resolvers to something useful. TODO - we dropping anything here?
+    val resolvers = getResolvers.toArray.toVector collect { case x: DependencyResolver => x }
+
+    // Here we do an attempt to resolve the artifact from each of the resolvers in the chain.
+    // -  If we have a return value already, AND isReturnFirst is true AND useLatest is false, we DO NOT resolve anything
+    // -  If we do not, try to resolve.
+    // RETURNS:   Left -> Error
+    //            Right -> Some(resolved module)  // Found in this resolver, can use this result.
+    //            Right -> None                   // Do not use this resolver
+    val results = resolvers map { x =>
+      // if the revision is cached and isReturnFirst is set, don't bother hitting any resolvers, just return None for this guy.
+      if (isReturnFirst && temp.isDefined && !useLatest) Right(None)
+      else {
+        // We actually do resolution.
+        val resolver = x
+        val oldLatest: Option[LatestStrategy] = setLatestIfRequired(resolver, Option(getLatestStrategy))
+        try {
+          val previouslyResolved = temp
+          // if the module qualifies as changing, then resolve all resolvers
+          if (useLatest) data.setCurrentResolvedModuleRevision(null)
+          else data.setCurrentResolvedModuleRevision(temp.orNull)
+          temp = Option(resolver.getDependency(dd, data))
+          Right(
+            if (temp eq previouslyResolved) None
+            else if (useLatest) temp map { x =>
+              (reparseModuleDescriptor(dd, data, resolver, x), resolver)
+            }
+            else temp map { x => (forcedRevision(x), resolver) }
+          )
+        } catch {
+          case ex: Exception =>
+            Message.verbose("problem occurred while resolving " + dd + " with " + resolver
+              + ": " + IvyStringUtils.getStackTrace(ex))
+            Left(ex)
+        } finally {
+          oldLatest map { _ => doSetLatestStrategy(resolver, oldLatest) }
+          checkInterrupted
+        }
+      }
+    }
+    val errors = results collect { case Left(e) => e }
+    val foundRevisions: Vector[(ResolvedModuleRevision, DependencyResolver)] = results collect { case Right(Some(x)) => x }
+    val sorted =
+      if (useLatest) foundRevisions.sortBy {
+        case (rmr, resolver) =>
+          Message.warn(s"Sorrting results from $rmr, using ${rmr.getPublicationDate} and ${rmr.getDescriptor.getPublicationDate}")
+          // Just issue warning about issues with publication date, and fake one on it for now.
+          Option(rmr.getPublicationDate) orElse Option(rmr.getDescriptor.getPublicationDate) match {
+            case None =>
+              (resolver.findIvyFileRef(dd, data), rmr.getDescriptor) match {
+                case (null, _) =>
+                  // In this instance, the dependency is specified by a direct URL or some other sort of "non-ivy" file
+                  if (dd.isChanging)
+                    Message.warn(s"Resolving a changing dependency (${rmr.getId}) with no ivy/pom file!, resolution order is undefined!")
+                  0L
+                case (ivf, dmd: DefaultModuleDescriptor) =>
+                  val lmd = new java.util.Date(ivf.getLastModified)
+                  Message.debug(s"Getting no publication date from resolver: ${resolver} for ${rmr.getId}, setting to: ${lmd}")
+                  dmd.setPublicationDate(lmd)
+                  ivf.getLastModified
+                case _ =>
+                  Message.warn(s"Getting null publication date from resolver: ${resolver} for ${rmr.getId}, resolution order is undefined!")
+                  0L
+              }
+            case Some(date) => // All other cases ok
+              date.getTime
+          }
+      }.reverse.headOption map {
+        case (rmr, resolver) =>
+          Message.warn(s"Choosing ${resolver} for ${rmr.getId}")
+          // Now that we know the real latest revision, let's force Ivy to use it
+          val artifactOpt = findFirstArtifactRef(rmr.getDescriptor, dd, data, resolver)
+          artifactOpt match {
+            case None if resolver.getName == "inter-project" => // do nothing
+            case None => throw new RuntimeException(s"\t${resolver.getName}: no ivy file nor artifact found for $rmr")
+            case Some(artifactRef) =>
+              val systemMd = toSystem(rmr.getDescriptor)
+              getRepositoryCacheManager.cacheModuleDescriptor(resolver, artifactRef,
+                toSystem(dd), systemMd.getAllArtifacts().head, None.orNull, getCacheOptions(data))
+          }
+          rmr
+      }
+      else foundRevisions.reverse.headOption map { _._1 } // we have to reverse because resolvers are hit in reverse order.
+  // If the value is arleady in cache, SORTED will be a Seq(None, None, ...) which means we'll fall over to the prevously cached or resolved version.
+  val mrOpt: Option[ResolvedModuleRevision] = sorted orElse resolvedOrCached
+    mrOpt match {
+      case None if errors.size == 1 =>
+        errors.head match {
+          case e: RuntimeException => throw e
+          case e: ParseException   => throw e
+          case e: Throwable        => throw new RuntimeException(e.toString, e)
+        }
+      case None if errors.size > 1 =>
+        val err = (errors.toList map { IvyStringUtils.getErrorMessage }).mkString("\n\t", "\n\t", "\n")
+        throw new RuntimeException(s"several problems occurred while resolving $dd:$err")
+      case _ =>
+        if (resolved == mrOpt) resolved.orNull
+        else (mrOpt map { resolvedRevision }).orNull
+    }
+  }
+  // Ivy seem to not want to use the module descriptor found at the latest resolver
+  private[this] def reparseModuleDescriptor(dd: DependencyDescriptor, data: ResolveData, resolver: DependencyResolver, rmr: ResolvedModuleRevision): ResolvedModuleRevision =
+  // TODO - Redownloading/parsing the ivy file is not really the best way to make this correct.
+  //        We should figure out a better alternative, or directly attack the resolvers Ivy uses to
+  //        give them correct behavior around -SNAPSHOT.
+    Option(resolver.findIvyFileRef(dd, data)) flatMap { ivyFile =>
+      ivyFile.getResource match {
+        case r: FileResource =>
+          try {
+            val parser = rmr.getDescriptor.getParser
+            val md = parser.parseDescriptor(settings, r.getFile.toURL, r, false)
+            Some(new ResolvedModuleRevision(resolver, resolver, md, rmr.getReport, true))
+          } catch {
+            case _: ParseException => None
+          }
+        case _ => None
+      }
+    } getOrElse {
+      Message.warn(s"Unable to reparse ${dd.getDependencyRevisionId} from $resolver, using ${rmr.getPublicationDate}")
+      rmr
+    }
+  /** Ported from BasicResolver#findFirstAirfactRef. */
+  private[this] def findFirstArtifactRef(md: ModuleDescriptor, dd: DependencyDescriptor, data: ResolveData, resolver: DependencyResolver): Option[ResolvedResource] =
+  {
+    def artifactRef(artifact: IArtifact, date: Date): Option[ResolvedResource] =
+      resolver match {
+        case resolver: BasicResolver =>
+          IvyContext.getContext.set(resolver.getName + ".artifact", artifact)
+          try {
+            Option(resolver.doFindArtifactRef(artifact, date)) orElse {
+              Option(artifact.getUrl) map { url =>
+                Message.verbose("\tusing url for " + artifact + ": " + url)
+                val resource =
+                  if ("file" == url.getProtocol) new FileResource(new IFileRepository(), new File(url.getPath()))
+                  else new URLResource(url)
+                new ResolvedResource(resource, artifact.getModuleRevisionId.getRevision)
+              }
+            }
+          } finally {
+            IvyContext.getContext.set(resolver.getName + ".artifact", null)
+          }
+        case _ =>
+          None
+      }
+    val artifactRefs = md.getConfigurations.toIterator flatMap { conf =>
+      md.getArtifacts(conf.getName).toIterator flatMap { af =>
+        artifactRef(af, data.getDate).toIterator
+      }
+    }
+    if (artifactRefs.hasNext) Some(artifactRefs.next)
+    else None
+  }
+  /** Ported from ChainResolver#forcedRevision. */
+  private[this] def forcedRevision(rmr: ResolvedModuleRevision): ResolvedModuleRevision =
+    new ResolvedModuleRevision(rmr.getResolver, rmr.getArtifactResolver, rmr.getDescriptor, rmr.getReport, true)
+  /** Ported from ChainResolver#resolvedRevision. */
+  private[this] def resolvedRevision(rmr: ResolvedModuleRevision): ResolvedModuleRevision =
+    if (isDual) new ResolvedModuleRevision(rmr.getResolver, this, rmr.getDescriptor, rmr.getReport, rmr.isForce)
+    else rmr
+  /** Ported from ChainResolver#setLatestIfRequired. */
+  private[this] def setLatestIfRequired(resolver: DependencyResolver, latest: Option[LatestStrategy]): Option[LatestStrategy] =
+    latestStrategyName(resolver) match {
+      case Some(latestName) if latestName != "default" =>
+        val oldLatest = latestStrategy(resolver)
+        doSetLatestStrategy(resolver, latest)
+        oldLatest
+      case _ => None
+    }
+  /** Ported from ChainResolver#getLatestStrategyName. */
+  private[this] def latestStrategyName(resolver: DependencyResolver): Option[String] =
+    resolver match {
+      case r: HasLatestStrategy => Some(r.getLatest)
+      case _                    => None
+    }
+  /** Ported from ChainResolver#getLatest. */
+  private[this] def latestStrategy(resolver: DependencyResolver): Option[LatestStrategy] =
+    resolver match {
+      case r: HasLatestStrategy => Some(r.getLatestStrategy)
+      case _                    => None
+    }
+  /** Ported from ChainResolver#setLatest. */
+  private[this] def doSetLatestStrategy(resolver: DependencyResolver, latest: Option[LatestStrategy]): Option[LatestStrategy] =
+    resolver match {
+      case r: HasLatestStrategy =>
+        val oldLatest = latestStrategy(resolver)
+        r.setLatestStrategy(latest.orNull)
+        oldLatest
+      case _ => None
+    }
+}

--- a/repl/src/main/scala/ammonite/repl/frontend/ReplAPI.scala
+++ b/repl/src/main/scala/ammonite/repl/frontend/ReplAPI.scala
@@ -89,6 +89,11 @@ trait Load extends (String => Unit){
   def ivy(coordinates: (String, String, String)): Unit
 
   /**
+   * Add a resolver for Ivy
+   */
+  def resolver(resolver: org.apache.ivy.plugins.resolver.DependencyResolver): Unit
+
+  /**
    * Loads a command into the REPL and
    * evaluates them one after another
    */

--- a/repl/src/main/scala/ammonite/repl/interp/Evaluator.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Evaluator.scala
@@ -52,7 +52,9 @@ object Evaluator{
     def namesFor(t: scala.reflect.runtime.universe.Type): Set[String] = {
       val yours = t.members.map(_.name.toString).toSet
       val default = typeOf[Object].members.map(_.name.toString)
-      yours -- default
+      // About nme.LOCAL_SUFFIX_STRING, see http://stackoverflow.com/a/17248174/3714539
+      // Using nme instead of termNames for 2.10 compatibility
+      (yours -- default).filterNot(_ endsWith nme.LOCAL_SUFFIX_STRING)
     }
 
     /**

--- a/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
@@ -101,9 +101,17 @@ class Interpreter(handleResult: => (String, Res[Evaluated]) => Unit,
       def ivy(coordinates: (String, String, String)): Unit ={
         val (groupId, artifactId, version) = coordinates
         eval.newClassloader()
-        IvyThing.resolveArtifact(groupId, artifactId, version)
+        IvyThing.resolveArtifact(groupId, artifactId, version, resolvers)
           .map(handleJar)
         init()
+      }
+
+      var resolvers = Seq(
+        Resolver.localRepo,
+        Resolver.defaultMaven
+      )
+      def resolver(resolver: org.apache.ivy.plugins.resolver.DependencyResolver) = {
+        resolvers = resolvers :+ resolver
       }
     }
     implicit def pprintConfig = interp.pprintConfig

--- a/repl/src/test/scala/ammonite/repl/AdvancedTests.scala
+++ b/repl/src/test/scala/ammonite/repl/AdvancedTests.scala
@@ -38,6 +38,25 @@ object AdvancedTests extends TestSuite{
             res2: String = "[1,2,3]"
           """)
         }
+        'resolvers{
+          // Actually tests that the Resolver._ methods can be called, does not try to fetch artifacts from them
+          check.session("""
+            @ load.resolver(Resolver.sonatypeRepo("snapshots"))
+            res0: Unit = ()
+
+            @ load.resolver(Resolver.mavenResolver("Scalaz Bintray Repo", "https://dl.bintray.com/scalaz/releases"))
+            res1: Unit = ()
+
+            @ load.resolver(Resolver.mavenLocal)
+            res2: Unit = ()
+
+            @ load.resolver(Resolver.defaultMaven)
+            res3: Unit = ()
+
+            @ load.resolver(Resolver.localRepo)
+            res4: Unit = ()
+                        """)
+        }
 
         'reloading{
           // Make sure earlier-loaded things indeed continue working
@@ -204,6 +223,29 @@ object AdvancedTests extends TestSuite{
 
         @ (Option(1) |@| Option(2))(_ + _)
         res3: scala.Option[Int] = Some(3)
+      """)
+    }
+
+    'scalazstream{
+      check.session("""
+        @ load.resolver("Scalaz Bintray Repo" at "https://dl.bintray.com/scalaz/releases")
+
+        @ load.ivy("org.scalaz.stream" %% "scalaz-stream" % "0.7a")
+
+        @ import scalaz.stream._
+        import scalaz.stream._
+
+        @ import scalaz.concurrent.Task
+        import scalaz.concurrent.Task
+
+        @ val p1 = Process.constant(1).toSource
+        p1: scalaz.stream.Process[scalaz.concurrent.Task,Int] = Append(Emit(Vector(1)),Vector(<function1>))
+
+        @ val pch = Process.constant((i:Int) => Task.now(())).take(3)
+        pch: scalaz.stream.Process[Nothing,Int => scalaz.concurrent.Task[Unit]] = Append(Halt(End),Vector(<function1>))
+
+        @ p1.to(pch).runLog.run.size == 3
+        res6: Boolean = true
       """)
     }
     'predef{


### PR DESCRIPTION
This PR demonstrates a way to add one's own repositories from the repl, like
```scala
@ load.resolver("Scalaz Bintray Repo" at "https://dl.bintray.com/scalaz/releases")

@ load.resolver(Resolver.sonatypeRepo("snapshots"))
```

About the implementation, as calling several times `addResolver` on the ivy settings (like here: https://github.com/lihaoyi/Ammonite/blob/master/repl/src/main/scala/ammonite/repl/IvyThing.scala#L49) seems not to work, it re-uses some code from SBT regarding "chained resolvers" (mixes several repo together), which I don't have a deep understanding of :-), but it works for me (and in the tests).

An alternate way of doing that could be to depend on the sbt artifacts themselves - cut-n-pasted like I did seems less worse to me...

Yet another way *could* consist in replacing Ivy by aether, which has a slicker API (I never used aether directly though, only heard of it).