### PR TITLE
Checker regex

### DIFF
--- a/repl/src/test/scala/ammonite/repl/FailureTests.scala
+++ b/repl/src/test/scala/ammonite/repl/FailureTests.scala
@@ -18,13 +18,13 @@ object FailureTests extends TestSuite{
 
         @ 1 + vale
         error: Compilation Failed
-        Main.scala:29: not found: value vale
+        Main.scala:\d\+: not found: value vale
         1 + vale
             ^
 
         @ val x = 1 + vale
         error: Compilation Failed
-        Main.scala:29: not found: value vale
+        Main.scala:\d\+: not found: value vale
         1 + vale
             ^
       """)

--- a/repl/src/test/scala/ammonite/repl/ScriptTests.scala
+++ b/repl/src/test/scala/ammonite/repl/ScriptTests.scala
@@ -56,7 +56,7 @@ object ScriptTests extends TestSuite{
 
           @ val r = res
           error: Compilation Failed
-          Main.scala:29: not found: value res
+          Main.scala:\\d\\+: not found: value res
           res
           ^
           """)
@@ -67,7 +67,7 @@ object ScriptTests extends TestSuite{
 
           @ val r = res
           error: Compilation Failed
-          Main.scala:39: not found: value res
+          Main.scala:\\d\\+: not found: value res
           res
           ^
 
@@ -89,7 +89,7 @@ object ScriptTests extends TestSuite{
 
           @ val r2 = res2
           error: Compilation Failed
-          Main.scala:41: not found: value res2
+          Main.scala:\\d\\+: not found: value res2
           res2 
           ^
           """)


### PR DESCRIPTION
This PR makes `Checker` in REPL test hadnle the expected output as a vim nomagic mode regex. This way we can handle more possible right outputs with ease. Regex special characters in expected output are handled as literals unless they are prefixed with `\`. Literal `\` itself needs to be escaped. 