### PR TITLE
Fix for multiline blocks separated by line breaks 

### DIFF
--- a/repl/src/main/scala/ammonite/repl/frontend/AmmoniteFrontEnd.scala
+++ b/repl/src/main/scala/ammonite/repl/frontend/AmmoniteFrontEnd.scala
@@ -82,7 +82,7 @@ case class AmmoniteFrontEnd(extraFilters: TermCore.Filter = PartialFunction.empt
     }
 
     val multilineFilter: TermCore.Filter = {
-      case TermState(13 ~: rest, b, c) => // Enter
+      case TermState(lb ~: rest, b, c) if (lb == 10 || lb == 13) => // Enter
         val code = b.mkString
         ammonite.repl.Parsers.split(code) match {
           case None =>


### PR DESCRIPTION
Previous version was just looking for CR.  This meant when pasting a multiline block without {} from Vim, an error would be thrown.  Now we will look for both CR and newline.  