### PR TITLE
Add Scala 2.10.5 for SBT 0.13.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: scala
 scala:
 - 2.10.4
+- 2.10.5
 - 2.11.4
 - 2.11.7
 jdk:

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import sbtassembly.AssemblyPlugin.defaultShellScript
 scalaVersion := "2.11.6"
 
 crossScalaVersions := Seq(
-  "2.10.3", "2.10.4", "2.11.3", "2.11.4", "2.11.5", "2.11.6", "2.11.7"
+  "2.10.3", "2.10.4", "2.10.5", "2.11.3", "2.11.4", "2.11.5", "2.11.6", "2.11.7"
 )
 
 publishArtifact := false


### PR DESCRIPTION
It would be great if you could publish for Scala 2.10.5 because otherwise one can't upgrade to SBT 0.13.9 (which brings a lot of fixes and maybe some speedups).

Thanks!