### PR TITLE
Fix version

### DIFF
--- a/project/Constants.scala
+++ b/project/Constants.scala
@@ -1,4 +1,4 @@
 package ammonite
 object Constants{
-  val version = "0.4.5-SNAPSHOT"
+  val version = "0.4.6-SNAPSHOT"
 }


### PR DESCRIPTION
Once `0.4.5` is released, version should become `0.4.6-SNAPSHOT` (`.6`, not `.5`), or `0.5.0-SNAPSHOT`, ...