### PR TITLE
avoid loading non-jar from load.ivy's classpath to prevent repl blow-up

### DIFF
--- a/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
@@ -230,7 +230,8 @@ class Interpreter(prompt0: Ref[String],
     object load extends DefaultLoadJar with Load {
 
       def handleJar(jar: File) = {
-        eval.sess.frames.head.extraJars = eval.sess.frames.head.extraJars ++ Seq(jar).filter(Classpath.isJar)
+        eval.sess.frames.head.extraJars = eval.sess.frames.head.extraJars ++ 
+          Seq(jar).filter(Classpath.isJar)
         evalClassloader.add(jar.toURI.toURL)
       }
 

--- a/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
@@ -230,7 +230,7 @@ class Interpreter(prompt0: Ref[String],
     object load extends DefaultLoadJar with Load {
 
       def handleJar(jar: File) = {
-        eval.sess.frames.head.extraJars = eval.sess.frames.head.extraJars ++ Seq(jar)
+        eval.sess.frames.head.extraJars = eval.sess.frames.head.extraJars ++ Seq(jar).filter(Classpath.isJar)
         evalClassloader.add(jar.toURI.toURL)
       }
 


### PR DESCRIPTION
Dependencies loaded via load.ivy can sometime contains non-jar files (e.g. pom) which blows up the repl, e.g.:

    sbt -Dammonite.trace-classpath=true 'project repl' run

and then

    load.ivy( "org.apache.tuscany.sca" % "tuscany-base-runtime-pom" % "2.0.1")

will results in 
```
ERROR: error while loading <root>, Error accessing /Users/hamero/.ivy2/cache/org.apache.tuscany.sca/tuscany-core-runtime-pom/poms/tuscany-core-runtime-pom-2.0.1.pom
scala.reflect.internal.MissingRequirementError: object java.lang.Object in compiler mirror not found.
	scala.reflect.internal.MissingRequirementError$.signal(MissingRequirementError.scala:17)
	scala.reflect.internal.MissingRequirementError$.notFound(MissingRequirementError.scala:18)
	scala.reflect.internal.Mirrors$RootsBase.getModuleOrClass(Mirrors.scala:53)
	scala.reflect.internal.Mirrors$RootsBase.getModuleOrClass(Mirrors.scala:45)
	scala.reflect.internal.Mirrors$RootsBase.getModuleOrClass(Mirrors.scala:45)
	scala.reflect.internal.Mirrors$RootsBase.getModuleOrClass(Mirrors.scala:66)
	scala.reflect.internal.Mirrors$RootsBase.getClassByName(Mirrors.scala:102)
	scala.reflect.internal.Mirrors$RootsBase.getRequiredClass(Mirrors.scala:105)
	scala.reflect.internal.Definitions$DefinitionsClass.ObjectClass$lzycompute(Definitions.scala:257)
	scala.reflect.internal.Definitions$DefinitionsClass.ObjectClass(Definitions.scala:257)
	scala.reflect.internal.Definitions$DefinitionsClass.init(Definitions.scala:1394)
	scala.tools.nsc.Global$Run.<init>(Global.scala:1215)
	ammonite.repl.interp.Compiler$$anon$4.<init>(Compiler.scala:204)
	ammonite.repl.interp.Compiler$.apply(Compiler.scala:129)
	ammonite.repl.interp.Interpreter.init(Interpreter.scala:329)
	ammonite.repl.interp.Interpreter$DefaultLoadJar.ivy(Interpreter.scala:219)
	cmd2$.<init>(Main.scala:34)
	cmd2$.<clinit>(Main.scala:-1)
```
This PR fixed the issue by filtering out non-jar files before adding to the session classpath.