### PR TITLE
Remove "Main.scala: xx" from compilation failure reports in repl

### DIFF
--- a/readme/Repl.scalatex
+++ b/readme/Repl.scalatex
@@ -216,10 +216,10 @@
     @hl.scala
       @@ mutable.Seq(x) // doesn't work
       Compilation Failed
-      Main.scala:122: not found: value mutable
+      not found: value mutable
       mutable.Seq(x) // doesn't work
       ^
-      Main.scala:122: not found: value x
+      not found: value x
       mutable.Seq(x) // doesn't work
                   ^
       @@ import ammonite.ops._

--- a/repl/src/main/scala/ammonite/repl/interp/Evaluator.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Evaluator.scala
@@ -106,8 +106,9 @@ object Evaluator{
       }
       _ = _compilationCount += 1
       result <- Res[(ClassFiles, Seq[ImportData])](
-        compiled, "Compilation Failed\n" + output.map(
-          _.split(": ").tail.mkString(": ")).mkString("\n")
+        compiled, List("Compilation Failed",
+          output.head.split(": ").tail.mkString(": "),
+          output.tail.mkString("\n")).mkString("\n")
       )
     } yield result
 

--- a/repl/src/main/scala/ammonite/repl/interp/Evaluator.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Evaluator.scala
@@ -106,7 +106,8 @@ object Evaluator{
       }
       _ = _compilationCount += 1
       result <- Res[(ClassFiles, Seq[ImportData])](
-        compiled, "Compilation Failed\n" + output.map(_.split(": ").tail.mkString(": ")).mkString("\n")
+        compiled, "Compilation Failed\n" + output.map(
+          _.split(": ").tail.mkString(": ")).mkString("\n")
       )
     } yield result
 

--- a/repl/src/main/scala/ammonite/repl/interp/Evaluator.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Evaluator.scala
@@ -106,7 +106,7 @@ object Evaluator{
       }
       _ = _compilationCount += 1
       result <- Res[(ClassFiles, Seq[ImportData])](
-        compiled, "Compilation Failed\n" + output.mkString("\n")
+        compiled, "Compilation Failed\n" + output.map(_.split(": ").tail.mkString(": ")).mkString("\n")
       )
     } yield result
 

--- a/repl/src/test/scala/ammonite/repl/ScriptTests.scala
+++ b/repl/src/test/scala/ammonite/repl/ScriptTests.scala
@@ -89,7 +89,7 @@ object ScriptTests extends TestSuite{
 
             @ val r = res
             error: Compilation Failed
-            Main.scala:\\d\\+: not found: value res
+            not found: value res
             res
             ^
             """)
@@ -103,7 +103,7 @@ object ScriptTests extends TestSuite{
 
             @ val r = res
             error: Compilation Failed
-            Main.scala:\\d\\+: not found: value res
+            not found: value res
             res
             ^
 
@@ -127,7 +127,7 @@ object ScriptTests extends TestSuite{
 
             @ val r2 = res2
             error: Compilation Failed
-            Main.scala:\\d\\+: not found: value res2
+            not found: value res2
             res2 
             ^
             """)
@@ -231,7 +231,7 @@ object ScriptTests extends TestSuite{
 
             @ val r = res
             error: Compilation Failed
-            Main.scala:\\d\\+: not found: value res
+            not found: value res
             res
             ^
             """)
@@ -245,7 +245,7 @@ object ScriptTests extends TestSuite{
 
             @ val r = res
             error: Compilation Failed
-            Main.scala:\\d\\+: not found: value res
+            not found: value res
             res
             ^
 
@@ -269,7 +269,7 @@ object ScriptTests extends TestSuite{
 
             @ val r2 = res2
             error: Compilation Failed
-            Main.scala:\\d\\+: not found: value res2
+            not found: value res2
             res2 
             ^
             """)

--- a/repl/src/test/scala/ammonite/repl/ScriptTests.scala
+++ b/repl/src/test/scala/ammonite/repl/ScriptTests.scala
@@ -109,6 +109,15 @@ object ScriptTests extends TestSuite{
 
             """)
         }
+        'compilationErrorWithColon{
+          check.session(s"""
+            @  a = ": 1"
+            error: Compilation Failed
+            not found: value a
+            a = ": 1"
+            ^
+            """)
+        }
         'nofile{
           check.session(s"""
             @ import ammonite.ops._

--- a/repl/src/test/scala/ammonite/repl/session/FailureTests.scala
+++ b/repl/src/test/scala/ammonite/repl/session/FailureTests.scala
@@ -18,13 +18,13 @@ object FailureTests extends TestSuite{
 
         @ 1 + vale
         error: Compilation Failed
-        Main.scala:\d\+: not found: value vale
+        not found: value vale
         1 + vale
             ^
 
         @ val x = 1 + vale
         error: Compilation Failed
-        Main.scala:\d\+: not found: value vale
+        not found: value vale
         1 + vale
             ^
       """)


### PR DESCRIPTION
The "Main.scala: xx" from the compilation failure reports do not help diagnose the problem. Further, it could cause confusion to beginners.

For example, the following code:

    @ a.foreach(println(_))

will result in:

    Compilation Failed
    Main.scala:33: not found: value a
    a.foreach(println(_))
    ^

This PR changes it to:

    Compilation Failed
    not found: value a
    a.foreach(println(_))
    ^