### PR TITLE
Fix for failure on typing anything in repl when using coreutils stty

### DIFF
--- a/terminal/src/main/scala/ammonite/terminal/Utils.scala
+++ b/terminal/src/main/scala/ammonite/terminal/Utils.scala
@@ -60,11 +60,11 @@ object TTY{
     val height = consoleDim("lines")
 //    Debug("Initializing, Width " + width)
 //    Debug("Initializing, Height " + height)
-    val initialConfig = stty("-g").trim
     stty("-icanon min 1 -icrnl -inlcr -ixon")
     sttyFailTolerant("dsusp undef")
     stty("-echo")
     stty("intr undef")
+    val initialConfig = stty("-g").trim
 //    Debug("")
     (width, height, initialConfig)
   }


### PR DESCRIPTION
Turns out if you have coreutils (brew install coreutils) BEFORE
the standard stty (typically found at /bin/stty) it does not like
the "-icanon min 1" flag and will die with the very help message
"standard input: unable to perform all requested operations"
when restoring the initial stty config fetched with stty -g < /dev/stty.

The fix was to restore the modified stty config rather than the original
but I have to admit, I don't know why this works :(

I tested this using both coreutils stty and the standard stty on Mac OSX.

Below are some notes I took while exploring the issue if this helps at all:

```scala
// this works but I don't like the hard-coding of the path
// /bin/stty -g produces a value like below that can be restored
// gfmt1:cflag=4b00:iflag=2102:lflag=5cf:oflag=3:discard=f:dsusp=19:eof=4:eol=ff:eol2=ff:erase=7f:intr=3:kill=15:lnext=16:min=1:quit=1c:reprint=12:start=11:status=14:stop=13:susp=1a:time=0:werase=17:ispeed=9600:ospeed=9600
Seq("bash", "-c", s"/bin/stty $s < /dev/tty"): ProcessBuilder

// this reliably fails with - standard input: unable to perform all requested operations
// /usr/local/opt/coreutils/libexec/gnubin/stty -g produces a value that cannot be restored like
// 2102:3:4b00:5cf:4:ff:ff:7f:17:15:12:ff:3:1c:1a:19:11:13:16:f:1:0:14:ff

// However this value CAN be restored
// 6b02:3:4b00:200005cb:4:ff:ff:7f:17:15:12:ff:3:1c:1a:19:11:13:16:f:1:0:14:ff

// So CAN this
// 6b02:3:4b00:5cf:4:ff:ff:7f:17:15:12:ff:3:1c:1a:19:11:13:16:f:1:0:14:ff

// And so CAN this
// 2102:3:4b00:200005cb:4:ff:ff:7f:17:15:12:ff:3:1c:1a:19:11:13:16:f:1:0:14:ff

// Which got me thinking there was something with the lflag settings
// turns out the icanon with min or time seems to screw everything up
// if using coreutils stty...

Seq("bash", "-c", s"/usr/local/opt/coreutils/libexec/gnubin/stty $s < /dev/tty"): ProcessBuilder
```