### PR TITLE
Script loading support

### DIFF
--- a/repl/src/main/scala/ammonite/repl/IvyThing.scala
+++ b/repl/src/main/scala/ammonite/repl/IvyThing.scala
@@ -47,7 +47,7 @@ object IvyThing {
   def resolveArtifact(groupId: String,
                       artifactId: String,
                       version: String,
-                      verbosity: Int = 2) = {
+                      verbosity: Int = 2) = synchronized {
     maxLevel = verbosity
     val ivy = Ivy.newInstance{
 

--- a/repl/src/main/scala/ammonite/repl/frontend/ReplAPI.scala
+++ b/repl/src/main/scala/ammonite/repl/frontend/ReplAPI.scala
@@ -110,6 +110,15 @@ trait Load extends (String => Unit){
    * evaluates them one after another
    */
   def apply(line: String): Unit
+
+  /**
+   * Loads and executes the scriptfile on the specified path.
+   * Compilation units separated by `@\n` are evaluated sequentially.
+   * If an error happens it prints an error message to the console.
+   */ 
+  def script(path: String): Unit
+
+  def script(file: File): Unit
 }
 
 // End of ReplAPI

--- a/repl/src/main/scala/ammonite/repl/interp/Preprocessor.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Preprocessor.scala
@@ -143,7 +143,6 @@ object Preprocessor{
           "Don't know how to handle " + code
         )
       }
-
     }
   }
 }

--- a/repl/src/test/resource/scripts/Annotation.scala
+++ b/repl/src/test/resource/scripts/Annotation.scala
@@ -1,0 +1,7 @@
+import annotation.tailrec
+val list= List(1,2,3,4)
+@tailrec def product(acc: Int, l: List[Int]): Int = {
+  if(l.isEmpty) acc
+  else product(acc*l.head,l.tail)
+}
+val res = product(1,list)

--- a/repl/src/test/resource/scripts/CompilationError.scala
+++ b/repl/src/test/resource/scripts/CompilationError.scala
@@ -1,0 +1,1 @@
+nonexistentSymbol

--- a/repl/src/test/resource/scripts/LoadIvy.scala
+++ b/repl/src/test/resource/scripts/LoadIvy.scala
@@ -1,0 +1,4 @@
+load.ivy("com.lihaoyi" %% "scalatags" % "0.4.5")
+@
+import scalatags.Text.all._
+val res = a("omg", href:="www.google.com").render

--- a/repl/src/test/resource/scripts/MultiBlockError.scala
+++ b/repl/src/test/resource/scripts/MultiBlockError.scala
@@ -1,0 +1,5 @@
+val res1 = 1
+@
+thisWillFail
+@
+val res2 = 1

--- a/repl/src/test/resource/scripts/PreserveImports.scala
+++ b/repl/src/test/resource/scripts/PreserveImports.scala
@@ -1,0 +1,3 @@
+import scala.util.{Either, Left}
+@
+val res = Left("asd")

--- a/repl/src/test/resource/scripts/SyntaxError.scala
+++ b/repl/src/test/resource/scripts/SyntaxError.scala
@@ -1,0 +1,2 @@
+#syntaxError
+val res = 1

--- a/repl/src/test/scala/ammonite/repl/ScriptTests.scala
+++ b/repl/src/test/scala/ammonite/repl/ScriptTests.scala
@@ -1,0 +1,86 @@
+package ammonite.repl
+
+import utest._
+
+object ScriptTests extends TestSuite{
+  val tests = TestSuite{
+    println("ScriptTests")
+    val check = new Checker()
+    val scriptPath = "repl/src/test/resource/scripts"
+
+    'compilationBlocks{
+      'loadIvy{
+        check.session(s"""
+          @ load.script("$scriptPath/LoadIvy.scala")
+
+          @ val r = res
+          r: String = ${"\"\"\""}
+          <a href="www.google.com">omg</a>
+          ${"\"\"\""}
+          """)
+      }
+      'preserveImports{
+        check.session(s"""
+          @ load.script("$scriptPath/PreserveImports.scala")
+
+          @ val r = res
+          r: Left[String, Nothing] = Left("asd")
+          """)
+      }
+      'annotation{
+        check.session(s"""
+          @ load.script("$scriptPath/Annotation.scala")
+
+          @ val r = res
+          r: Int = 24
+          """)
+      }
+    }
+    'failures{
+      'syntaxError{
+        check.session(s"""
+          @ load.script("$scriptPath/SyntaxError.scala")
+
+          @ val r = res
+          error: Compilation Failed
+          Main.scala:29: not found: value res
+          res
+          ^
+          """)
+      }
+      'compilationError{
+        check.session(s"""
+          @ load.script("$scriptPath/CompilationError.scala")
+
+          @ val r = res
+          error: Compilation Failed
+          Main.scala:39: not found: value res
+          res
+          ^
+
+          """)
+      }
+      'nofile{
+        check.session(s"""
+          @ load.script("$scriptPath/notHere")
+          error: java.nio.file.NoSuchFileException: $scriptPath/notHere
+          """
+        )
+      }
+      'multiBlockError{
+        check.session(s"""
+          @ load.script("$scriptPath/MultiBlockError.scala")
+
+          @ val r1 = res1
+          r1: Int = 1
+
+          @ val r2 = res2
+          error: Compilation Failed
+          Main.scala:41: not found: value res2
+          res2 
+          ^
+          """)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Scripts can be loaded with `load.script`. It support breaking scripts up to multiple compilation blocks with the separator `@\n`. The printing snippets generated by `Preprocessor` are discarded in scripts. Errors in script compilation are reported with `Interpreter.stdout`.