### PR TITLE
load(scalaCode: String, visible: Boolean = false) REPL command addition

### DIFF
--- a/readme/Repl.scalatex
+++ b/readme/Repl.scalatex
@@ -263,6 +263,32 @@
     @p
       All types, values and imports defined in scripts are available to commands entered in REPL after loading the script.
 
+     @p
+      Ammonite also provides a function to load a string of Scala code as if it were entered from the REPL. It comes with an option to load the code silently, or to get a printout of the results in the REPL exactly as if it was entered in the REPL:
+
+      @@
+
+      // scalaCode can be multiple lines, define functions, etc
+      // visible is an optional parameter that defaults to false (no output)
+      load(scalaCode: String, visible: Boolean = false)
+ 
+     @p
+      Here's an example:
+
+      @@
+
+      $: load("""val foo = "I am cow!" """)
+
+      $: foo
+      res19: String = "I am cow!"
+      $: load("""val bar = 42; val baz = 2; bar*baz""", true)
+      bar: Int = 42
+      baz: Int = 2
+      res21_2: Int = 84
+      $: res21_2
+      res22: Int = 84
+      $:
+
   @sect{Configuration}
     @p
       Ammonite is configured via Scala code, that can live in the @code{~/.ammonite/predef.scala} file, passed in through SBT's @hl.scala{initialCommands}, or passed to the command-line executable as @code{--predef='...'}.

