### PR TITLE
An improvement to the state of IvyThing.scala

### DIFF
--- a/repl/src/main/scala/ammonite/repl/IvyThing.scala
+++ b/repl/src/main/scala/ammonite/repl/IvyThing.scala
@@ -9,6 +9,8 @@ import org.apache.ivy.util._
 
 import org.apache.ivy.plugins.resolver.IBiblioResolver
 import acyclic.file
+import java.io.File
+
 object IvyConstructor extends IvyConstructor
 trait IvyConstructor{
   implicit class GroupIdExt(groupId: String){
@@ -47,7 +49,7 @@ object IvyThing {
   def resolveArtifact(groupId: String,
                       artifactId: String,
                       version: String,
-                      verbosity: Int = 2) = synchronized {
+                      verbosity: Int = 2) : Option[Array[File]] = synchronized {
     maxLevel = verbosity
     val ivy = Ivy.newInstance{
 
@@ -106,7 +108,12 @@ object IvyThing {
 
     //init resolve report
     val report = ivy.resolve(md, options)
-    //so you can get the jar libraries
-    report.getAllArtifactsReports.map(_.getLocalFile)
+    val unresolved = report.getUnresolvedDependencies()
+    if (unresolved.size > 0) {
+      Console.err.println("There were unresolved dependencies:")
+      unresolved.foreach(ur => Console.err.println("Dependency %s was unresolved".format(ur.getId())))
+      None
+    }
+    else Some(report.getAllArtifactsReports.map(_.getLocalFile))
   }
 }

--- a/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
@@ -146,17 +146,24 @@ class Interpreter(prompt0: Ref[String],
       def ivy(coordinates: (String, String, String), verbose: Boolean = true): Unit = {
         val (groupId, artifactId, version) = coordinates
         storage().ivyCache().get((groupId, artifactId, version)) match{
-          case Some(ps) => ps.map(new java.io.File(_)).map(handleJar)
+          case Some(ps) => {
+            ps.map(new java.io.File(_)).map(handleJar)
+            Console.err.println("success")
+          }
           case None =>
-            val resolved = IvyThing.resolveArtifact(groupId, artifactId, version, if (verbose) 2 else 1)
-            storage().ivyCache() = storage().ivyCache().updated(
-              (groupId, artifactId, version),
-              resolved.map(_.getAbsolutePath).toSet
-            )
+            val resolution = IvyThing.resolveArtifact(groupId, artifactId, version, if (verbose) 2 else 1)
+            resolution map { resolved =>
+              storage().ivyCache() = storage().ivyCache().updated(
+                (groupId, artifactId, version),
+                resolved.map(_.getAbsolutePath).toSet
+              )
 
-            resolved.map(handleJar)
+              resolved.map(handleJar)
+            } match {
+              case Some(_) => Console.err.println("success")
+              case None => Console.err.println("failure")
+            }
         }
-
         init()
       }
     }

--- a/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
@@ -152,17 +152,15 @@ class Interpreter(prompt0: Ref[String],
           }
           case None =>
             val resolution = IvyThing.resolveArtifact(groupId, artifactId, version, if (verbose) 2 else 1)
-            resolution map { resolved =>
+            resolution foreach { resolved =>
               storage().ivyCache() = storage().ivyCache().updated(
                 (groupId, artifactId, version),
                 resolved.map(_.getAbsolutePath).toSet
               )
 
               resolved.map(handleJar)
-            } match {
-              case Some(_) => Console.err.println("success")
-              case None => Console.err.println("failure")
-            }
+            } 
+            Console.err.println(resolution.fold("failure")(_ => "success"))
         }
         init()
       }


### PR DESCRIPTION
A small fix to help the state of #151.  `resolveArtifact` now returns an `Option[Array[File]]` explicitly, instead of the previous `Array[File]`, where `None` indicates that the resolution failed somehow.  Corresponding updates to `ivy(...)` in `Interpreter.scala` were made.  In addition, `ivy(...)` prints `success` or `failure` as appropriate on attempting to get artifacts from Maven.