### PR TITLE
only add jar files as jar dependencies, fixes #148

### DIFF
--- a/repl/src/main/scala/ammonite/repl/interp/Classpath.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Classpath.scala
@@ -30,7 +30,6 @@ object Classpath {
   }
 
   val (jarDeps, dirDeps) = files.toVector.filter(_.exists).partition(
-    // dunno why we need to filter out jnilib files but seems to make it work
-    x => x.isFile && !x.toString.endsWith(".jnilib")
+    x => x.isFile && x.getName.endsWith(".jar")
   )
 }


### PR DESCRIPTION
Otherwise, startup will fail for openjdk because the classpath includes
an entry like this:

/usr/lib/jvm/java-7-openjdk-amd64/jre/lib/ext/libatk-wrapper.so

and initializing the compiler symbol table will fail with this (silenced)
error message:

error while loading <root>, Error accessing /usr/lib/jvm/java-7-openjdk-amd64/jre/lib/ext/libatk-wrapper.so