### PR TITLE
Have terminal.TTY commands prefer standard paths

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ The layout of the repository is roughly:
 - `sbt ~repl/test`/`sbt ~ops/test`/`sbt ~terminal/test`  runs tests after every change. `repl/test` can be a bit slow because of the amount of code it compiles, so you may want to specify the test manually via `repl/test-only -- ammonite.repl.TestObject.path.to.test`
 - `sbt +modules/publishLocal` or `+sbt modules/publishSigned` is used for publishing.
 - `sbt ~readme/run` builds the documentation inside its target folder, which you can view by opening `readme/target/scalatex/index.html` in your browser.
-- `git checkout gh-pages; cp -r readme/target/scalatex.* .; git commit -am .; git push` will deploy the generated documentation to Github Pages
+- `git checkout gh-pages; cp -r readme/target/scalatex/* .; git commit -am .; git push` will deploy the generated documentation to Github Pages
 
 ## Contribution Guidelines
 

--- a/readme/Sample.scala
+++ b/readme/Sample.scala
@@ -9,7 +9,7 @@ import scalatags.Text.all._
 object Sample{
   val replCurl = "$ curl -L -o amm http://git.io/v4gOX; chmod +x amm; ./amm"
   val filesystemCurl =
-    "$ mkdir ~/.ammonite; curl -L -o ~/.ammonite/predef.scala http://git.io/v4gOX"
+    "$ mkdir ~/.ammonite; curl -L -o ~/.ammonite/predef.scala http://git.io/vnnBy"
   val cacheVersion = 5
   def cached(key: Any)(calc: => String) = {
     val path = cwd/'target/'cache/(key.hashCode + cacheVersion).toString

--- a/terminal/src/main/scala/ammonite/terminal/Utils.scala
+++ b/terminal/src/main/scala/ammonite/terminal/Utils.scala
@@ -49,9 +49,14 @@ class Ansi(output: Writer){
   def clearLine(n: Int) = control(n, 'K')
 }
 object TTY{
+
+  // Prefer standard tools
+  val pathedTput = if (new java.io.File("/usr/bin/tput").exists()) "/usr/bin/tput" else "tput"
+  val pathedStty = if (new java.io.File("/bin/stty").exists()) "/bin/stty" else "stty"
+
   def consoleDim(s: String) = {
     import sys.process._
-    Seq("bash", "-c", s"tput $s 2> /dev/tty").!!.trim.toInt
+    Seq("bash", "-c", s"$pathedTput $s 2> /dev/tty").!!.trim.toInt
   }
   def init() = {
     stty("-a")
@@ -71,7 +76,7 @@ object TTY{
 
   private def sttyCmd(s: String) = {
     import sys.process._
-    Seq("bash", "-c", s"stty $s < /dev/tty"): ProcessBuilder
+    Seq("bash", "-c", s"$pathedStty $s < /dev/tty"): ProcessBuilder
   }
 
   def stty(s: String) =


### PR DESCRIPTION
Fix for #143, #212, #259.
Tested on MacOSX and Ubuntu.  No Windows box to determine
standard path for `stty` and `tput`.