### PR TITLE
Disable Ctrl-y wherever possible (fix #180)

### DIFF
--- a/terminal/src/main/scala/ammonite/terminal/Utils.scala
+++ b/terminal/src/main/scala/ammonite/terminal/Utils.scala
@@ -63,7 +63,6 @@ object TTY{
 //    Debug("Initializing, Height " + height)
     val initialConfig = stty("-g").trim
     stty("-icanon min 1 -icrnl -inlcr -ixon")
-    // this command fails on ubuntu, but that is harmless.
     sttyFailTolerant("dsusp undef")
     stty("-echo")
     stty("intr undef")

--- a/terminal/src/main/scala/ammonite/terminal/Utils.scala
+++ b/terminal/src/main/scala/ammonite/terminal/Utils.scala
@@ -63,16 +63,22 @@ object TTY{
 //    Debug("Initializing, Height " + height)
     val initialConfig = stty("-g").trim
     stty("-icanon min 1 -icrnl -inlcr -ixon")
-    // blows up on ubuntu
-//    stty("dsusp undef")
+    // this command fails on ubuntu, but that is harmless.
+    sttyFailTolerant("dsusp undef")
     stty("-echo")
     stty("intr undef")
 //    Debug("")
     (width, height, initialConfig)
   }
+  def sttyCmd(s: String) =
+    Seq("bash", "-c", s"stty $s < /dev/tty")
   def stty(s: String) = {
     import sys.process._
-    Seq("bash", "-c", s"stty $s < /dev/tty").!!
+    sttyCmd(s).!!
+  }
+  def sttyFailTolerant(s: String) = {
+    import sys.process._
+    sttyCmd(s).!
   }
   def restore(initialConfig: String) = {
     stty(initialConfig)

--- a/terminal/src/main/scala/ammonite/terminal/Utils.scala
+++ b/terminal/src/main/scala/ammonite/terminal/Utils.scala
@@ -78,7 +78,7 @@ object TTY{
   }
   def sttyFailTolerant(s: String) = {
     import sys.process._
-    sttyCmd(s).!
+    sttyCmd(s ++ " 2> /dev/null").!
   }
   def restore(initialConfig: String) = {
     stty(initialConfig)

--- a/terminal/src/main/scala/ammonite/terminal/Utils.scala
+++ b/terminal/src/main/scala/ammonite/terminal/Utils.scala
@@ -70,16 +70,23 @@ object TTY{
 //    Debug("")
     (width, height, initialConfig)
   }
-  def sttyCmd(s: String) =
-    Seq("bash", "-c", s"stty $s < /dev/tty")
-  def stty(s: String) = {
+
+  private def sttyCmd(s: String) = {
     import sys.process._
+    Seq("bash", "-c", s"stty $s < /dev/tty"): ProcessBuilder
+  }
+
+  def stty(s: String) =
     sttyCmd(s).!!
-  }
-  def sttyFailTolerant(s: String) = {
-    import sys.process._
+  /*
+   * Executes a stty command for which failure is expected, hence the return
+   * status can be non-null and errors are ignored.
+   * This is appropriate for `stty dsusp undef`, since it's unsupported on Linux
+   * (http://man7.org/linux/man-pages/man3/termios.3.html).
+   */
+  def sttyFailTolerant(s: String) =
     sttyCmd(s ++ " 2> /dev/null").!
-  }
+
   def restore(initialConfig: String) = {
     stty(initialConfig)
   }


### PR DESCRIPTION
This PR simply reenables the code disabling Ctrl-y, while ensuring it does no harm where Ctrl-y is unsupported (Linux). After this commit, Ctrl-y works as expected in Emacs/bash/readline: it yanks/pastes text killed/cut with Ctrl-k and similar combos.

Fixes #180.