--- a/repl/src/main/scala/ammonite/repl/frontend/ReplAPI.scala
+++ b/repl/src/main/scala/ammonite/repl/frontend/ReplAPI.scala
@@ -24,6 +24,12 @@ class ReplAPIHolder {
 case class ReplExit(value: Any) extends ControlThrowable
 
 trait ReplAPI {
+
+  /**
+   * My extensions
+   */
+   //def runLine: Unit 
+
   /**
    * Exit the Ammonite REPL. You can also use Ctrl-D to exit
    */
@@ -142,12 +148,12 @@ trait LoadJar {
    */
   def ivy(coordinates: (String, String, String), verbose: Boolean = true): Unit
 }
-trait Load extends (String => Unit) with LoadJar{
+trait Load extends ((String, Boolean) => Unit) with LoadJar{
   /**
    * Loads a command into the REPL and
    * evaluates them one after another
    */
-  def apply(line: String): Unit
+  def apply(line: String, visible: Boolean = false): Unit
 
   /**
    * Loads and executes the scriptfile on the specified path.

--- a/repl/src/main/scala/ammonite/repl/interp/Compiler.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Compiler.scala
@@ -87,6 +87,8 @@ object Compiler{
     val vd = new io.VirtualDirectory("(memory)", None)
     lazy val settings = new Settings
     val settingsX = settings
+    settingsX.Yrangepos.value = true
+    settings.Ylogcp.value = true
     val jCtx = new JavaContext()
     val jDirs = jarDeps.map(x =>
       new DirectoryClassPath(new FileZipArchive(x), jCtx)
@@ -94,6 +96,10 @@ object Compiler{
       new DirectoryClassPath(new PlainDirectory(new Directory(x)), jCtx)
     ) ++ Seq(new DirectoryClassPath(dynamicClasspath, jCtx))
     val jcp = new JavaClassPath(jDirs, jCtx)
+    //println("jardeps")
+    //jarDeps.foreach(p => println(s"${p.getName.takeRight(4)} $p"))
+    //println("finished")
+
     settings.outputDirs.setSingleOutput(vd)
 
     val reporter = new AbstractReporter {
@@ -101,7 +107,9 @@ object Compiler{
 
       def display(pos: Position, msg: String, severity: Severity) = {
         severity match{
-          case ERROR => logger(Position.formatMessage(pos, msg, false))
+          case ERROR =>
+             println(s"ERROR: $msg")
+             logger(Position.formatMessage(pos, msg, false))
           case _ => logger(msg)
         }
       }

--- a/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
@@ -5,7 +5,7 @@ import java.nio.file.NotDirectoryException
 import scala.collection.mutable
 import acyclic.file
 import ammonite.ops._
-import pprint.{Config, PPrint}
+import pprint.{ Config, PPrint }
 import annotation.tailrec
 import ammonite.repl._
 import ammonite.repl.frontend._
@@ -18,17 +18,16 @@ import scala.reflect.io.VirtualDirectory
  * real encapsulation for now.
  */
 class Interpreter(prompt0: Ref[String],
-                  frontEnd0: Ref[FrontEnd],
-                  width: => Int,
-                  height: => Int,
-                  pprintConfig: pprint.Config,
-                  colors0: Ref[Colors],
-                  stdout: String => Unit,
-                  storage: Ref[Storage],
-                  history: => History,
-                  predef: String,
-                  replArgs: Seq[Bind[_]]){ interp =>
-
+  frontEnd0: Ref[FrontEnd],
+  width: => Int,
+  height: => Int,
+  pprintConfig: pprint.Config,
+  colors0: Ref[Colors],
+  stdout: String => Unit,
+  storage: Ref[Storage],
+  history: => History,
+  predef: String,
+  replArgs: Seq[Bind[_]]) { interp =>
 
   val hardcodedPredef =
     """import ammonite.repl.frontend.ReplBridge.repl
@@ -57,11 +56,12 @@ class Interpreter(prompt0: Ref[String],
   var extraJars = Seq[java.io.File]()
 
   def processLine(code: String,
-                  stmts: Seq[String],
-                  printer: Iterator[String] => Unit) = {
-    for{
-      _ <- Catching { case ex =>
-        Res.Exception(ex, "Something unexpected went wrong =(")
+    stmts: Seq[String],
+    printer: Iterator[String] => Unit) = {
+    for {
+      _ <- Catching {
+        case ex =>
+          Res.Exception(ex, "Something unexpected went wrong =(")
       }
       Preprocessor.Output(code, printSnippet) <- preprocess(stmts, eval.getCurrentLine)
       out <- evaluateLine(code, printSnippet, printer)
@@ -69,11 +69,11 @@ class Interpreter(prompt0: Ref[String],
   }
 
   def evaluateLine(code: String,
-                   printSnippet: Seq[String],
-                   printer: Iterator[String] => Unit,
-                   extraImports: Seq[ImportData] = Seq() ) = {
+    printSnippet: Seq[String],
+    printer: Iterator[String] => Unit,
+    extraImports: Seq[ImportData] = Seq()) = {
     val oldClassloader = Thread.currentThread().getContextClassLoader
-    try{
+    try {
       Thread.currentThread().setContextClassLoader(eval.evalClassloader)
       eval.processLine(
         code,
@@ -86,8 +86,7 @@ class Interpreter(prompt0: Ref[String],
                 .combinePrints(${printSnippet.mkString(", ")})
         """,
         printer,
-        extraImports
-      )
+        extraImports)
     } finally Thread.currentThread().setContextClassLoader(oldClassloader)
   }
 
@@ -95,8 +94,8 @@ class Interpreter(prompt0: Ref[String],
     processScript(hardcodedPredef + "\n@\n" + code, eval.processScriptBlock)
 
   def processExec(code: String) =
-    processScript(hardcodedPredef + "\n@\n" + code, { (c, i) => evaluateLine(c, Nil, _ => (), i)})
- 
+    processScript(hardcodedPredef + "\n@\n" + code, { (c, i) => evaluateLine(c, Nil, _ => (), i) })
+
   //this variable keeps track of where should we put the imports resulting from scripts.
   private var scriptImportCallback: Seq[ImportData] => Unit = eval.update
 
@@ -110,21 +109,21 @@ class Interpreter(prompt0: Ref[String],
 
     val blocks = blocks0.map(preprocess(_, ""))
     Timer("processScript 1")
-    val errors = blocks.collect{ case Res.Failure(err) => err }
+    val errors = blocks.collect { case Res.Failure(err) => err }
     Timer("processScript 2")
     // we store the old value, because we will reassign this in the loop
     val outerScriptImportCallback = scriptImportCallback
-    try{
-      if(!errors.isEmpty)
+    try {
+      if (!errors.isEmpty)
         stdout(colors0().error() + errors.mkString("\n") + colors0().reset() + "\n")
       else
-        loop(blocks.collect{ case Res.Success(o) => o }, Seq())
+        loop(blocks.collect { case Res.Success(o) => o }, Seq())
     } finally {
       scriptImportCallback = outerScriptImportCallback
     }
     Timer("processScript 3")
     @tailrec def loop(blocks: Seq[Preprocessor.Output], imports: Seq[Seq[ImportData]]): Unit = {
-      if(!blocks.isEmpty){
+      if (!blocks.isEmpty) {
         Timer("processScript loop 0")
         // imports from scripts loaded from this script block will end up in this buffer
         val nestedScriptImports = mutable.Buffer.empty[ImportData]
@@ -147,7 +146,7 @@ class Interpreter(prompt0: Ref[String],
   }
 
   def handleOutput(res: Res[Evaluated]) = {
-    res match{
+    res match {
       case Res.Skip => true
       case Res.Exit(value) =>
         pressy.shutdownPressy()
@@ -160,7 +159,7 @@ class Interpreter(prompt0: Ref[String],
     }
   }
 
-  abstract class DefaultLoadJar extends LoadJar{
+  abstract class DefaultLoadJar extends LoadJar {
 
     def handleJar(jar: File): Unit
 
@@ -172,24 +171,22 @@ class Interpreter(prompt0: Ref[String],
       val (groupId, artifactId, version) = coordinates
       val psOpt =
         storage().ivyCache()
-                 .get((groupId, artifactId, version))
-                 .map(_.map(new java.io.File(_)))
-                 .filter(_.forall(_.exists()))
+          .get((groupId, artifactId, version))
+          .map(_.map(new java.io.File(_)))
+          .filter(_.forall(_.exists()))
 
-      psOpt match{
+      psOpt match {
         case Some(ps) => ps.map(handleJar)
         case None =>
           val resolved = IvyThing.resolveArtifact(
             groupId,
             artifactId,
             version,
-            if (verbose) 2 else 1
-          )
+            if (verbose) 2 else 1)
 
           storage().ivyCache() = storage().ivyCache().updated(
             (groupId, artifactId, version),
-            resolved.map(_.getAbsolutePath).toSet
-          )
+            resolved.map(_.getAbsolutePath).toSet)
 
           resolved.map(handleJar)
       }
@@ -212,7 +209,13 @@ class Interpreter(prompt0: Ref[String],
         eval.addJar(jar.toURI.toURL)
       }
 
-      def apply(line: String) = processExec(line)
+      def apply(line: String, visible: Boolean) = {
+        if (!visible) processExec(line)
+        else {
+          val res = interp.processLine(line, Parsers.split(line).get.get.value, _.foreach(interp.stdout))
+          handleOutput(res)
+        }
+      }
 
       def exec(file: Path): Unit = apply(read(file))
 
@@ -232,9 +235,7 @@ class Interpreter(prompt0: Ref[String],
       Ref.live[pprint.Config](
         () => interp.pprintConfig.copy(
           width = width,
-          height = height / 2
-        )
-      )
+          height = height / 2))
     }
 
     def show[T: PPrint](implicit cfg: Config) = (t: T) => {
@@ -242,12 +243,10 @@ class Interpreter(prompt0: Ref[String],
       println()
     }
     def show[T: PPrint](t: T,
-                        width: Integer = null,
-                        height: Integer = 0,
-                        indent: Integer = null,
-                        colors: pprint.Colors = null)
-                       (implicit cfg: Config = Config.Defaults.PPrintConfig) = {
-
+      width: Integer = null,
+      height: Integer = 0,
+      indent: Integer = null,
+      colors: pprint.Colors = null)(implicit cfg: Config = Config.Defaults.PPrintConfig) = {
 
       pprint.tokenize(t, width, height, indent, colors)(implicitly[PPrint[T]], cfg).foreach(print)
       println()
@@ -260,7 +259,6 @@ class Interpreter(prompt0: Ref[String],
     def newCompiler() = init()
     def fullHistory = storage().fullHistory()
     def history = Interpreter.this.history
-
 
     def width = interp.width
 
@@ -279,18 +277,15 @@ class Interpreter(prompt0: Ref[String],
       dynamicClasspath,
       eval.evalClassloader,
       eval.pluginClassloader,
-      () => pressy.shutdownPressy()
-    )
+      () => pressy.shutdownPressy())
     Timer("Interpreter init init compiler")
     pressy = Pressy(
       Classpath.jarDeps ++ extraJars,
       Classpath.dirDeps,
       dynamicClasspath,
-      eval.evalClassloader
-    )
+      eval.evalClassloader)
     Timer("Interpreter init init pressy")
   }
-
 
   val mainThread = Thread.currentThread()
   val preprocess = Preprocessor(compiler.parse)
@@ -303,23 +298,22 @@ class Interpreter(prompt0: Ref[String],
     0,
     storage().compileCacheLoad,
     storage().compileCacheSave,
-    compiler.addToClasspath
-  )
+    compiler.addToClasspath)
 
   eval.evalClassloader.findClassPublic("ammonite.repl.frontend.ReplBridge$")
   val bridgeCls = eval.evalClassloader.findClassPublic("ammonite.repl.frontend.ReplBridge")
 
   ReplAPI.initReplBridge(
     bridgeCls.asInstanceOf[Class[ReplAPIHolder]],
-    replApi
-  )
+    replApi)
   Timer("Interpreterinit eval")
   init()
   Timer("Interpreter init init")
   val argString =
     replArgs.zipWithIndex
-            .map{ case (b, idx) =>
-              s"""
+      .map {
+        case (b, idx) =>
+          s"""
               val ${b.name} =
                 ammonite.repl
                         .frontend
@@ -329,8 +323,8 @@ class Interpreter(prompt0: Ref[String],
                         .value
                         .asInstanceOf[${b.typeTag.tpe}]
               """
-            }
-            .mkString("\n")
+      }
+      .mkString("\n")
 
   processModule(hardcodedPredef)
   init()


### PR DESCRIPTION
My first pull request ever... so there's a chance I've screwed something up!
As per our gitter conversation, this pull request contains 2 changes:

Modifications the load.apply method in Interpreter.scala file to add support for evaluating code and getting a full printout, just as if the code was entered in the REPL itself. 

Here's an example of it in use:
```
@: load("""val foo = "I am cow!" """)

@: foo
res19: String = "I am cow!"
@: load("""val bar = 42; val baz = 2; bar*baz""", true)
bar: Int = 42
baz: Int = 2
res21_2: Int = 84
@: res21_2
res22: Int = 84
@:
```

I've tried all kinds of code, def's, multiple lines of input... it all seems to work fine.
I've included a small update to the Script Files section of the Repl.scalatex file to document the new REPL command.

A small modification to the Compiler.scala file to print error message if Jar dependencies cannot be found. It *only* prints if there is a fatal error, otherwise there is no additional output. This allowed me debug my problem with a Jar dependency issue, and I think it will help other people as well. The change is in the `def display(pos: Position, msg: String, severity: Severity) ` and its exactly the change from the diff file in lihaoyi/Ammonite#168

P.S. I too am a fan of the Arrogant Worms!



