### PR TITLE
fix crash when autocompleting an unknown import

### DIFF
--- a/repl/src/main/scala/ammonite/repl/interp/Pressy.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Pressy.scala
@@ -131,13 +131,15 @@ object Pressy {
         // If the selectors haven't been defined yet...
         if (selectors.head.name.toString == "<error>") {
           if (expr.tpe.toString == "<error>") {
-            // If the expr is badly typed, try to scope complete it
-            val exprName = expr.asInstanceOf[pressy.Ident].name.decoded
-            expr.pos.point -> handleCompletion(
-              ask(expr.pos.point, pressy.askScopeCompletion),
-              // if it doesn't have a name at all, accept anything
-              if (exprName == "<error>") "" else exprName
-            )
+              // If the expr is badly typed, try to scope complete it
+              if (expr.isInstanceOf[pressy.Ident]) {
+                val exprName =  expr.asInstanceOf[pressy.Ident].name.decoded
+                expr.pos.point -> handleCompletion(
+                  ask(expr.pos.point, pressy.askScopeCompletion),
+                  // if it doesn't have a name at all, accept anything
+                  if (exprName == "<error>") "" else exprName
+                )
+              } else (expr.pos.point, Seq.empty)
           } else {
             // If the expr is well typed, type complete
             // the next thing

--- a/repl/src/test/scala/ammonite/repl/AutocompleteTests.scala
+++ b/repl/src/test/scala/ammonite/repl/AutocompleteTests.scala
@@ -53,7 +53,12 @@ object AutocompleteTests extends TestSuite{
           """import java.util.{LinkedHashMap, Linke<caret>""",
           Set("LinkedHashMap", "LinkedHashSet", "LinkedList") ^ _
         )
-
+        complete(
+          """import scala.uti.<caret>""", Set.empty[String] -- _
+        )
+        complete(
+          """import scala.colltion.<caret>""", Set.empty[String] -- _
+        )
       }
 
       'scope {
@@ -147,10 +152,12 @@ object AutocompleteTests extends TestSuite{
         //      complete("""Seq(1, 2, 3).map(_.co<caret>mpa)""", compares ^)
         //      complete("""Seq(1, 2, 3).map(_.<caret>compa)""", compares, ^)
       }
+
       'defTab {
         //Assert no NullPointerException was thrown. Does not verify any completions.
         complete( """def<caret>""", Set.empty -- _)
       }
+
       'Array {
         //Test around https://github.com/lihaoyi/Ammonite/issues/252
         complete("""new Array<caret>""", Set() ^)


### PR DESCRIPTION
When trying to autocomplete an unknown or mistyped import such as:

```
import scala.collction.<tab>
```

Ammonite exits with the following error:

```
@ import scala.collction.Exception in thread "main"
java.lang.ClassCastException: scala.reflect.internal.Trees$Select
    cannot be cast to scala.reflect.internal.Trees$Ident
    at ammonite.repl.interp.Pressy$Run.prefixed(Pressy.scala:135)
    at ammonite.repl.interp.Pressy$$anon$3.complete(Pressy.scala:231)
```

The error is due to casting a scala.reflect.internal.Trees$Select to a
scala.reflect.internal.Trees$Ident. The fix simply tests for the
Trees$Ident type before casting to it.

If the expr type of the Import is not a Trees$Ident then we return no
matches.

Also added a couple of tests for the fix to repl/AutocompleteTests.