### PR TITLE
Fix compiler error on parsing

### DIFF
--- a/repl/src/test/scala/ammonite/repl/AdvancedTests.scala
+++ b/repl/src/test/scala/ammonite/repl/AdvancedTests.scala
@@ -11,7 +11,6 @@ object AdvancedTests extends TestSuite{
     println("AdvancedTests")
     val check = new Checker()
     'pprint{
-      if (!scala2_10) //buggy in 2.10
       check.session("""
         @ Seq.fill(10)(Seq.fill(3)("Foo"))
         res0: Seq[Seq[String]] = List(
@@ -45,7 +44,7 @@ object AdvancedTests extends TestSuite{
       // Make sure these various "special" data structures get pretty-printed
       // correctly, i.e. not as their underlying type but as something more
       // pleasantly human-readable
-      if (!scala.util.Properties.versionString.contains("2.10"))
+      if (!scala2_10)
         check.session("""
           @ import ammonite.ops._
 
@@ -93,16 +92,16 @@ object AdvancedTests extends TestSuite{
       }
       check2.session("""
         @ -x
-        res0: Int = -1
+        res1: Int = -1
 
         @ y
-        res1: String = "2"
+        res2: String = "2"
 
         @ x + y
-        res2: String = "12"
+        res3: String = "12"
 
         @ abs(-x)
-        res3: Int = 1
+        res4: Int = 1
       """)
 
     }

--- a/repl/src/test/scala/ammonite/repl/AutocompleteTests.scala
+++ b/repl/src/test/scala/ammonite/repl/AutocompleteTests.scala
@@ -1,5 +1,6 @@
 package ammonite.repl
 
+import ammonite.repl.TestUtils._
 import utest._
 import acyclic.file
 import scala.collection.{immutable => imm}
@@ -79,7 +80,7 @@ object AutocompleteTests extends TestSuite{
       complete("""object Zomg{ <caret>Zom }""", Set("Zomg") ^)
     }
     'dot{
-      if (!scala.util.Properties.versionString.contains("2.10")) {
+      if (!scala2_10) {
         complete( """java.math.<caret>""",
           Set("MathContext", "BigDecimal", "BigInteger", "RoundingMode") ^
         )

--- a/repl/src/test/scala/ammonite/repl/EvaluatorTests.scala
+++ b/repl/src/test/scala/ammonite/repl/EvaluatorTests.scala
@@ -104,7 +104,6 @@ object EvaluatorTests extends TestSuite{
       """)
     }
     'types{
-      if (!scala2_10) //buggy in 2.10
       check.session("""
         @ type Funky = Array[Array[String]]
         defined type Funky
@@ -240,7 +239,6 @@ object EvaluatorTests extends TestSuite{
 
 
     'classes{
-      if (!scala2_10) //buggy in 2.10
       check.session("""
         @ class C{override def toString() = "Ceee"}
         defined class C
@@ -304,7 +302,6 @@ object EvaluatorTests extends TestSuite{
       """)
     }
     'multistatement{
-      if (!scala2_10) //buggy in 2.10
       check.session("""
         @ ;1; 2L; '3';
         res0_0: Int = 1

--- a/repl/src/test/scala/ammonite/repl/ProjectTests.scala
+++ b/repl/src/test/scala/ammonite/repl/ProjectTests.scala
@@ -14,7 +14,6 @@ object ProjectTests extends TestSuite{
       'ivy{
         'standalone{
           val tq = "\"\"\""
-          if (!scala2_10) //buggy in 2.10
           check.session(s"""
             @ import scalatags.Text.all._
             error: not found: value scalatags
@@ -31,7 +30,6 @@ object ProjectTests extends TestSuite{
           """)
         }
         'complex{
-          if (!scala2_10) //buggy in 2.10
           check.session("""
             @ load.ivy("com.typesafe.akka" %% "akka-http-experimental" % "1.0-M3")
 
@@ -76,22 +74,21 @@ object ProjectTests extends TestSuite{
     }
 
     'shapeless{
-      if (!scala2_10)
-        check.session("""
-          @ load.ivy("com.chuusai" %% "shapeless" % "2.1.0")
+      // Shapeless 2.1.0 isn't published for scala 2.10
+      if (!scala2_10) check.session("""
+        @ load.ivy("com.chuusai" %% "shapeless" % "2.1.0")
 
-          @ import shapeless._
+        @ import shapeless._
 
-          @ (1 :: "lol" :: List(1, 2, 3) :: HNil)
-          res2: Int :: String :: List[Int] :: HNil = ::(1, ::("lol", ::(List(1, 2, 3), HNil)))
+        @ (1 :: "lol" :: List(1, 2, 3) :: HNil)
+        res2: Int :: String :: List[Int] :: HNil = ::(1, ::("lol", ::(List(1, 2, 3), HNil)))
 
-          @ res2(1)
-          res3: String = "lol"
-        """)
+        @ res2(1)
+        res3: String = "lol"
+      """)
     }
 
     'scalaz{
-      if (!scala2_10) //buggy in 2.10
       check.session("""
         @ load.ivy("org.scalaz" %% "scalaz-core" % "7.1.1")
 
@@ -126,7 +123,6 @@ object ProjectTests extends TestSuite{
 
     'finagle{
       // Prevent regressions when wildcard-importing things called `macro` or `_`
-      if (!scala2_10) //buggy in 2.10
       check.session("""
         @ load.ivy("com.twitter" %% "finagle-httpx" % "6.26.0")
 
@@ -205,6 +201,36 @@ object ProjectTests extends TestSuite{
 
           @ mean(Rational(1, 2), Rational(3, 2), Rational(0))
           res9: Rational = 2/3
+        """)
+      else
+        check.session(s"""
+          @ load.ivy("org.spire-math" %% "spire" % "0.10.1")
+
+          @ import spire.implicits._
+
+          @ import spire.math._
+
+          @ def euclidGcd[A: Integral](x: A, y: A): A = {
+          @   if (y == 0) x
+          @   else euclidGcd(y, x % y)
+          @ }
+
+          @ euclidGcd(42, 96)
+          res4: Int = 6
+
+          @ euclidGcd(42L, 96L)
+          res5: Long = 6L
+
+          @ euclidGcd(BigInt(42), BigInt(96))
+          res6: math.BigInt = 6
+
+          @ def mean[A: Fractional](xs: A*): A = xs.reduceLeft(_ + _) / xs.size
+
+          @ mean(0.5, 1.5, 0.0, -0.5)
+          res8: Double = 0.375
+
+          @ mean(Rational(1, 2), Rational(3, 2), Rational(0))
+          res9: spire.math.Rational = 2/3
         """)
     }
 

--- a/repl/src/test/scala/ammonite/repl/ScriptTests.scala
+++ b/repl/src/test/scala/ammonite/repl/ScriptTests.scala
@@ -107,7 +107,6 @@ object ScriptTests extends TestSuite{
     'module{
       'compilationBlocks{
         'loadIvy{
-          if (!scala2_10) //buggy in 2.10
           check.session(s"""
             @ load.module("$scriptPath/LoadIvy.scala")
 
@@ -118,9 +117,8 @@ object ScriptTests extends TestSuite{
             """)
         }
         'preserveImports{
-          if (!scala2_10) { //buggy in 2.10
             val typeString =
-              if (!scala.util.Properties.versionString.contains("2.10"))
+              if (!scala2_10)
                 """Left[String, Nothing]"""
               else
                 """util.Left[String,Nothing]"""
@@ -130,7 +128,7 @@ object ScriptTests extends TestSuite{
               @ val r = res
               r: $typeString = Left("asd")
               """)
-          }
+
         }
         'annotation{
           if (!scala2_10) //buggy in 2.10
@@ -142,13 +140,12 @@ object ScriptTests extends TestSuite{
             """)
         }
         'syntax{
-          if (!scala2_10) //buggy in 2.10
           check.session(s"""
             @ load.module("$scriptPath/BlockSepSyntax.scala")
 
             @ val r = res
             r: Int = 24
-            """)
+          """)
         }
       }
       'failures{
@@ -219,19 +216,22 @@ object ScriptTests extends TestSuite{
             val storage = new MemoryStorage
             val interp = createTestInterp(storage)
             interp.replApi.load.module(s"$scriptPath/OneBlock.scala")
-            assert(storage.compileCache.size==2) //ReplBridge adds an object to cache
+            val n = storage.compileCache.size
+            assert(n == 1) //ReplBridge adds an object to cache
           }
           'two{
             val storage = new MemoryStorage
             val interp = createTestInterp(storage)
             interp.replApi.load.module(s"$scriptPath/TwoBlocks.scala")
-            assert(storage.compileCache.size==3)
+            val n = storage.compileCache.size
+            assert(n == 2)
           }
           'three{
             val storage = new MemoryStorage
             val interp = createTestInterp(storage)
             interp.replApi.load.module(s"$scriptPath/ThreeBlocks.scala")
-            assert(storage.compileCache.size==4)
+            val n = storage.compileCache.size
+            assert(n == 3)
           }
         }
         'persistence{
