### PR TITLE
Grab bag of fixes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -102,7 +102,6 @@ lazy val repl = project
       "org.apache.ivy" % "ivy" % "2.4.0",
       "com.lihaoyi" %% "scalaparse" % "0.2.1",
       "com.lihaoyi" %% "upickle" % "0.3.4",
-      "org.yaml" % "snakeyaml" % "1.15",
       "com.lihaoyi" %% "pprint" % "0.3.4",
       "com.github.scopt" %% "scopt" % "3.3.0"
     ),

--- a/ops/src/main/scala/ammonite/ops/FileOps.scala
+++ b/ops/src/main/scala/ammonite/ops/FileOps.scala
@@ -152,7 +152,13 @@ object LsSeq{
     PPrinter(
       (t: LsSeq, c: Config) =>
         pprint.Internals.handleChunksVertical("LsSeq", c, (c) =>
-          t.listed.iterator.map(implicitly[PPrint[RelPath]].pprinter.render(_, c))
+          t.listed
+           .iterator
+           // Don't show dotfiles by default, to follow the behavior
+           // of bash and friends. If the user wants to see them then
+           // he can call toSeq on the result
+           .filter(!_.last.startsWith("."))
+           .map(implicitly[PPrint[RelPath]].pprinter.render(_, c))
         )
 
     )

--- a/ops/src/main/scala/ammonite/ops/Model.scala
+++ b/ops/src/main/scala/ammonite/ops/Model.scala
@@ -36,7 +36,8 @@ class PermSet(s: Set[PosixFilePermission]) extends Set[PosixFilePermission]{
 
 object stat extends Op1[ops.Path, ops.stat]{
   def apply(p: ops.Path) = ops.stat.make(
-    p.last,
+    // Don't blow up if we stat `root`
+    p.segments.lastOption.getOrElse("/"),
     Files.readAttributes(java.nio.file.Paths.get(p.toString), classOf[BasicFileAttributes]),
     Try(Files.readAttributes(java.nio.file.Paths.get(p.toString), classOf[PosixFileAttributes])).toOption
   )

--- a/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -10,7 +10,7 @@ import Util.CompileCache
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.util.Try
-
+import ammonite.ops._
 class Repl(input: InputStream,
            output: OutputStream,
            storage: Ref[Storage],
@@ -99,9 +99,9 @@ object Repl{
     )
     traces.mkString("\n")
   }
-  case class Config(predef: String = "", ammoniteHome: java.io.File = defaultAmmoniteHome)
+  case class Config(predef: String = "", ammoniteHome: Path = defaultAmmoniteHome)
 
-  def defaultAmmoniteHome = new java.io.File(System.getProperty("user.home") + "/.ammonite")
+  def defaultAmmoniteHome = Path(System.getProperty("user.home"))/".ammonite"
   def main(args: Array[String]) = {
     val parser = new scopt.OptionParser[Config]("ammonite") {
       head("ammonite", ammonite.Constants.version)
@@ -110,12 +110,12 @@ object Repl{
         .text("Any commands you want to execute at the start of the REPL session")
       opt[File]('h', "home")
         .valueName("<file>")
-        .action((x, c) => c.copy(ammoniteHome = x))
+        .action((x, c) => c.copy(ammoniteHome = Path(x)))
         .text("The home directory of the REPL; where it looks for config and caches")
     }
     parser.parse(args, Config()).foreach(c => run(c.predef, c.ammoniteHome))
   }
-  def run(predef: String = "", ammoniteHome: java.io.File = defaultAmmoniteHome) = {
+  def run(predef: String = "", ammoniteHome: Path = defaultAmmoniteHome) = {
     println("Loading Ammonite Repl...")
     Timer("Repl.run Start")
     val storage = Storage(ammoniteHome)

--- a/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -49,6 +49,7 @@ class Repl(input: InputStream,
     _ <- Signaller("INT") { interp.mainThread.stop() }
     out <- interp.processLine(code, stmts, _.foreach(printer.print))
   } yield {
+    Timer("interp.processLine end")
     printer.println()
     out
   }
@@ -67,6 +68,7 @@ class Repl(input: InputStream,
           printer.println(colors().error() + msg + colors().reset())
         case _ =>
       }
+      Timer("End Of Loop")
       if (interp.handleOutput(res)) loop()
     }
     loop()

--- a/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -44,7 +44,7 @@ class Repl(input: InputStream,
       colors().prompt() + prompt() + colors().reset(),
       colors(),
       interp.pressy.complete(_, interp.eval.previousImportBlock, _),
-      storage().history()
+      storage().fullHistory()
     )
     _ <- Signaller("INT") { interp.mainThread.stop() }
     out <- interp.processLine(code, stmts, _.foreach(printer.print))

--- a/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -22,6 +22,7 @@ class Repl(input: InputStream,
   val frontEnd = Ref[FrontEnd](FrontEnd.Ammonite)
 
   val printer = new PrintStream(output, true)
+  Timer("Repl init printer")
   val interp: Interpreter = new Interpreter(
     prompt,
     frontEnd,
@@ -33,6 +34,7 @@ class Repl(input: InputStream,
     storage,
     predef
   )
+  Timer("Repl init interpreter")
   val reader = new InputStreamReader(input)
   def action() = for{
     (code, stmts) <- frontEnd().action(
@@ -113,6 +115,7 @@ object Repl{
   }
   def run(predef: String = "", ammoniteHome: java.io.File = defaultAmmoniteHome) = {
     println("Loading Ammonite Repl...")
+    Timer("Repl.run Start")
     val storage = Storage(ammoniteHome)
     val repl = new Repl(
       System.in, System.out,
@@ -120,7 +123,7 @@ object Repl{
       predef = predef + "\n" + storage.loadPredef
     )
     repl.run()
-
+    Timer("Repl.run End")
   }
 }
 

--- a/repl/src/main/scala/ammonite/repl/Storage.scala
+++ b/repl/src/main/scala/ammonite/repl/Storage.scala
@@ -86,13 +86,13 @@ object Storage{
       def apply() = {
         val json =
           try read(ivyCacheFile)
-          catch{ case e: java.io.FileNotFoundException => "[]" }
+          catch{ case e: java.nio.file.NoSuchFileException => "[]" }
 
         try upickle.default.read[IvyMap](json)
         catch{ case e: Exception => Map.empty }
       }
       def update(map: IvyMap) = {
-        write(ivyCacheFile, upickle.default.write(map))
+        write.over(ivyCacheFile, upickle.default.write(map))
       }
     }
 

--- a/repl/src/main/scala/ammonite/repl/Storage.scala
+++ b/repl/src/main/scala/ammonite/repl/Storage.scala
@@ -2,6 +2,7 @@ package ammonite.repl
 
 import acyclic.file
 import java.io.{File, FileInputStream, IOException, FileWriter}
+import ammonite.ops._
 import ammonite.repl.Util.{IvyMap, CompileCache, ClassFiles}
 import org.yaml.snakeyaml.Yaml
 import scala.util.Try
@@ -26,16 +27,8 @@ trait Storage{
 
 object Storage{
 
-  def apply(dir: File): Storage = new Storage{
+  def apply(dir: Path): Storage = new Storage{
   
-    if(dir.exists){
-      if(!dir.isDirectory){
-        dir.delete()
-        dir.mkdir()
-      }
-    } else {
-      dir.mkdir()
-    }
 
     val history = new StableRef[History]{
       def apply(): History = {
@@ -60,39 +53,35 @@ object Storage{
 
     def compileCacheSave(tag: String, data: CompileCache): Unit = {
       val (classFiles, imports) = data
-      val cacheDir = new File(dir + s"/compileCache/$tag")
-      if(!cacheDir.exists){
-        cacheDir.mkdirs()
+      val cacheDir = dir/'compileCache/tag
+      if(!exists(cacheDir)){
+        mkdir(cacheDir)
         val metadata = upickle.default.write(imports)
-        writeFile(cacheDir + "/metadata.json", metadata.getBytes)
+        write(cacheDir/"metadata.json", metadata)
         classFiles.foreach{ case (name, bytes) =>
-          writeFile(cacheDir + s"/$name.class", bytes)
+          write(cacheDir/s"$name.class", bytes)
         }
       }
     }
 
     def compileCacheLoad(tag: String): Option[CompileCache] = {
-      val cacheDir = new File(dir + s"/compileCache/$tag")
-      if(!cacheDir.exists) None
+      val cacheDir = dir/'compileCache/tag
+      if(!exists(cacheDir)) None
       else for{
-        metadataJson <- Try{
-          new String(readFile(cacheDir + "/metadata.json"))
-        }.toOption
-        metadata <- Try{
-          upickle.default.read[Seq[ImportData]](metadataJson)
-        }.toOption
+        metadataJson <- Try{read(cacheDir/"metadata.json")}.toOption
+        metadata <- Try{upickle.default.read[Seq[ImportData]](metadataJson)}.toOption
         classFiles <- loadClassFiles(cacheDir)
       } yield {
         (classFiles, metadata)
       }
     }
 
-    def loadClassFiles(cacheDir: File): Option[ClassFiles] = {
-      val classFiles = cacheDir.listFiles().filter(_.getName.endsWith(".class"))
+    def loadClassFiles(cacheDir: Path): Option[ClassFiles] = {
+      val classFiles = ls(cacheDir).filter(_.ext == "class")
       Try{
-        val data = classFiles.map{ file =>
-          val className = file.getName.replaceAll("\\.class$","")
-          (className, readFile(file))
+        val data = classFiles.map{ case file =>
+          val className = (file - cacheDir).toString.stripSuffix(".class")
+          (className, read.bytes(file))
         }
         data
       }.toOption.map(_.toSeq)
@@ -101,7 +90,7 @@ object Storage{
     val ivyCache = new StableRef[IvyMap]{
       def apply() = {
         val json = try{
-          new String(readFile(dir + "/ivycache.json"))
+          read(dir/"ivycache.json")
         }catch{
           case e: java.io.FileNotFoundException => "[]"
         }
@@ -113,33 +102,14 @@ object Storage{
         }
       }
       def update(map: IvyMap) = {
-        writeFile(dir + "/ivycache.json", upickle.default.write(map).getBytes)
+        write(dir/"ivycache.json", upickle.default.write(map))
       }
     }
 
     def loadPredef = try{
-      new String(readFile(dir + "/predef.scala"))
+      read(dir/"predef.scala")
     } catch {
       case e: java.io.FileNotFoundException => ""
-    }
-
-    def writeFile(filename: String, data: Array[Byte]): Unit = {
-      val fos = new java.io.FileOutputStream(filename)
-      fos.write(data)
-      fos.flush()
-    }
-
-    def readFile(filename: String): Array[Byte] = {
-      val file = new File(filename)
-      readFile(file)
-    }
-
-    def readFile(file: File): Array[Byte] = {
-      val fis = new java.io.FileInputStream(file)
-      val bytes = new Array[Byte](file.length.toInt)
-      var c = 0
-      while(c < bytes.length) c += fis.read(bytes, c, bytes.length-c)
-      bytes
     }
   }
 }

--- a/repl/src/main/scala/ammonite/repl/Storage.scala
+++ b/repl/src/main/scala/ammonite/repl/Storage.scala
@@ -82,7 +82,9 @@ object Storage{
           upickle.default.read[Seq[ImportData]](metadataJson)
         }.toOption
         classFiles <- loadClassFiles(cacheDir)
-      } yield (classFiles, metadata)
+      } yield {
+        (classFiles, metadata)
+      }
     }
 
     def loadClassFiles(cacheDir: File): Option[ClassFiles] = {

--- a/repl/src/main/scala/ammonite/repl/Util.scala
+++ b/repl/src/main/scala/ammonite/repl/Util.scala
@@ -154,7 +154,7 @@ object Timer{
    */
   def apply(s: String) = {
     val now = System.nanoTime()
-    println(s + ": " + (now - current) / 1000000.0)
+//    println(s + ": " + (now - current) / 1000000.0)
     current = now
   }
 }

--- a/repl/src/main/scala/ammonite/repl/frontend/FrontEnd.scala
+++ b/repl/src/main/scala/ammonite/repl/frontend/FrontEnd.scala
@@ -39,7 +39,7 @@ object FrontEnd{
     def tabulate(snippets: Seq[String], width: Int) = {
       val gap =   2
       val maxLength = snippets.maxBy(_.replaceAll("\u001B\\[[;\\d]*m", "").length).length + gap
-      val columns = width / maxLength
+      val columns = (width / maxLength) + 1
       snippets.grouped(columns).flatMap{
         case first :+ last => first.map(_.padTo(width / columns, ' ')) :+ last :+ "\n"
       }

--- a/repl/src/main/scala/ammonite/repl/frontend/FrontEnd.scala
+++ b/repl/src/main/scala/ammonite/repl/frontend/FrontEnd.scala
@@ -56,8 +56,8 @@ object FrontEnd{
                colors: Colors,
                compilerComplete: (Int, String) => (Int, Seq[String], Seq[String]),
                history: Seq[String]) = {
-
-      readLine(reader, output, prompt, colors, compilerComplete, history) match{
+      Timer("FrontEnd.Ammonite.action start")
+      val res = readLine(reader, output, prompt, colors, compilerComplete, history) match{
         case None => Res.Exit
         case Some(code) =>
           Parsers.Splitter.parse(code) match{
@@ -67,6 +67,8 @@ object FrontEnd{
             )
           }
       }
+      Timer("FrontEnd.Ammonite.action end")
+      res
     }
     def readLine(reader: java.io.Reader,
                  output: OutputStream,
@@ -74,6 +76,7 @@ object FrontEnd{
                  colors: Colors,
                  compilerComplete: (Int, String) => (Int, Seq[String], Seq[String]),
                  history: Seq[String]) = {
+      Timer("FrontEnd.Ammonite.readLine start")
       val writer = new OutputStreamWriter(output)
       val autocompleteFilter: TermCore.Filter = {
         case TermInfo(TermState(9 ~: rest, b, c), width) => // Enter
@@ -125,10 +128,8 @@ object FrontEnd{
       val historyFilter = ReadlineFilters.HistoryFilter(() => history.reverse)
       val cutPasteFilter = ReadlineFilters.CutPasteFilter()
       val selectionFilter = AdvancedFilters.SelectionFilter()
-      TermCore.readLine(
-        prompt,
-        reader,
-        writer,
+
+      val allFilters =
         selectionFilter orElse
         AdvancedFilters.altFilter orElse
         AdvancedFilters.fnFilter orElse
@@ -137,7 +138,14 @@ object FrontEnd{
         historyFilter.filter orElse
         cutPasteFilter orElse
         multilineFilter orElse
-        BasicFilters.all,
+        BasicFilters.all
+
+      Timer("FrontEnd.Ammonite.readLine 1")
+      val res = TermCore.readLine(
+        prompt,
+        reader,
+        writer,
+        allFilters,
         displayTransform = { (buffer, cursor) =>
           val indices = Highlighter.defaultHighlightIndices(
             buffer,
@@ -168,7 +176,8 @@ object FrontEnd{
           }
         }
       )
-
+      Timer("TermCore.readLine")
+      res
     }
   }
   object JLineUnix extends JLineTerm(() => new jline.UnixTerminal())

--- a/repl/src/main/scala/ammonite/repl/frontend/ReplAPI.scala
+++ b/repl/src/main/scala/ammonite/repl/frontend/ReplAPI.scala
@@ -45,7 +45,14 @@ trait ReplAPI {
   def help: String
 
   /**
-   * History of commands that have been entered into the shell
+   * History of commands that have been entered into the shell, including
+   * previous sessions
+   */
+  def fullHistory: History
+
+  /**
+   * History of commands that have been entered into the shell during the
+   * current session
    */
   def history: History
 

--- a/repl/src/main/scala/ammonite/repl/frontend/ReplAPI.scala
+++ b/repl/src/main/scala/ammonite/repl/frontend/ReplAPI.scala
@@ -3,6 +3,7 @@ package ammonite.repl.frontend
 import java.io.File
 
 import ammonite.ops._
+import ammonite.repl.Colors
 import pprint.{PPrinter, PPrint, Config}
 import ammonite.repl.{Colors, Ref, History}
 
@@ -109,6 +110,14 @@ trait ReplAPI {
   def width: Int
 
   def height: Int
+
+  def show[T: PPrint](implicit cfg: Config): T => Unit
+  def show[T: PPrint](t: T,
+                          width: Integer = 0,
+                          height: Integer = null,
+                          indent: Integer = null,
+                          colors: pprint.Colors = null)
+                         (implicit cfg: Config = Config.Defaults.PPrintConfig): Unit
 }
 trait Load extends (String => Unit){
   /**

--- a/repl/src/main/scala/ammonite/repl/frontend/ReplAPI.scala
+++ b/repl/src/main/scala/ammonite/repl/frontend/ReplAPI.scala
@@ -216,3 +216,4 @@ trait DefaultReplAPI extends FullReplAPI {
     }
   }
 }
+object ReplBridge extends ammonite.repl.frontend.ReplAPIHolder{}

--- a/repl/src/main/scala/ammonite/repl/interp/Compiler.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Compiler.scala
@@ -136,6 +136,12 @@ object Compiler{
         }
         override lazy val analyzer = CompilerCompatibility.analyzer(g, evalClassloader)
       }
+      // Initialize scalac to the parser phase immediately, so we can start
+      // using Compiler#parse even if we haven't compiled any compilation
+      // units yet due to caching
+      val run = new scalac.Run()
+      scalac.phase = run.parserPhase
+      run.cancel()
       (vd, reporter, scalac)
     }
 

--- a/repl/src/main/scala/ammonite/repl/interp/Evaluator.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Evaluator.scala
@@ -65,16 +65,6 @@ object Evaluator{
      */
     lazy val previousImports = mutable.Map.empty[String, ImportData]
 
-    lazy val defaultImports = {
-      Timer("defaultImports0")
-
-      val res = Map.empty[String, ImportData]
-      Timer("defaultImports1")
-      res
-    }
-
-    lazy val defaultImportBlock = importBlock(defaultImports.values.toSeq)
-
     /**
      * The current line number of the REPL, used to make sure every snippet
      * evaluated can have a distinct name that doesn't collide.
@@ -204,7 +194,6 @@ object Evaluator{
                  code: String,
                  printCode: String,
                  imports: Seq[ImportData]) = s"""
-      $defaultImportBlock
       ${importBlock(imports)}
 
       object $wrapperName{

--- a/repl/src/main/scala/ammonite/repl/interp/Evaluator.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Evaluator.scala
@@ -173,9 +173,9 @@ object Evaluator{
         printCode,
         previousImports.values.toSeq
       ))
-
+      _ = Timer("eval.processLine compileClass end")
       cls <- loadClass(wrapperName, classFiles)
-
+      _ = Timer("eval.processLine loadClass end")
       _ = currentLine += 1
       _ <- Catching{
         // Exit
@@ -192,7 +192,11 @@ object Evaluator{
     } yield {
       // Exhaust the printer iterator now, before exiting the `Catching`
       // block, so any exceptions thrown get properly caught and handled
-      evaluatorRunPrinter(printer(evalMain(cls).asInstanceOf[Iterator[String]]))
+
+      val iter = evalMain(cls).asInstanceOf[Iterator[String]]
+      Timer("eval.processLine evaluatorRunPrinter 1")
+      evaluatorRunPrinter(printer(iter))
+      Timer("eval.processLine evaluatorRunPrinter end")
       evaluationResult(wrapperName, newImports)
     }
     

--- a/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
@@ -1,7 +1,7 @@
 package ammonite.repl.interp
 
 import java.io.File
-import java.nio.file.Files
+import java.nio.file.{NotDirectoryException, Files}
 import acyclic.file
 import ammonite.ops._
 import ammonite.repl.Util.IvyMap
@@ -120,14 +120,9 @@ class Interpreter(prompt0: Ref[String],
 
     object load extends Load{
 
-      def apply(line: String) = {
-        processExec(line)
-      }
+      def apply(line: String) = processExec(line)
 
-      def exec(file: Path): Unit = {
-
-        apply(read(file))
-      }
+      def exec(file: Path): Unit = apply(read(file))
 
       def module(file: Path): Unit = {
         processModule(read(file))
@@ -186,8 +181,11 @@ class Interpreter(prompt0: Ref[String],
      */
     val cd = new ammonite.ops.Op1[ammonite.ops.Path, ammonite.ops.Path]{
       def apply(arg: Path) = {
-        wd0 = arg
-        wd0
+        if (!stat(arg).isDir) throw new NotDirectoryException(arg.toString)
+        else {
+          wd0 = arg
+          wd0
+        }
       }
     }
     implicit def Relativizer[T](p: T)(implicit b: Path, f: T => RelPath): Path = b/f(p)

--- a/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
@@ -29,6 +29,12 @@ class Interpreter(prompt0: Ref[String],
                   storage: Ref[Storage],
                   predef: String){ interp =>
 
+  val hardcodedPredef =
+    """import ammonite.repl.frontend.ReplBridge.repl
+      |import ammonite.repl.frontend.ReplBridge.repl._
+      |import ammonite.repl.IvyConstructor._
+      |""".stripMargin
+
   val dynamicClasspath = new VirtualDirectory("(memory)", None)
   var extraJars = Seq[java.io.File]()
 
@@ -61,9 +67,9 @@ class Interpreter(prompt0: Ref[String],
     } finally Thread.currentThread().setContextClassLoader(oldClassloader)
   }
 
-  def processModule(code: String) = processScript(code, eval.processScriptBlock)
+  def processModule(code: String) = processScript(hardcodedPredef + "\n@\n" + code, eval.processScriptBlock)
 
-  def processExec(code: String) = processScript(code, { (c, _) => evaluateLine(c, Seq(), _ => ()) })
+  def processExec(code: String) = processScript(hardcodedPredef + "\n@\n" + code, { (c, _) => evaluateLine(c, Seq(), _ => ()) })
  
   //common stuff in proccessModule and processExec
   def processScript(code: String, evaluate: (String, Seq[ImportData]) => Res[Evaluated]): Unit = {
@@ -262,13 +268,10 @@ class Interpreter(prompt0: Ref[String],
   Timer("Interpreterinit eval")
   init()
   Timer("Interpreter init init")
-  val hardcodedPredef =
-    """import ammonite.repl.frontend.ReplBridge.repl
-      |import ammonite.repl.frontend.ReplBridge.repl._
-      |import ammonite.repl.IvyConstructor._
-      |""".stripMargin
 
-  processModule(hardcodedPredef + predef)
+
+  processModule(hardcodedPredef)
+  processModule(predef)
   Timer("Interpreter init predef 0")
   init()
   Timer("Interpreter init predef 1")

--- a/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
@@ -32,10 +32,14 @@ class Interpreter(prompt0: Ref[String],
   val dynamicClasspath = new VirtualDirectory("(memory)", None)
   var extraJars = Seq[java.io.File]()
 
+  var history = new History(Vector())
   def processLine(code: String,
                   stmts: Seq[String],
                   printer: Iterator[String] => Unit) = {
-    if (code != "") storage().history() = storage().history() :+ code
+    if (code != "") {
+      storage().fullHistory() = storage().fullHistory() :+ code
+      history = history :+ code
+    }
     for{
       _ <- Catching { case ex =>
         Res.Exception(ex, "Something unexpected went wrong =(")
@@ -183,7 +187,8 @@ class Interpreter(prompt0: Ref[String],
     def search(target: scala.reflect.runtime.universe.Type) = Interpreter.this.compiler.search(target)
     def compiler = Interpreter.this.compiler.compiler
     def newCompiler() = init()
-    def history = storage().history()
+    def fullHistory = storage().fullHistory()
+    def history = Interpreter.this.history
 
     var wd0 = cwd
     /**

--- a/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
@@ -159,9 +159,25 @@ class Interpreter(prompt0: Ref[String],
       Ref.live[pprint.Config](
         () => interp.pprintConfig.copy(
           width = width,
-          height = height
+          height = height / 2
         )
       )
+    }
+
+    def show[T: PPrint](implicit cfg: Config) = (t: T) => {
+      pprint.tokenize(t, height = 0)(implicitly[PPrint[T]], cfg).foreach(print)
+      println()
+    }
+    def show[T: PPrint](t: T,
+                        width: Integer = null,
+                        height: Integer = 0,
+                        indent: Integer = null,
+                        colors: pprint.Colors = null)
+                       (implicit cfg: Config = Config.Defaults.PPrintConfig) = {
+
+
+      pprint.tokenize(t, width, height, indent, colors)(implicitly[PPrint[T]], cfg).foreach(print)
+      println()
     }
 
     def search(target: scala.reflect.runtime.universe.Type) = Interpreter.this.compiler.search(target)
@@ -244,7 +260,6 @@ class Interpreter(prompt0: Ref[String],
   val hardcodedPredef =
     """import ammonite.repl.frontend.ReplBridge.repl
       |import ammonite.repl.frontend.ReplBridge.repl._
-      |import pprint.pprintln
       |import ammonite.repl.IvyConstructor._
       |""".stripMargin
 

--- a/repl/src/main/scala/ammonite/repl/interp/Preprocessor.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Preprocessor.scala
@@ -25,10 +25,10 @@ object Preprocessor{
 
     def pprintSignature(ident: String, customMsg: Option[String]) = {
       val customCode = customMsg.fold("None")(x => s"""Some("$x")""")
-      s"""ReplBridge.repl.Internal.print($ident, $ident, "$ident", $customCode)"""
+      s"""ammonite.repl.frontend.ReplBridge.repl.Internal.print($ident, $ident, "$ident", $customCode)"""
     }
     def definedStr(definitionLabel: String, name: String) =
-      s"""ReplBridge.repl.Internal.printDef("$definitionLabel", "$name")"""
+      s"""ammonite.repl.frontend.ReplBridge.repl.Internal.printDef("$definitionLabel", "$name")"""
 
     def pprint(ident: String) = pprintSignature(ident, None)
 
@@ -79,7 +79,7 @@ object Preprocessor{
     val Import = Processor{
       case (name, code, tree: G#Import) =>
         val Array(keyword, body) = code.split(" ", 2)
-        Output(code, Seq(s"""ReplBridge.repl.Internal.printImport("$body")"""))
+        Output(code, Seq(s"""ammonite.repl.frontend.ReplBridge.repl.Internal.printImport("$body")"""))
     }
 
     val Expr = Processor{

--- a/repl/src/test/scala/ammonite/repl/AdvancedTests.scala
+++ b/repl/src/test/scala/ammonite/repl/AdvancedTests.scala
@@ -92,16 +92,16 @@ object AdvancedTests extends TestSuite{
       }
       check2.session("""
         @ -x
-        res1: Int = -1
+        res0: Int = -1
 
         @ y
-        res2: String = "2"
+        res1: String = "2"
 
         @ x + y
-        res3: String = "12"
+        res2: String = "12"
 
         @ abs(-x)
-        res4: Int = 1
+        res3: Int = 1
       """)
 
     }
@@ -196,6 +196,26 @@ object AdvancedTests extends TestSuite{
 
         @ x
         error: not found: value x
+      """)
+    }
+    'replApiUniqueness{
+      // Make sure we can instantiate multiple copies of Interpreter, with each
+      // one getting its own `ReplBridge`. This ensures that the various
+      // Interpreters are properly encapsulated and don't interfere with each
+      // other.
+      val c1 = new Checker()
+      val c2 = new Checker()
+      c1.session("""
+        @ repl.prompt() = "A"
+      """)
+      c2.session("""
+        @ repl.prompt() = "B"
+      """)
+      c1.session("""
+        @ assert(repl.prompt() == "A")
+      """)
+      c2.session("""
+        @ assert(repl.prompt() == "B")
       """)
     }
   }

--- a/repl/src/test/scala/ammonite/repl/Checker.scala
+++ b/repl/src/test/scala/ammonite/repl/Checker.scala
@@ -13,7 +13,10 @@ class Checker {
   var allOutput = ""
 
 
-  val tempDir = java.nio.file.Files.createTempDirectory("ammonite-tester").toFile
+  val tempDir = ammonite.ops.Path(
+    java.nio.file.Files.createTempDirectory("ammonite-tester")
+  )
+
 
   val interp = new Interpreter(
     Ref[String](""),

--- a/repl/src/test/scala/ammonite/repl/MemoryStorage.scala
+++ b/repl/src/test/scala/ammonite/repl/MemoryStorage.scala
@@ -7,7 +7,7 @@ class MemoryStorage extends Storage{
   def loadPredef = predef
 
   var _history = new History(Vector())
-  val history = new StableRef[History]{
+  val fullHistory = new StableRef[History]{
     def apply() = _history
     def update(h: History): Unit = _history = h
   }

--- a/repl/src/test/scala/ammonite/repl/ProjectTests.scala
+++ b/repl/src/test/scala/ammonite/repl/ProjectTests.scala
@@ -68,7 +68,7 @@ object ProjectTests extends TestSuite{
           @ load("val x = 1")
 
           @ x
-          res2: Int = 1
+          res3: Int = 1
         """)
       }
     }

--- a/repl/src/test/scala/ammonite/repl/ScriptTests.scala
+++ b/repl/src/test/scala/ammonite/repl/ScriptTests.scala
@@ -18,6 +18,7 @@ object ScriptTests extends TestSuite{
       pprint.tokenize(scriptPath)
             .mkString
     }
+
     'exec{
       'compilationBlocks{
         'loadIvy{
@@ -251,12 +252,12 @@ object ScriptTests extends TestSuite{
         )
 
         'blocks{
-          val cases = Seq("OneBlock.scala" -> 2, "TwoBlocks.scala" -> 3, "ThreeBlocks.scala" -> 4)
+          val cases = Seq("OneBlock.scala" -> 3, "TwoBlocks.scala" -> 4, "ThreeBlocks.scala" -> 5)
           for((fileName, expected) <- cases){
             val storage = new MemoryStorage
             val interp = createTestInterp(storage)
             val n0 = storage.compileCache.size
-            assert(n0 == 1) // Predef counts as a module
+            assert(n0 == 2) // Predef + hardcodedPredef
             interp.replApi.load.module(scriptPath/fileName)
             val n = storage.compileCache.size
             assert(n == expected)
@@ -274,8 +275,8 @@ object ScriptTests extends TestSuite{
           interp2.replApi.load.module(scriptPath/"OneBlock.scala")
           val n1 = interp1.eval.compilationCount
           val n2 = interp2.eval.compilationCount
-          assert(n1 == 2) // predef + first init
-          assert(n2 == 0) // both predef and OneBlock.scala are cached
+          assert(n1 == 3) // hardcodedPredef + predef + first init
+          assert(n2 == 0) // all three should be cached
         }
         'tags{
           val storage = new MemoryStorage
@@ -285,7 +286,7 @@ object ScriptTests extends TestSuite{
           interp.replApi.load.ivy("com.lihaoyi" %% "scalatags" % "0.4.5")
           interp.replApi.load.module(scriptPath/"TagBase.scala")
           val n = storage.compileCache.size
-          assert(n == 7) // predef + two blocks for each loading
+          assert(n == 9) // predef + two blocks for each loading
         }
         'encapsulation{
           check.session(s"""

--- a/repl/src/test/scala/ammonite/repl/UnitTests.scala
+++ b/repl/src/test/scala/ammonite/repl/UnitTests.scala
@@ -27,73 +27,68 @@ object UnitTests extends TestSuite{
     val highlighted = testHighlight(source.toVector).mkString
     assert(highlighted == expected)
   }
-  val tests = TestSuite{
+  val tests = TestSuite {
     println("UnitTests")
 
-//    'historyPPrint{
-//      import pprint._
-//      val hist = new History(Vector("1","2","{\nblock\n}"))
-//
-//      implicit val cfg = new Config
-//      val pprinted = implicitly[PPrint[History]].render(hist, cfg).mkString
-//      assert(pprinted == "\n@ 1\n@ 2\n@ {\nblock\n}\n")
-//    }
-    'comment - test("//a", "><B|//a>")
-    'literal - test("1", "><G|1>")
-    'expressions - test("val (x, y) = 1 + 2 + 3", "><Y|val> (x, y) = <G|1> + <G|2> + <G|3>")
-    'interpolation - test(
-      """(s"hello ${world + 1}")""",
-      """>(<G|s"hello >${world + <G|1>}<G|">)"""
-    )
-    'runOff - test(
-      """(1 + "Hello...""",
-      """>(<G|1> + <G|"Hello..."""
-    )
-    'underscore - test(
-      """val _ = 1""",
-      """><Y|val> <Y|_> = <G|1>"""
-    )
-    'nonTrivial - test(
-      """def processLine(stmts: Seq[String],
-                          saveHistory: (String => Unit, String) => Unit,
-                          printer: Iterator[String] => Unit) = for{
-            _ <- Catching { case Ex(x@_*) =>
-              val Res.Failure(trace) = Res.Failure(x)
-              Res.Failure(trace + "\nSomething unexpected went wrong =(")
-            }
-            Preprocessor.Output(code, printSnippet) <- preprocess(stmts, eval.getCurrentLine)
-            _ = saveHistory(history.append(_), stmts.mkString("; "))
-            oldClassloader = Thread.currentThread().getContextClassLoader
-            out <- try{
-              Thread.currentThread().setContextClassLoader(eval.evalClassloader)
-              eval.processLine(
-                code,
-                s"ReplBridge.shell.Internal.combinePrints(${printSnippet.mkString(", ")})",
-                printer
-              )
-            } finally Thread.currentThread().setContextClassLoader(oldClassloader)
-          } yield out
-      """,
-      """><Y|def> processLine(stmts: <G|Seq[String]>,
-                          saveHistory: <G|(String => Unit, String) => Unit>,
-                          printer: <G|Iterator[String] => Unit>) = <Y|for>{
-            <Y|_> <- Catching { <Y|case> Ex(x@<Y|_>*) =>
-              <Y|val> Res.Failure(trace) = Res.Failure(x)
-              Res.Failure(trace + <G|"\nSomething unexpected went wrong =(">)
-            }
-            Preprocessor.Output(code, printSnippet) <- preprocess(stmts, eval.getCurrentLine)
-            <Y|_> = saveHistory(history.append(<Y|_>), stmts.mkString(<G|"; ">))
-            oldClassloader = Thread.currentThread().getContextClassLoader
-            out <- <Y|try>{
-              Thread.currentThread().setContextClassLoader(eval.evalClassloader)
-              eval.processLine(
-                code,
-                <G|s"ReplBridge.shell.Internal.combinePrints(>${printSnippet.mkString(<G|", ">)}<G|)">,
-                printer
-              )
-            } <Y|finally> Thread.currentThread().setContextClassLoader(oldClassloader)
-          } <Y|yield> out
-      """
-    )
+
+    'highlighting {
+      'comment - test("//a", "><B|//a>")
+      'literal - test("1", "><G|1>")
+      'expressions - test("val (x, y) = 1 + 2 + 3", "><Y|val> (x, y) = <G|1> + <G|2> + <G|3>")
+      'interpolation - test(
+        """(s"hello ${world + 1}")""",
+        """>(<G|s"hello >${world + <G|1>}<G|">)"""
+      )
+      'runOff - test(
+        """(1 + "Hello...""",
+        """>(<G|1> + <G|"Hello..."""
+      )
+      'underscore - test(
+        """val _ = 1""",
+        """><Y|val> <Y|_> = <G|1>"""
+      )
+      'nonTrivial - test(
+        """def processLine(stmts: Seq[String],
+                            saveHistory: (String => Unit, String) => Unit,
+                            printer: Iterator[String] => Unit) = for{
+              _ <- Catching { case Ex(x@_*) =>
+                val Res.Failure(trace) = Res.Failure(x)
+                Res.Failure(trace + "\nSomething unexpected went wrong =(")
+              }
+              Preprocessor.Output(code, printSnippet) <- preprocess(stmts, eval.getCurrentLine)
+              _ = saveHistory(history.append(_), stmts.mkString("; "))
+              oldClassloader = Thread.currentThread().getContextClassLoader
+              out <- try{
+                Thread.currentThread().setContextClassLoader(eval.evalClassloader)
+                eval.processLine(
+                  code,
+                  s"ReplBridge.shell.Internal.combinePrints(${printSnippet.mkString(", ")})",
+                  printer
+                )
+              } finally Thread.currentThread().setContextClassLoader(oldClassloader)
+            } yield out
+        """,
+        """><Y|def> processLine(stmts: <G|Seq[String]>,
+                            saveHistory: <G|(String => Unit, String) => Unit>,
+                            printer: <G|Iterator[String] => Unit>) = <Y|for>{
+              <Y|_> <- Catching { <Y|case> Ex(x@<Y|_>*) =>
+                <Y|val> Res.Failure(trace) = Res.Failure(x)
+                Res.Failure(trace + <G|"\nSomething unexpected went wrong =(">)
+              }
+              Preprocessor.Output(code, printSnippet) <- preprocess(stmts, eval.getCurrentLine)
+              <Y|_> = saveHistory(history.append(<Y|_>), stmts.mkString(<G|"; ">))
+              oldClassloader = Thread.currentThread().getContextClassLoader
+              out <- <Y|try>{
+                Thread.currentThread().setContextClassLoader(eval.evalClassloader)
+                eval.processLine(
+                  code,
+                  <G|s"ReplBridge.shell.Internal.combinePrints(>${printSnippet.mkString(<G|", ">)}<G|)">,
+                  printer
+                )
+              } <Y|finally> Thread.currentThread().setContextClassLoader(oldClassloader)
+            } <Y|yield> out
+        """
+      )
+    }
   }
 }


### PR DESCRIPTION
- Make `stat` return `null` if it can't provide owner/group, rather than a lambda that blows up when called
- Dotfiles don't show up in LsSeq's pretty-printing
- Renamed `history` to `fullHistory`, added a session-local `history`
- Simplified `History` pretty-printing and storage
- Moved everything in `Storage` over to use `ammonite.ops`
- Replace `defaultImports` with `defaultPredef`
- Remove `ReplBridge` string-eval-initialization with classloader hackery to load multiple copies of the pre-compiled code
- `cd!` now throws if the target isn't a valid directory
- Replaced `pprintln` import with `show`, which by default does not truncate

Fixes #131 #132 #135 (at least partially). The ProjectTests don't pass yet but almost...