### PR TITLE
add VI mode filters for Ammonite

### DIFF
--- a/repl/src/main/scala/ammonite/repl/frontend/AmmoniteFrontEnd.scala
+++ b/repl/src/main/scala/ammonite/repl/frontend/AmmoniteFrontEnd.scala
@@ -1,12 +1,11 @@
 package ammonite.repl.frontend
 
-import java.io.{OutputStreamWriter, OutputStream, InputStream}
+import java.io.{InputStream, OutputStream, OutputStreamWriter}
 
 import ammonite.repl._
 import ammonite.terminal.LazyList.~:
 import ammonite.terminal._
 import fastparse.core.Result
-import scala.annotation.tailrec
 
 case class AmmoniteFrontEnd(extraFilters: TermCore.Filter = PartialFunction.empty) extends FrontEnd{
 
@@ -46,8 +45,6 @@ case class AmmoniteFrontEnd(extraFilters: TermCore.Filter = PartialFunction.empt
                history: Seq[String]) = {
     Timer("AmmoniteFrontEnd.readLine start")
     val writer = new OutputStreamWriter(output)
-
-    import ammonite.ops._
 
     val autocompleteFilter: TermCore.Filter = {
       case TermInfo(TermState(9 ~: rest, b, c), width) =>
@@ -90,12 +87,15 @@ case class AmmoniteFrontEnd(extraFilters: TermCore.Filter = PartialFunction.empt
     }
 
     val historyFilter = ReadlineFilters.HistoryFilter(() => history.reverse)
+    val viHistoryFilter = VIFilters.VIHistoryFilter(history)
     val cutPasteFilter = ReadlineFilters.CutPasteFilter()
     val selectionFilter = GUILikeFilters.SelectionFilter(indent = 2)
 
     val allFilters =
       extraFilters orElse
       selectionFilter orElse
+      VIFilters.viFilter orElse
+      viHistoryFilter orElse
       GUILikeFilters.altFilter orElse
       GUILikeFilters.fnFilter orElse
       ReadlineFilters.navFilter orElse

--- a/terminal/src/main/scala/ammonite/terminal/BasicFilters.scala
+++ b/terminal/src/main/scala/ammonite/terminal/BasicFilters.scala
@@ -1,8 +1,7 @@
 package ammonite.terminal
-import acyclic.file
+import ammonite.terminal.FilterTools._
 import ammonite.terminal.LazyList._
-import FilterTools._
-import SpecialKeys._
+import ammonite.terminal.SpecialKeys._
 import ammonite.terminal.TermCore.Filter
 
 /**
@@ -68,6 +67,8 @@ object BasicFilters {
       val (first, last) = b.splitAt(c)
       TS(rest, first.dropRight(1) ++ last, c - 1)
 
+    case TS(char ~: rest, b, c) if VIFilters.VISUAL_MODE =>
+      TS(rest, b, c)
     case TS(char ~: rest, b, c) =>
 //      Debug("NORMAL CHAR " + char)
       val (first, last) = b.splitAt(c)

--- a/terminal/src/main/scala/ammonite/terminal/ReadlineFilters.scala
+++ b/terminal/src/main/scala/ammonite/terminal/ReadlineFilters.scala
@@ -1,8 +1,7 @@
 package ammonite.terminal
-import acyclic.file
-import FilterTools._
+import ammonite.terminal.FilterTools._
 import ammonite.terminal.LazyList._
-import SpecialKeys._
+import ammonite.terminal.SpecialKeys._
 /**
  * Filters for injection of readline-specific hotkeys, the sort that
  * are available in bash, python and most other interactive command-lines
@@ -58,6 +57,11 @@ object ReadlineFilters {
     def cutCharLeft(b: Vector[Char], c: Int) = {
       /* Do not edit current cut. Zsh(zle) & Bash(readline) do not edit the yank ring for Ctrl-h */
       (b patch(from = c - 1, patch = Nil, replaced = 1), c - 1)
+    }
+
+    def cutCharCursor(b: Vector[Char], c: Int) = {
+      /* Do not edit current cut. Zsh(zle) & Bash(readline) do not edit the yank ring for Ctrl-h */
+      (b patch(from = c, patch = Nil, replaced = 1), c)
     }
 
     def cutAllLeft(b: Vector[Char], c: Int) = {

--- a/terminal/src/main/scala/ammonite/terminal/VIFilters.scala
+++ b/terminal/src/main/scala/ammonite/terminal/VIFilters.scala
@@ -1,0 +1,89 @@
+package ammonite.terminal
+
+import ammonite.terminal.FilterTools._
+import ammonite.terminal.GUILikeFilters.{wordLeft, wordRight}
+import ammonite.terminal.LazyList._
+import ammonite.terminal.ReadlineFilters.CutPasteFilter
+import ammonite.terminal.TermCore.Filter
+
+/**
+ * Ammonite VI Mode
+ * Created by chengpohi on 12/5/15.
+ */
+object VIFilters {
+  var VI_MODE = false
+  var VISUAL_MODE = false
+  lazy val cutPasteFilter = CutPasteFilter()
+
+  val viFilter = {
+    enableViFilter orElse
+    viSingleKeyFilter orElse
+    viNavFilter orElse
+    viEditModeFilter
+  }
+
+  def enableViFilter: TermCore.Filter = {
+    case TS(27 ~: 13 ~: rest, b, c) => {
+      VI_MODE = !VI_MODE
+      VISUAL_MODE = VI_MODE
+      TS(rest, b, c)
+    }
+    case TS(27 ~: 10 ~: rest, b, c) => {
+      VI_MODE = !VI_MODE
+      VISUAL_MODE = VI_MODE
+      TS(rest, b, c)
+    }
+  }
+
+  def viSingleKeyFilter: Filter = {
+    case TS(27 ~: rest, b, c) if VI_MODE =>
+      VISUAL_MODE = true
+      TS(rest, b, c)
+  }
+
+  def viEditModeFilter: Filter = {
+    case TS('i' ~: rest, b, c) if VISUAL_MODE =>
+      VISUAL_MODE = false
+      TS(rest, b, c)
+    case TS('a' ~: rest, b, c) if VISUAL_MODE =>
+      VISUAL_MODE = false
+      TS(rest, b, c + 1)
+    case TS('x' ~: rest, b, c) if VISUAL_MODE =>
+      val right: (Vector[Char], Int) = cutPasteFilter.cutCharCursor(b, c)
+      TS(rest, right._1, right._2)
+    case TS('d' ~: 'd' ~: rest, b, c) if VISUAL_MODE =>
+      TS(rest, b.take(0), 0)
+    case TS('D' ~: rest, b, c) if VISUAL_MODE =>
+      val right: (Vector[Char], Int) = cutPasteFilter.cutAllRight(b, c)
+      TS(rest, right._1, right._2)
+  }
+
+  def viNavFilter: Filter = {
+    case TS('h' ~: rest, b, c) if VISUAL_MODE =>
+      TS(rest, b, c - 1)
+    case TS('l' ~: rest, b, c) if VISUAL_MODE =>
+      TS(rest, b, c + 1)
+    case TS('0' ~: rest, b, c) if VISUAL_MODE =>
+      TS(rest, b, 0)
+    case TS('b' ~: rest, b, c) if VISUAL_MODE =>
+      val left = wordLeft(b, c)
+      TS(rest, left._1, left._2)
+    case TS('w' ~: rest, b, c) if VISUAL_MODE =>
+      val left = wordRight(b, c)
+      TS(rest, left._1, left._2)
+    case TS('$' ~: rest, b, c) if VISUAL_MODE =>
+      TS(rest, b, b.size)
+  }
+
+  case class VIHistoryFilter(history: Seq[String]) extends TermCore.DelegateFilter {
+    val historyFilter = ReadlineFilters.HistoryFilter(() => history.reverse)
+
+    override def filter: Filter = {
+      case TS('j' ~: rest, b, c) if VISUAL_MODE =>
+        historyFilter.nextHistory(b, rest)
+      case TS('k' ~: rest, b, c) if VISUAL_MODE =>
+        historyFilter.previousHistory(b, rest)
+    }
+  }
+
+}


### PR DESCRIPTION
Enable VI mode in Ammonite repl, For now it supports:


|ShortCut | Function|
|:----|:----|
|Esc + Enter |Toggle VI Model|
|Esc|Toggle Visual Mode|
|h|move to left char|
|l|move to right char|
|i|insert mode|
|a|insert mode|
|x|delete current char|
|0|go to the start of line|
|d + d|delete current line|
|$|go to the end of line|
|b|go to the left word|
|w|go to the next word|
|j|go to the next history|
|k|go to the previous history|
