### PR TITLE
Configure external links in ScalaDoc

### DIFF
--- a/project/build.sbt
+++ b/project/build.sbt
@@ -3,3 +3,5 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.13.0")
 addSbtPlugin("com.lihaoyi" % "scalatex-sbt-plugin" % "0.3.5")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
+
+addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "0.2.2")


### PR DESCRIPTION
I found that the [ScalaDoc](http://www.lihaoyi.com/Ammonite/api/ops/index.html) does not link to Scala standard library and other dependencies. This patch fixes the problem.
