### PR TITLE
Load available compiler plugins

### DIFF
--- a/repl/src/main/scala-2.10/ammonite/repl/interp/CompilerCompatibility.scala
+++ b/repl/src/main/scala-2.10/ammonite/repl/interp/CompilerCompatibility.scala
@@ -2,6 +2,7 @@ package ammonite.repl.interp
 
 import scala.tools.nsc.Global
 import scala.tools.nsc.interactive.{ Global => InteractiveGlobal }
+import scala.tools.nsc.plugins.Plugin
 import scala.tools.nsc.typechecker.Analyzer
 
 object CompilerCompatibility {
@@ -17,4 +18,9 @@ object CompilerCompatibility {
 
   def trees(g: Global)(parser: g.syntaxAnalyzer.UnitParser): Seq[Global#Tree] =
     parser.templateStats() ++ parser.topStatSeq()
+
+  def pluginInit(plugin: Plugin, options: List[String], error: String => Unit): Boolean = {
+    plugin.processOptions(options, error)
+    true
+  }
 }

--- a/repl/src/main/scala-2.11/ammonite/repl/interp/CompilerCompatibility.scala
+++ b/repl/src/main/scala-2.11/ammonite/repl/interp/CompilerCompatibility.scala
@@ -2,6 +2,7 @@ package ammonite.repl.interp
 
 import scala.tools.nsc.Global
 import scala.tools.nsc.interactive.{ Global => InteractiveGlobal }
+import scala.tools.nsc.plugins.Plugin
 import scala.tools.nsc.typechecker.Analyzer
 
 object CompilerCompatibility {
@@ -19,4 +20,7 @@ object CompilerCompatibility {
 
   def trees(g: Global)(parser: g.syntaxAnalyzer.UnitParser): Seq[Global#Tree] =
     parser.parseStatsOrPackages()
+
+  def pluginInit(plugin: Plugin, options: List[String], error: String => Unit): Boolean =
+    plugin.init(options, error)
 }

--- a/repl/src/main/scala/ammonite/repl/frontend/ReplAPI.scala
+++ b/repl/src/main/scala/ammonite/repl/frontend/ReplAPI.scala
@@ -145,7 +145,7 @@ trait OpsAPI{
 
 }
 // End of OpsAPI
-trait Load extends (String => Unit){
+trait LoadJar {
   /**
    * Load a `.jar` file
    */
@@ -154,7 +154,8 @@ trait Load extends (String => Unit){
    * Load a library from its maven/ivy coordinates
    */
   def ivy(coordinates: (String, String, String), verbose: Boolean = true): Unit
-
+}
+trait Load extends (String => Unit) with LoadJar{
   /**
    * Loads a command into the REPL and
    * evaluates them one after another
@@ -169,6 +170,8 @@ trait Load extends (String => Unit){
   def exec(path: Path): Unit
 
   def module(path: Path): Unit
+
+  def plugin: LoadJar
 
 }
 

--- a/repl/src/main/scala/ammonite/repl/interp/Compiler.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Compiler.scala
@@ -117,13 +117,14 @@ object Compiler{
             dirDeps: Seq[java.io.File],
             dynamicClasspath: VirtualDirectory,
             evalClassloader: => ClassLoader,
+            pluginClassloader: => ClassLoader,
             shutdownPressy: () => Unit): Compiler = new Compiler{
 
     val PluginXML = "scalac-plugin.xml"
 
     lazy val plugins0 = {
       import scala.collection.JavaConverters._
-      val loader = evalClassloader
+      val loader = pluginClassloader
 
       val urls = loader
         .getResources(PluginXML)

--- a/repl/src/main/scala/ammonite/repl/interp/Compiler.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Compiler.scala
@@ -119,6 +119,42 @@ object Compiler{
             evalClassloader: => ClassLoader,
             shutdownPressy: () => Unit): Compiler = new Compiler{
 
+    val PluginXML = "scalac-plugin.xml"
+
+    lazy val plugins0 = {
+      import scala.collection.JavaConverters._
+      val loader = evalClassloader
+
+      val urls = loader
+        .getResources(PluginXML)
+        .asScala
+        .toVector
+
+      val plugins = for {
+        url <- urls
+        elem = scala.xml.XML.load(url.openStream())
+        name = (elem \\ "plugin" \ "name").text
+        className = (elem \\ "plugin" \ "classname").text
+        // acyclic seems to conflict with AmmonitePlugin (happens during the tests in particular), so it's
+        // filtered out here. Else it raises:
+        //   scala.reflect.internal.FatalError: Multiple phases want to run right after typer; followers:
+        //   AmmonitePhase,acyclic; created phase-order.dot
+        if name != "acyclic"
+        if name.nonEmpty && className.nonEmpty
+        classOpt =
+          try Some(loader.loadClass(className))
+          catch { case _: ClassNotFoundException => None }
+      } yield (name, className, classOpt)
+
+      val notFound = plugins.collect{case (name, className, None) => (name, className) }
+      if (notFound.nonEmpty) {
+        for ((name, className) <- notFound.sortBy(_._1))
+          Console.err.println(s"Implementation $className of plugin $name not found.")
+      }
+
+      plugins.collect{case (name, _, Some(cls)) => name -> cls }
+    }
+
     var logger: String => Unit = s => ()
 
     var lastImports = Seq.empty[ImportData]
@@ -128,7 +164,20 @@ object Compiler{
         jarDeps, dirDeps, dynamicClasspath, logger
       )
       val scalac = new nsc.Global(settings, reporter) { g =>
-        override lazy val plugins = List(new AmmonitePlugin(g, lastImports = _))
+        override lazy val plugins = List(new AmmonitePlugin(g, lastImports = _)) ++ {
+          for {
+            (name, cls) <- plugins0
+            plugin = Plugin.instantiate(cls, g)
+            initOk =
+              try CompilerCompatibility.pluginInit(plugin, Nil, g.globalError)
+              catch { case ex: Exception =>
+                Console.err.println(s"Warning: disabling plugin $name, initialization failed: $ex")
+                false
+              }
+            if initOk
+          } yield plugin
+        }
+
         override def classPath = platform.classPath // Actually jcp, avoiding a path-dependent type issue in 2.10 here
         override lazy val platform: ThisPlatform = new JavaPlatform{
           val global: g.type = g

--- a/repl/src/main/scala/ammonite/repl/interp/Evaluator.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Evaluator.scala
@@ -40,7 +40,9 @@ trait Evaluator{
 
   def previousImportBlock: String
   def addJar(url: URL): Unit
+  def addPluginJar(url: URL): Unit
   def evalClassloader: SpecialClassloader
+  def pluginClassloader: SpecialClassloader
 
   /*
    * How many wrappers has this instance compiled
@@ -82,10 +84,13 @@ object Evaluator{
      * actual classes with methods we can execute.
      */
     var evalClassloader: SpecialClassloader = null
+    var pluginClassloader: SpecialClassloader = null
 
     evalClassloader = new SpecialClassloader(currentClassloader)
+    pluginClassloader = new SpecialClassloader(currentClassloader)
 
     def addJar(url: URL) = evalClassloader.add(url)
+    def addPluginJar(url: URL) = pluginClassloader.add(url)
 
     private var _compilationCount = 0
     def compilationCount = _compilationCount

--- a/repl/src/test/scala/ammonite/repl/AdvancedTests.scala
+++ b/repl/src/test/scala/ammonite/repl/AdvancedTests.scala
@@ -262,13 +262,32 @@ object AdvancedTests extends TestSuite{
     }
     'compilerPlugin{
       check.session("""
+        @ // Make sure plugins from eval class loader are not loaded
+
         @ load.ivy("org.spire-math" %% "kind-projector" % "0.6.3")
+
+        @ trait TC0[F[_]]
+        defined trait TC0
+
+        @ type TC0EitherStr = TC0[Either[String, ?]]
+        error: not found: type ?
+
+        @ // This one must be loaded
+
+        @ load.plugin.ivy("org.spire-math" %% "kind-projector" % "0.6.3")
 
         @ trait TC[F[_]]
         defined trait TC
 
         @ type TCEitherStr = TC[Either[String, ?]]
         defined type TCEitherStr
+
+        @ // Useless - does not add plugins, and ignored by eval class loader
+        
+        @ load.plugin.ivy("eu.timepit" %% "refined" % "0.2.1")
+
+        @ import eu.timepit.refined._
+        error: not found: value eu
       """)
     }
     'replApiUniqueness{

--- a/repl/src/test/scala/ammonite/repl/AdvancedTests.scala
+++ b/repl/src/test/scala/ammonite/repl/AdvancedTests.scala
@@ -260,6 +260,17 @@ object AdvancedTests extends TestSuite{
         error: not found: value x
       """)
     }
+    'compilerPlugin{
+      check.session("""
+        @ load.ivy("org.spire-math" %% "kind-projector" % "0.6.3")
+
+        @ trait TC[F[_]]
+        defined trait TC
+
+        @ type TCEitherStr = TC[Either[String, ?]]
+        defined type TCEitherStr
+      """)
+    }
     'replApiUniqueness{
       // Make sure we can instantiate multiple copies of Interpreter, with each
       // one getting its own `ReplBridge`. This ensures that the various


### PR DESCRIPTION
Fixes https://github.com/lihaoyi/Ammonite/issues/145

I haven't added tests for when loading a plugin fails. Having the ability to add resources to the class loader on the fly, to add a `scalac-plugin.xml`, would make that easier. One could directly write the plugin from Ammonite then.