### PR TITLE
History YAML storage and pretty printing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -145,7 +145,8 @@ lazy val repl = project
       "jline" % "jline" % "2.12",
       "org.scala-lang" % "scala-reflect" % scalaVersion.value,
       "org.apache.ivy" % "ivy" % "2.4.0",
-      "com.lihaoyi" %% "scalaparse" % "0.1.7"
+      "com.lihaoyi" %% "scalaparse" % "0.1.7",
+      "org.yaml" % "snakeyaml" % "1.15"
     ),
     javaOptions += "-Xmx4G",
     assemblyOption in assembly := (assemblyOption in assembly).value.copy(

--- a/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -50,7 +50,7 @@ class Repl(input: InputStream,
       output,
       colorSet().prompt + shellPrompt() + scala.Console.RESET,
       interp.pressy.complete(_, interp.eval.previousImportBlock, _),
-      initialHistory ++ history
+      history
     )
     _ = {
       history += code

--- a/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -81,12 +81,12 @@ object Repl{
   def main(args: Array[String]) = run()
   def run(predef: String = defaultPredef) = {
     println("Loading Ammonite Repl...")
-
+    val storage = Storage()
     val shell = new Repl(
       System.in, System.out,
-      initialHistory = Storage.loadHistory,
+      initialHistory = storage.loadHistory,
       saveHistory = { s =>
-        Storage.saveHistory(s)
+        storage.saveHistory(s)
       },
       predef = predef
     )

--- a/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -14,13 +14,14 @@ class Repl(input: InputStream,
            output: OutputStream,
            pprintConfig: pprint.Config = pprint.Config.Colors.PPrintConfig,
            shellPrompt0: String = "@ ",
-           initialHistory: History = new History,
+           initialHistory: Seq[String] = Nil,
            saveHistory: History => Unit = _ => (),
            predef: String = Repl.defaultPredef) {
 
   val shellPrompt = Ref(shellPrompt0)
 
-  val history = initialHistory
+  val history = new History
+  history ++= initialHistory
 
   val colorSet = Ref[ColorSet](ColorSet.Default)
   val frontEnd = Ref[FrontEnd](FrontEnd.JLine)
@@ -81,8 +82,6 @@ object Repl{
   def run(predef: String = defaultPredef) = {
     println("Loading Ammonite Repl...")
 
-    val saveFile = new java.io.File(System.getProperty("user.home")) + "/.amm"
-    val delimiter = "\n\n\n"
     val shell = new Repl(
       System.in, System.out,
       initialHistory = Storage.loadHistory,

--- a/repl/src/main/scala/ammonite/repl/Storage.scala
+++ b/repl/src/main/scala/ammonite/repl/Storage.scala
@@ -45,7 +45,7 @@ object Storage{
 }
 
 class History extends ArrayBuffer[String]{
-  def last(lines: Int){
+  def last(lines: Int) = {
     drop(length - lines)
   }
 }

--- a/repl/src/main/scala/ammonite/repl/Storage.scala
+++ b/repl/src/main/scala/ammonite/repl/Storage.scala
@@ -5,6 +5,7 @@ import java.io.{File, FileInputStream, IOException, FileWriter}
 import org.yaml.snakeyaml.Yaml
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.JavaConversions.asScalaBuffer
+import ammonite.pprint
 
 trait Storage{
   
@@ -56,4 +57,16 @@ class History extends ArrayBuffer[String]{
   }
 }
 
+object History{
+  import pprint._
+  implicit def historyPPrint(implicit c: Config): PPrint[History] = new PPrint(
+    new PPrinter[History]{
+      def render(t: History, c: Config)={
+        val seq = "\n...\n" +: t.last(c.lines()).flatMap{ code => Seq("@ ", code, "\n") }
+        seq.iterator
+      }
+    },
+    c
+  )
+}
 

--- a/repl/src/main/scala/ammonite/repl/Storage.scala
+++ b/repl/src/main/scala/ammonite/repl/Storage.scala
@@ -62,8 +62,10 @@ object History{
   implicit def historyPPrint(implicit c: Config): PPrint[History] = new PPrint(
     new PPrinter[History]{
       def render(t: History, c: Config)={
-        val seq = "\n...\n" +: t.last(c.lines()).flatMap{ code => Seq("@ ", code, "\n") }
-        seq.iterator
+        val lines = if(c.lines() > 0) c.lines() else t.length
+        val seq = "\n" +: t.last(lines).flatMap{ code => Seq("@ ", code, "\n") }
+        if(t.length > lines) ("\n..." +: seq).iterator
+        else seq.iterator
       }
     },
     c

--- a/repl/src/main/scala/ammonite/repl/Storage.scala
+++ b/repl/src/main/scala/ammonite/repl/Storage.scala
@@ -38,7 +38,7 @@ object Storage{
   def saveHistory(h: History): Unit = {
     val fw = new FileWriter(dir + "/history")
     yaml.synchronized{
-      yaml.dump(h.toArray,fw)
+      yaml.dump(h.toArray, fw)
     }
   }
 

--- a/repl/src/main/scala/ammonite/repl/Storage.scala
+++ b/repl/src/main/scala/ammonite/repl/Storage.scala
@@ -6,38 +6,44 @@ import org.yaml.snakeyaml.Yaml
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.JavaConversions.asScalaBuffer
 
+trait Storage{
+  
+  def loadHistory: History
+
+  def saveHistory(h: History): Unit
+}
+
 object Storage{
-  val dir = new java.io.File(System.getProperty("user.home") + "/.ammonite")    
-  if(dir.exists){
-    if(!dir.isDirectory){
-      dir.delete()
+  val defaultPath = new java.io.File(System.getProperty("user.home") + "/.ammonite") 
+  def apply(dir: File = defaultPath) = new Storage{
+  
+    if(dir.exists){
+      if(!dir.isDirectory){
+        dir.delete()
+        dir.mkdir()
+      }
+    } else {
       dir.mkdir()
     }
-  } else {
-    dir.mkdir()
-  }
 
-  lazy val yaml = new Yaml
-
-  def loadHistory: History = {
-    try{
+    def loadHistory: History = {
+      val yaml = new Yaml
       val res = new History
-      val list = yaml.synchronized{
-        yaml.load(new FileInputStream(dir + "/history"))
+      try{
+        val list = yaml.load(new FileInputStream(dir + "/history"))
+        list match {
+          case a: java.util.List[String] => res ++= a
+          case _ =>
+        }
+        res
+      } catch {
+        case e: IOException => new History
       }
-      list match {
-        case a: java.util.List[String] => res ++= a
-        case _ =>
-      }
-      res
-    } catch {
-      case e: IOException => new History
     }
-  }
 
-  def saveHistory(h: History): Unit = {
-    val fw = new FileWriter(dir + "/history")
-    yaml.synchronized{
+    def saveHistory(h: History): Unit = {
+      val yaml = new Yaml
+      val fw = new FileWriter(dir + "/history")
       yaml.dump(h.toArray, fw)
     }
   }

--- a/repl/src/main/scala/ammonite/repl/Storage.scala
+++ b/repl/src/main/scala/ammonite/repl/Storage.scala
@@ -7,6 +7,11 @@ import scala.collection.mutable.ArrayBuffer
 import scala.collection.JavaConversions.asScalaBuffer
 import ammonite.pprint
 
+/**Trait for the interface of common persistent storage. 
+ * This handles history and persistent caches.
+ * Right now it is not threadsafe nor does it handle the mutual exclusion of files between processes. 
+ * Mutexes should be added to be able to run multiple Ammonite processes on the same system.
+ */ 
 trait Storage{
   
   def loadHistory: History

--- a/repl/src/main/scala/ammonite/repl/Storage.scala
+++ b/repl/src/main/scala/ammonite/repl/Storage.scala
@@ -1,0 +1,53 @@
+package ammonite.repl
+
+import acyclic.file
+import java.io.{File, FileInputStream, IOException, FileWriter}
+import org.yaml.snakeyaml.Yaml
+import scala.collection.mutable.ArrayBuffer
+import scala.collection.JavaConversions.asScalaBuffer
+
+object Storage{
+  val dir = new java.io.File(System.getProperty("user.home") + "/.ammonite")    
+  if(dir.exists){
+    if(!dir.isDirectory){
+      dir.delete()
+      dir.mkdir()
+    }
+  } else {
+    dir.mkdir()
+  }
+
+  lazy val yaml = new Yaml
+
+  def loadHistory: History = {
+    try{
+      val res = new History
+      val list = yaml.synchronized{
+        yaml.load(new FileInputStream(dir + "/history"))
+      }
+      list match {
+        case a: java.util.List[String] => res ++= a
+        case _ =>
+      }
+      res
+    } catch {
+      case e: IOException => new History
+    }
+  }
+
+  def saveHistory(h: History): Unit = {
+    val fw = new FileWriter(dir + "/history")
+    yaml.synchronized{
+      yaml.dump(h.toArray,fw)
+    }
+  }
+
+}
+
+class History extends ArrayBuffer[String]{
+  def last(lines: Int){
+    drop(length - lines)
+  }
+}
+
+

--- a/repl/src/main/scala/ammonite/repl/Util.scala
+++ b/repl/src/main/scala/ammonite/repl/Util.scala
@@ -3,6 +3,7 @@ package ammonite.repl
 import acyclic.file
 import ammonite.pprint.{PPrinter, PPrint}
 import fastparse._
+import parsers.Terminals.Literal
 
 import scala.util.Try
 import scalaparse.Scala._
@@ -192,8 +193,9 @@ object Parsers {
     }
   }
 
-  val CompilationUnit = P( WL ~ StatementBlock("@\n") ~ WL )
-  val ScriptSplitter = P( CompilationUnit.rep(1, "@\n") ~ End)
+  val Separator = P( Literal("@") ~ CharIn(" \n").rep(1) )
+  val CompilationUnit = P( WL ~ StatementBlock(Separator) ~ WL )
+  val ScriptSplitter = P( CompilationUnit.rep(1, Separator) ~ End)
   def splitScript(code: String) = {
     ScriptSplitter.parse(code) match{
       case Result.Success(value, idx) => value

--- a/repl/src/main/scala/ammonite/repl/frontend/ReplAPI.scala
+++ b/repl/src/main/scala/ammonite/repl/frontend/ReplAPI.scala
@@ -3,7 +3,7 @@ package ammonite.repl.frontend
 import java.io.File
 
 import ammonite.pprint.{PPrinter, PPrint, Config, TPrint}
-import ammonite.repl.Ref
+import ammonite.repl.{Ref, History}
 
 import scala.reflect.runtime.universe._
 import acyclic.file
@@ -50,7 +50,7 @@ trait ReplAPI {
   /**
    * History of commands that have been entered into the shell
    */
-  def history: Seq[String]
+  def history: History
 
   /**
    * Get the `Type` object of [[T]]. Useful for finding
@@ -94,6 +94,8 @@ trait ReplAPI {
    * to shadow this with your own definition to change how things look
    */
   implicit var pprintConfig: ammonite.pprint.Config
+
+  implicit val historyPPrinter: ammonite.pprint.PPrinter[History]
 }
 trait Load extends (String => Unit){
   /**

--- a/repl/src/main/scala/ammonite/repl/frontend/ReplAPI.scala
+++ b/repl/src/main/scala/ammonite/repl/frontend/ReplAPI.scala
@@ -94,8 +94,6 @@ trait ReplAPI {
    * to shadow this with your own definition to change how things look
    */
   implicit var pprintConfig: ammonite.pprint.Config
-
-  implicit val historyPPrinter: ammonite.pprint.PPrinter[History]
 }
 trait Load extends (String => Unit){
   /**

--- a/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
@@ -21,7 +21,7 @@ class Interpreter(shellPrompt0: Ref[String],
                   pprintConfig: pprint.Config,
                   colors0: Ref[ColorSet],
                   stdout: String => Unit,
-                  history0: => Seq[String],
+                  history0: => History,
                   predef: String){ interp =>
 
   val dynamicClasspath = new VirtualDirectory("(memory)", None)
@@ -135,9 +135,16 @@ class Interpreter(shellPrompt0: Ref[String],
     def search(target: scala.reflect.runtime.universe.Type) = Interpreter.this.compiler.search(target)
     def compiler = Interpreter.this.compiler.compiler
     def newCompiler() = init()
-    def history = history0.toVector.dropRight(1)
-    def historyS = history0
+    def history = history0
     def show[T](a: T, lines: Int = 0) = ammonite.pprint.Show(a, lines)
+
+    implicit val historyPPrinter: pprint.PPrinter[History] = 
+      new pprint.PPrinter[History]{
+        def render(t: History, c: pprint.Config)={
+          val seq = "\n" +: t.flatMap{ code => Seq("@ ", code, "\n") }
+          seq.iterator
+      }
+    }
   }
 
   var compiler: Compiler = _

--- a/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
@@ -137,14 +137,6 @@ class Interpreter(shellPrompt0: Ref[String],
     def newCompiler() = init()
     def history = history0
     def show[T](a: T, lines: Int = 0) = ammonite.pprint.Show(a, lines)
-
-    implicit val historyPPrinter: pprint.PPrinter[History] = 
-      new pprint.PPrinter[History]{
-        def render(t: History, c: pprint.Config)={
-          val seq = "\n" +: t.flatMap{ code => Seq("@ ", code, "\n") }
-          seq.iterator
-      }
-    }
   }
 
   var compiler: Compiler = _

--- a/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
@@ -136,6 +136,7 @@ class Interpreter(shellPrompt0: Ref[String],
     def compiler = Interpreter.this.compiler.compiler
     def newCompiler() = init()
     def history = history0.toVector.dropRight(1)
+    def historyS = history0
     def show[T](a: T, lines: Int = 0) = ammonite.pprint.Show(a, lines)
   }
 

--- a/repl/src/test/resource/scripts/BlockSepSyntax.scala
+++ b/repl/src/test/resource/scripts/BlockSepSyntax.scala
@@ -1,0 +1,8 @@
+"block1"
+@
+"block2"
+@      
+"block3"
+@    "block4"
+@ "block5"
+val res = 24

--- a/repl/src/test/scala/ammonite/repl/Checker.scala
+++ b/repl/src/test/scala/ammonite/repl/Checker.scala
@@ -14,7 +14,7 @@ class Checker {
     ammonite.pprint.Config.Defaults.PPrintConfig.copy(lines = () => 15),
     Ref(ColorSet.BlackWhite),
     stdout = allOutput += _,
-    history0 = Nil,
+    history0 = new History,
     predef = predef
   )
 

--- a/repl/src/test/scala/ammonite/repl/ScriptTests.scala
+++ b/repl/src/test/scala/ammonite/repl/ScriptTests.scala
@@ -35,6 +35,14 @@ object ScriptTests extends TestSuite{
           r: Int = 24
           """)
       }
+      'syntax{
+        check.session(s"""
+          @ load.script("$scriptPath/BlockSepSyntax.scala")
+
+          @ val r = res
+          r: Int = 24
+          """)
+      }
     }
     'failures{
       'syntaxError{
@@ -43,7 +51,7 @@ object ScriptTests extends TestSuite{
 
           @ val r = res
           error: Compilation Failed
-          Main.scala:29: not found: value res
+          Main.scala:30: not found: value res
           res
           ^
           """)
@@ -54,7 +62,7 @@ object ScriptTests extends TestSuite{
 
           @ val r = res
           error: Compilation Failed
-          Main.scala:39: not found: value res
+          Main.scala:40: not found: value res
           res
           ^
 
@@ -76,7 +84,7 @@ object ScriptTests extends TestSuite{
 
           @ val r2 = res2
           error: Compilation Failed
-          Main.scala:41: not found: value res2
+          Main.scala:42: not found: value res2
           res2 
           ^
           """)

--- a/repl/src/test/scala/ammonite/repl/ScriptTests.scala
+++ b/repl/src/test/scala/ammonite/repl/ScriptTests.scala
@@ -51,7 +51,7 @@ object ScriptTests extends TestSuite{
 
           @ val r = res
           error: Compilation Failed
-          Main.scala:30: not found: value res
+          Main.scala:29: not found: value res
           res
           ^
           """)
@@ -62,7 +62,7 @@ object ScriptTests extends TestSuite{
 
           @ val r = res
           error: Compilation Failed
-          Main.scala:40: not found: value res
+          Main.scala:39: not found: value res
           res
           ^
 
@@ -84,7 +84,7 @@ object ScriptTests extends TestSuite{
 
           @ val r2 = res2
           error: Compilation Failed
-          Main.scala:42: not found: value res2
+          Main.scala:41: not found: value res2
           res2 
           ^
           """)

--- a/repl/src/test/scala/ammonite/repl/UnitTests.scala
+++ b/repl/src/test/scala/ammonite/repl/UnitTests.scala
@@ -29,6 +29,14 @@ object UnitTests extends TestSuite{
   val tests = TestSuite{
     println("UnitTests")
 
+    'historyPPrint{
+      import ammonite.pprint._
+      val hist = new History
+      hist ++= Seq("1","2","{\nblock\n}")
+      implicit val cfg = new Config
+      val pprinted = implicitly[PPrint[History]].render(hist).mkString
+      assert(pprinted == "\n@ 1\n@ 2\n@ {\nblock\n}\n")
+    }
     'comment - test("//a", "><B|//a>")
     'literal - test("1", "><G|1>")
     'expressions - test("val (x, y) = 1 + 2 + 3", "><Y|val> (x, y) = <G|1> + <G|2> + <G|3>")


### PR DESCRIPTION
This addresses issues #99 and #101. A new class `History` and a new singleton `Storage` is added. `History` has a `PPrinter` that prints it in script syntax. Script syntax was modified, so now not just `@\n` but anything matching the regex `@[\n ]+` is accepted as compilation block separator. `History` also has a `last(lines: Int)` method. `Storage` stores history in the `~/.ammonite/history` file with YAML syntax.  