@@ -241,20 +241,21 @@ object ScriptTests extends TestSuite{
             val interp2 = createTestInterp(Storage(tempDir))
             interp1.replApi.load.module(s"$scriptPath/OneBlock.scala")
             interp2.replApi.load.module(s"$scriptPath/OneBlock.scala")
-            assert(interp1.eval.compilationCount == 2) //first init adds a compilation because of ReplBridge
-            assert(interp2.eval.compilationCount == 0)
+            val n1 = interp1.eval.compilationCount
+            val n2 = interp2.eval.compilationCount
+            assert(n1 == 1) //first init adds a compilation because of ReplBridge
+            assert(n2 == 0)
           }
         }
         'tags{
-          if (!scala2_10) {//buggy in 2.10
-            val storage = new MemoryStorage
-            val interp = createTestInterp(storage)
-            interp.replApi.load.module(s"$scriptPath/TagBase.scala")
-            interp.replApi.load.module(s"$scriptPath/TagPrevCommand.scala")
-            interp.replApi.load.ivy("com.lihaoyi" %% "scalatags" % "0.4.5")
-            interp.replApi.load.module(s"$scriptPath/TagBase.scala")
-            assert(storage.compileCache.size == 7) //two blocks for each loading + ReplBridge
-          }
+          val storage = new MemoryStorage
+          val interp = createTestInterp(storage)
+          interp.replApi.load.module(s"$scriptPath/TagBase.scala")
+          interp.replApi.load.module(s"$scriptPath/TagPrevCommand.scala")
+          interp.replApi.load.ivy("com.lihaoyi" %% "scalatags" % "0.4.5")
+          interp.replApi.load.module(s"$scriptPath/TagBase.scala")
+          val n = storage.compileCache.size
+          assert(n == 6) //two blocks for each loading + ReplBridge
         }
         'encapsulation{
           check.session(s"""

--- a/repl/src/test/scala/ammonite/repl/ScriptTests.scala
+++ b/repl/src/test/scala/ammonite/repl/ScriptTests.scala
@@ -217,7 +217,7 @@ object ScriptTests extends TestSuite{
             val interp = createTestInterp(storage)
             interp.replApi.load.module(s"$scriptPath/OneBlock.scala")
             val n = storage.compileCache.size
-            assert(n == 1) //ReplBridge adds an object to cache
+            assert(n == 1) // ReplBridge doesn't get counted
           }
           'two{
             val storage = new MemoryStorage
@@ -235,17 +235,16 @@ object ScriptTests extends TestSuite{
           }
         }
         'persistence{
-          if (!scala2_10) {//buggy in 2.10
-            val tempDir = java.nio.file.Files.createTempDirectory("ammonite-tester").toFile
-            val interp1 = createTestInterp(Storage(tempDir))
-            val interp2 = createTestInterp(Storage(tempDir))
-            interp1.replApi.load.module(s"$scriptPath/OneBlock.scala")
-            interp2.replApi.load.module(s"$scriptPath/OneBlock.scala")
-            val n1 = interp1.eval.compilationCount
-            val n2 = interp2.eval.compilationCount
-            assert(n1 == 1) //first init adds a compilation because of ReplBridge
-            assert(n2 == 0)
-          }
+
+          val tempDir = java.nio.file.Files.createTempDirectory("ammonite-tester").toFile
+          val interp1 = createTestInterp(Storage(tempDir))
+          val interp2 = createTestInterp(Storage(tempDir))
+          interp1.replApi.load.module(s"$scriptPath/OneBlock.scala")
+          interp2.replApi.load.module(s"$scriptPath/OneBlock.scala")
+          val n1 = interp1.eval.compilationCount
+          val n2 = interp2.eval.compilationCount
+          assert(n1 == 1) // first init
+          assert(n2 == 0) // no need for further compilations
         }
         'tags{
           val storage = new MemoryStorage
@@ -255,7 +254,7 @@ object ScriptTests extends TestSuite{
           interp.replApi.load.ivy("com.lihaoyi" %% "scalatags" % "0.4.5")
           interp.replApi.load.module(s"$scriptPath/TagBase.scala")
           val n = storage.compileCache.size
-          assert(n == 6) //two blocks for each loading + ReplBridge
+          assert(n == 6) // two blocks for each loading
         }
         'encapsulation{
           check.session(s"""


### PR DESCRIPTION
- Don't cache manually-entered commands; it makes the mangled names of classes really ugly =/
- Don't cache the `ReplBridge` instantiation; it turns out that this was what was causing that compiler error that @laci37 was seeing. There's probably a separate bug here, but we can remove this instantiation when we fix that bug. Apart from happening on 2.10, the same compiler error was happening intermittently in 2.11 too
- Re-enable all the tests we disabled in 2.10
- Move the last few manual calls to `scala.util.Properties` onto `scala2_10`