### PR TITLE
Enable C-d to delete when line is not empty.

### DIFF
--- a/terminal/src/main/scala/ammonite/terminal/BasicFilters.scala
+++ b/terminal/src/main/scala/ammonite/terminal/BasicFilters.scala
@@ -73,9 +73,17 @@ object BasicFilters {
     case TS(13 ~: 10 ~:rest, b, c) => // Enter
       Result(b.mkString)
   }
+
   lazy val exitFilter: TermCore.Filter = {
-    case TS(Ctrl('c') ~: rest, b, c) => Result("")
-    case TS(Ctrl('d') ~: rest, b, c) => Exit
+    case TS(Ctrl('c') ~: rest, b, c) =>
+      Result("")
+    case TS(Ctrl('d') ~: rest, b, c) =>
+      // only exit if the line is empty, otherwise, behave like
+      // "delete" (i.e. delete one char to the right)
+      if (b.isEmpty) Exit else {
+        val (first, last) = b.splitAt(c)
+        TS(rest, first ++ last.drop(1), c)
+      }
   }
 
   def moveStart(b: Vector[Char],


### PR DESCRIPTION
Most tools only use C-d to exit when the line is empty. Previously
a C-d would exit instead of delete, which will be surprising for
bash users.