### PR TITLE
Sort output of ls! (fix #192)

### DIFF
--- a/ops/src/main/scala/ammonite/ops/FileOps.scala
+++ b/ops/src/main/scala/ammonite/ops/FileOps.scala
@@ -222,7 +222,7 @@ trait ImplicitOp[V] extends Function1[Path, V]{
  * List the files and folders in a directory
  */
 object ls extends StreamableOp1[Path, Path, LsSeq] with ImplicitOp[LsSeq]{
-  def materialize(src: Path, i: Iterator[Path]) = new LsSeq(src, i.toStream.map(_ - src).sorted:_*)
+  def materialize(src: Path, i: Iterator[Path]) = new LsSeq(src, i.toStream.map(_ - src).sorted(RelPath.alphaOrdering):_*)
   def !!(arg: Path): SelfClosingIterator[Path] = {
     import scala.collection.JavaConverters._
     val dirStream = Files.newDirectoryStream(arg.nio)

--- a/ops/src/main/scala/ammonite/ops/FileOps.scala
+++ b/ops/src/main/scala/ammonite/ops/FileOps.scala
@@ -222,7 +222,7 @@ trait ImplicitOp[V] extends Function1[Path, V]{
  * List the files and folders in a directory
  */
 object ls extends StreamableOp1[Path, Path, LsSeq] with ImplicitOp[LsSeq]{
-  def materialize(src: Path, i: Iterator[Path]) = new LsSeq(src, i.toStream.map(_-src):_*)
+  def materialize(src: Path, i: Iterator[Path]) = new LsSeq(src, i.toStream.map(_ - src).sorted:_*)
   def !!(arg: Path): SelfClosingIterator[Path] = {
     import scala.collection.JavaConverters._
     val dirStream = Files.newDirectoryStream(arg.nio)

--- a/ops/src/main/scala/ammonite/ops/Path.scala
+++ b/ops/src/main/scala/ammonite/ops/Path.scala
@@ -193,7 +193,7 @@ object RelPath extends RelPathStuff with (String => RelPath){
     Iterator((Seq.fill(p.ups)("up") ++ p.segments.map(BasePath.reprSection(_, c).mkString)).mkString("/"))
   }
 
-  implicit val relPathOrdering: Ordering[RelPath] = Ordering.by((rp: RelPath) => (rp.ups, rp.segments.toIterable))
+  val alphaOrdering: Ordering[RelPath] = Ordering.by(rp => (rp.ups, rp.segments.toIterable))
 }
 object Path extends (String => Path){
   def apply(s: String): Path = {
@@ -224,6 +224,8 @@ object Path extends (String => Path){
   implicit def pathRepr = pprint.PPrinter[ammonite.ops.Path]{(p, c) =>
     Iterator("root") ++ p.segments.iterator.map("/" + BasePath.reprSection(_, c).mkString)
   }
+
+  val alphaOrdering: Ordering[Path] = Ordering.by(_.segments.toIterable)
 }
 
 /**

--- a/ops/src/main/scala/ammonite/ops/Path.scala
+++ b/ops/src/main/scala/ammonite/ops/Path.scala
@@ -192,6 +192,8 @@ object RelPath extends RelPathStuff with (String => RelPath){
   implicit val relPathRepr = pprint.PPrinter[ammonite.ops.RelPath]{(p, c) =>
     Iterator((Seq.fill(p.ups)("up") ++ p.segments.map(BasePath.reprSection(_, c).mkString)).mkString("/"))
   }
+
+  implicit val relPathOrdering: Ordering[RelPath] = Ordering.by((rp: RelPath) => (rp.ups, rp.segments.toIterable))
 }
 object Path extends (String => Path){
   def apply(s: String): Path = {

--- a/ops/src/test/scala/test/ammonite/ops/PathTests.scala
+++ b/ops/src/test/scala/test/ammonite/ops/PathTests.scala
@@ -148,6 +148,28 @@ object PathTests extends TestSuite{
           compileError("""'omg/'wtf > root/'omg/'wtf""")
         }
       }
+      'AlphabeticComparison{
+        'Relative - {
+          import RelPath.alphaOrdering.{mkOrderingOps => m}
+          assert(
+            m(rel/'a) <= rel/'b,
+            m(rel/'a) < rel/'b,
+            m(rel/up) < rel,
+            m(rel/up/'b) < rel/'a,
+            m(rel/up/up/'b) < rel/up/'a,
+            m(rel/up/'b) >= rel/up/'a,
+            Seq(rel/'target, rel/'src).sorted(RelPath.alphaOrdering) == Seq(rel/'src, rel/'target)
+          )
+        }
+        'Absolute - {
+          import Path.alphaOrdering.{mkOrderingOps => m}
+          assert(
+            m(root/'a) <= root/'b,
+            m(root/'a) < root/'b,
+            Seq(root/'target, root/'src).sorted(Path.alphaOrdering) == Seq(root/'src, root/'target)
+          )
+        }
+      }
     }
     'Errors{
       'InvalidChars {


### PR DESCRIPTION
Straightforward fix (the whitespace change slipped in). Do you agree with sorting `RelPath` by `ups` first, then by `segments`?