### PR TITLE
relative paths, in particular to outside the jar are invalid and e.g.…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,9 @@ val sharedSettings = Seq(
   addCompilerPlugin("com.lihaoyi" %% "acyclic" % "0.1.2"),
   parallelExecution in Test := !scalaVersion.value.contains("2.10"),
   (unmanagedSources in Compile) += baseDirectory.value/".."/"project"/"Constants.scala",
+  mappings in (Compile, packageSrc) += {
+    (baseDirectory.value/".."/"project"/"Constants.scala") -> "Constants.scala"
+  },
   libraryDependencies ++= Seq(
     "com.lihaoyi" %% "acyclic" % "0.1.2" % "provided",
     "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided"


### PR DESCRIPTION
… crash vfs2 ensime-server is using. This rewrites the unmanaged source file outside of the base directory to one inside the jar

fixes #227