### PR TITLE
Fix StandaloneTests.hello failure with predef.scala #262

### DIFF
--- a/shell/src/main/resources/ammonite/shell/empty-predef.scala
+++ b/shell/src/main/resources/ammonite/shell/empty-predef.scala
@@ -1,0 +1,1 @@
+//this file is intentionally empty.


### PR DESCRIPTION
I've updated the exec method to use an empty predef file, thus
isolating the tests from the effects of a user-supplied predef file.

It used to be that any output from a user's predef.scala file would
conflict with the 'hello test causing it to fail.

issue: #262