### PR TITLE
Add support for C-p/C-n for prev/next in history.

### DIFF
--- a/terminal/src/main/scala/ammonite/terminal/ReadlineFilters.scala
+++ b/terminal/src/main/scala/ammonite/terminal/ReadlineFilters.scala
@@ -90,12 +90,11 @@ object ReadlineFilters {
     var index = -1
     var currentHistory = Vector[Char]()
 
-    def swapInHistory(b: Vector[Char], newIndex: Int, rest: LazyList[Int], c: Int): TermState = {
+    def swapInHistory(b: Vector[Char], newIndex: Int, rest: LazyList[Int]): TermState = {
       if (index == -1 && newIndex != -1) currentHistory = b
-      val h2 = if (newIndex == -1) currentHistory else history()(newIndex).toVector
-      val c2 = if (c == b.length) h2.length else c
       index = newIndex
-      TS(rest, h2, c2)
+      val h = if (index == -1) currentHistory else history()(index).toVector
+      TS(rest, h, h.length)
     }
 
     def constrainIndex(n: Int): Int = {
@@ -104,10 +103,10 @@ object ReadlineFilters {
     }
 
     def previousHistory(b: Vector[Char], rest: LazyList[Int], c: Int): TermState =
-      swapInHistory(b, constrainIndex(index + 1), rest, c)
+      swapInHistory(b, constrainIndex(index + 1), rest)
 
     def nextHistory(b: Vector[Char], rest: LazyList[Int], c: Int): TermState =
-      swapInHistory(b, constrainIndex(index - 1), rest, c)
+      swapInHistory(b, constrainIndex(index - 1), rest)
 
     def filter = {
       case TermInfo(TS(p"\u001b[A$rest", b, c), w) if firstRow(c, b, w) =>


### PR DESCRIPTION
This commit also makes some adjustments to the history code
that hopefully make it a bit clearer what is going on.

It also makes a change to cursor positioning. In most
readline-based programs (e.g. bash), if the cursor is
currently at the end of the line, it will remain at the
end of the line after moving through the history. The
current behavior leaves the cursor at position 0. With
this change, a specific check is made to see if the
cursor is at the end of line, and if so the cursor
is moved to the "new" end of the line.