### PR TITLE
Bugfix in SyntaxError

### DIFF
--- a/repl/src/main/scala/ammonite/repl/Util.scala
+++ b/repl/src/main/scala/ammonite/repl/Util.scala
@@ -184,7 +184,7 @@ object SyntaxError{
   def msg(code: String, p: fastparse.core.Parser[_], idx: Int) = {
     val locationString = {
       val (first, last) = code.splitAt(idx)
-      val lastSnippet = last.split('\n')(0)
+      val lastSnippet = last.split('\n').headOption.getOrElse("")
       val firstSnippet = first.reverse.split('\n').lift(0).getOrElse("").reverse
       firstSnippet + lastSnippet + "\n" + (" " * firstSnippet.length) + "^"
     }


### PR DESCRIPTION
SyntaxError.msg throws an `IndexOutOfBoundsException` if the failing position is at the end of the last line.