### PR TITLE
Adding: Load(scalaCode:String, visible: Boolean) + Jar dependency error message

### DIFF
--- a/readme/Repl.scalatex
+++ b/readme/Repl.scalatex
@@ -263,6 +263,32 @@
     @p
       All types, values and imports defined in scripts are available to commands entered in REPL after loading the script.
 
+   @p
+      Ammonite also provides a function to load a string of Scala code as if it were entered from the REPL. It comes with an option to load the code silently, or to get a printout of the results in the REPL exactly as if it was entered in the REPL:
+
+      @@
+
+      // scalaCode can be multiple lines, define functions, etc
+      // visible is an optional parameter that defaults to false (no output)
+      load(scalaCode: String, visible: Boolean = false)
+ 
+     @p
+      Here's an example:
+
+      @@
+
+      $: load("""val foo = "I am cow!" """)
+
+      $: foo
+      res19: String = "I am cow!"
+      $: load("""val bar = 42; val baz = 2; bar*baz""", true)
+      bar: Int = 42
+      baz: Int = 2
+      res21_2: Int = 84
+      $: res21_2
+      res22: Int = 84
+      $:
+
   @sect{Configuration}
     @p
       Ammonite is configured via Scala code, that can live in the @code{~/.ammonite/predef.scala} file, passed in through SBT's @hl.scala{initialCommands}, or passed to the command-line executable as @code{--predef='...'}.

--- a/repl/src/main/scala/ammonite/repl/frontend/ReplAPI.scala
+++ b/repl/src/main/scala/ammonite/repl/frontend/ReplAPI.scala
@@ -142,12 +142,12 @@ trait LoadJar {
    */
   def ivy(coordinates: (String, String, String), verbose: Boolean = true): Unit
 }
-trait Load extends (String => Unit) with LoadJar{
+trait Load extends ((String, Boolean) => Unit) with LoadJar{
   /**
    * Loads a command into the REPL and
    * evaluates them one after another
    */
-  def apply(line: String): Unit
+  def apply(line: String, visible: Boolean = false): Unit
 
   /**
    * Loads and executes the scriptfile on the specified path.

--- a/repl/src/main/scala/ammonite/repl/interp/Compiler.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Compiler.scala
@@ -101,7 +101,9 @@ object Compiler{
 
       def display(pos: Position, msg: String, severity: Severity) = {
         severity match{
-          case ERROR => logger(Position.formatMessage(pos, msg, false))
+          case ERROR => 
+            println(s"ERROR: $msg")
+            logger(Position.formatMessage(pos, msg, false))
           case _ => logger(msg)
         }
       }

--- a/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
@@ -226,7 +226,13 @@ class Interpreter(prompt0: Ref[String],
         eval.addJar(jar.toURI.toURL)
       }
 
-      def apply(line: String) = processExec(line)
+      def apply(line: String, visible: Boolean) = {
+        if (!visible) processExec(line)
+        else {
+          val res = interp.processLine(line, Parsers.split(line).get.get.value, _.foreach(interp.stdout))
+          handleOutput(res)
+        }
+      }
 
       def exec(file: Path): Unit = apply(read(file))
 


### PR DESCRIPTION
I've closed my previous messy pull request and replaced it with this one, which is clean and based on the latest version of your Master in Github. Apologies for the previous mess!
As per our gitter conversation, this pull request contains 2 changes:

Modifications the load.apply method in Interpreter.scala file to add support for evaluating code and getting a full printout, just as if the code was entered in the REPL itself. 

Here's an example of it in use:
```
@: load("""val foo = "I am cow!" """)

@: foo
res19: String = "I am cow!"
@: load("""val bar = 42; val baz = 2; bar*baz""", true)
bar: Int = 42
baz: Int = 2
res21_2: Int = 84
@: res21_2
res22: Int = 84
@:
```

I've tried all kinds of code, def's, multiple lines of input... it all seems to work fine.
I've included a small update to the Script Files section of the Repl.scalatex file to document the new REPL command.

A small modification to the Compiler.scala file to print error message if Jar dependencies cannot be found. It *only* prints if there is a fatal error, otherwise there is no additional output. This allowed me debug my problem with a Jar dependency issue, and I think it will help other people as well. The change is in the `def display(pos: Position, msg: String, severity: Severity) ` and its exactly the change from the diff file in lihaoyi/Ammonite#168
