### PR TITLE
Fix documentation url

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ The layout of the repository is roughly:
 
 - **All code PRs should come with**: a meaningful description, inline-comments for important things, unit tests (positive and negative), and a green build in [CI](https://travis-ci.org/lihaoyi/Ammonite)
 - **Try to keep lines below 80 characters width**, with a hard limit of 100 characters.
-- **PRs for features should generally come with *something* added to the [Documentation](lihaoyi.github.io/Ammonite)**, so people can discover that it exists
+- **PRs for features should generally come with *something* added to the [Documentation](http://lihaoyi.github.io/Ammonite)**, so people can discover that it exists
 - **Be prepared to discuss/argue-for your changes if you want them merged**! You will probably need to refactor so your changes fit into the larger codebase
 - **If your code is hard to unit test, and you don't want to unit test it, that's ok**. But be prepared to argue why that's the case!
 - **It's entirely possible your changes won't be merged**, or will get ripped out later. This is also the case for my changes, as the Author!


### PR DESCRIPTION
Updated documentation link from lihaoyi.github.io/Ammonite to
http://lihaoyi.github.io/Ammonite.

When lihaoyi.github.io/Ammonite is used as the link to the
documentation it resolves to: https://github.com/lihaoyi/Ammonite/blob/master/lihaoyi.github.io/Ammonite because it is a relative url.