### PR TITLE
Misc Fixes

### DIFF
--- a/repl/src/main/scala/ammonite/repl/Storage.scala
+++ b/repl/src/main/scala/ammonite/repl/Storage.scala
@@ -13,15 +13,16 @@ import ammonite.pprint
  * Mutexes should be added to be able to run multiple Ammonite processes on the same system.
  */ 
 trait Storage{
-  
+  def loadPredef: String
+
   def loadHistory: History
 
   def saveHistory(h: History): Unit
 }
 
 object Storage{
-  val defaultPath = new java.io.File(System.getProperty("user.home") + "/.ammonite") 
-  def apply(dir: File = defaultPath) = new Storage{
+
+  def apply(dir: File) = new Storage{
   
     if(dir.exists){
       if(!dir.isDirectory){
@@ -51,6 +52,12 @@ object Storage{
       val yaml = new Yaml
       val fw = new FileWriter(dir + "/history")
       yaml.dump(h.toArray, fw)
+    }
+
+    def loadPredef = try{
+      io.Source.fromFile(dir + "/predef.scala").mkString
+    }catch{
+      case e: java.io.FileNotFoundException => ""
     }
   }
 

--- a/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
@@ -180,8 +180,6 @@ class Interpreter(shellPrompt0: Ref[String],
   // line number to -1 if the predef exists so the first user-entered
   // line becomes 0
   if (predef != "") {
-    val res1 = processLine(Parsers.split(predef), _.foreach(stdout))
-    val res2 = handleOutput(res1)
-    stdout("\n")
+    processScript(predef)
   }
 }

--- a/terminal/src/main/scala/ammonite/terminal/Term.scala
+++ b/terminal/src/main/scala/ammonite/terminal/Term.scala
@@ -7,13 +7,17 @@ import scala.annotation.tailrec
 
 // Test Unicode:  漢語;𩶘da
 object Term{
+  def consoleDim(s: String) = {
+    import sys.process._
+    Seq("bash", "-c", s"tput $s 2> /dev/tty").!!.trim.toInt
+  }
   def main(args: Array[String]): Unit = {
     var history = List.empty[String]
     val selection = AdvancedFilters.SelectionFilter()
     rec()
     @tailrec def rec(): Unit = {
       TermCore.readLine(
-        "@ ",
+        Console.MAGENTA + "@ " + Console.RESET,
         System.in,
         System.out,
         selection orElse

--- a/terminal/src/main/scala/ammonite/terminal/TermCore.scala
+++ b/terminal/src/main/scala/ammonite/terminal/TermCore.scala
@@ -167,7 +167,7 @@ object TermCore {
 
     @tailrec def rec(lastState: TermState, areaHeight: Int): Option[String] = {
       if (!reader.ready())redrawLine(lastState.buffer, lastState.cursor)
-      filters(TermInfo(lastState, width - prompt.length)) match {
+      filters(TermInfo(lastState, width - noAnsiPrompt.length)) match {
         case TermState(s, b, c) =>
           val newCursor = math.max(math.min(c, b.length), 0)
 


### PR DESCRIPTION
- Predef script is now loaded from `.ammonite/predef.scala`
- `ammonite-terminal` now properly strips ansi colors from prompt when calculating width
- Move `consoleDim` from `ammonite.repl.Repl` into `ammonite.terminal.Term`, and make `Repl` access it through `ammonite.repl.frontend.FrontEnd.Ammonite` to keep `Repl` free of too much bash/unix-isms
- predef script now uses multi-unit script format