### PR TITLE
preserve settings when replacing compilers

### DIFF
--- a/repl/src/main/scala/ammonite/repl/interp/Compiler.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Compiler.scala
@@ -87,9 +87,9 @@ object Compiler{
                      dynamicClasspath: VirtualDirectory,
                      errorLogger: => String => Unit,
                      warningLogger: => String => Unit,
-                     infoLogger: => String => Unit) = {
+                     infoLogger: => String => Unit,
+                     settings: Settings) = {
     val vd = new io.VirtualDirectory("(memory)", None)
-    lazy val settings = new Settings
     val settingsX = settings
     val jCtx = new JavaContext()
     val (dirDeps, jarDeps) = classpath.partition(_.isDirectory)
@@ -131,14 +131,15 @@ object Compiler{
 
       val settings = settingsX
     }
-    (settings, reporter, vd, jcp)
+    (reporter, vd, jcp)
   }
 
   def apply(classpath: Seq[java.io.File],
             dynamicClasspath: VirtualDirectory,
             evalClassloader: => ClassLoader,
             pluginClassloader: => ClassLoader,
-            shutdownPressy: () => Unit): Compiler = new Compiler{
+            shutdownPressy: () => Unit,
+            settings: Settings): Compiler = new Compiler{
 
     val PluginXML = "scalac-plugin.xml"
 
@@ -178,8 +179,8 @@ object Compiler{
     var lastImports = Seq.empty[ImportData]
 
     val (vd, reporter, compiler) = {
-      val (settings, reporter, vd, jcp) = initGlobalBits(
-        classpath, dynamicClasspath, errorLogger, warningLogger, infoLogger
+      val (reporter, vd, jcp) = initGlobalBits(
+        classpath, dynamicClasspath, errorLogger, warningLogger, infoLogger, settings
       )
       val scalac = new nsc.Global(settings, reporter) { g =>
         override lazy val plugins = List(new AmmonitePlugin(g, lastImports = _)) ++ {

--- a/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Interpreter.scala
@@ -5,6 +5,7 @@ import java.nio.file.NotDirectoryException
 import org.apache.ivy.plugins.resolver.RepositoryResolver
 
 import scala.collection.mutable
+import scala.tools.nsc.Settings
 import acyclic.file
 import fastparse.all._
 import ammonite.ops._
@@ -383,18 +384,21 @@ class Interpreter(prompt0: Ref[String],
   def evalClassloader = eval.sess.frames.head.classloader
   def init() = {
     Timer("Interpreter init init 0")
+    val settings = Option(compiler).fold(new Settings)(_.compiler.settings.copy)
     compiler = Compiler(
       Classpath.classpath ++ eval.sess.frames.head.classpath,
       dynamicClasspath,
       evalClassloader,
       eval.sess.frames.head.pluginClassloader,
-      () => pressy.shutdownPressy()
+      () => pressy.shutdownPressy(),
+      settings
     )
     Timer("Interpreter init init compiler")
     pressy = Pressy(
       Classpath.classpath ++ eval.sess.frames.head.classpath,
       dynamicClasspath,
-      evalClassloader
+      evalClassloader,
+      settings
     )
     Timer("Interpreter init init pressy")
   }

--- a/repl/src/main/scala/ammonite/repl/interp/Pressy.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/Pressy.scala
@@ -5,6 +5,7 @@ import acyclic.file
 import scala.reflect.internal.util.{Position, OffsetPosition, BatchSourceFile}
 import scala.reflect.io.VirtualDirectory
 import scala.tools.nsc
+import scala.tools.nsc.Settings
 import scala.tools.nsc.backend.JavaPlatform
 import scala.tools.nsc.interactive.Response
 import scala.tools.nsc.util._
@@ -180,17 +181,19 @@ object Pressy {
   }
   def apply(classpath: Seq[java.io.File],
             dynamicClasspath: VirtualDirectory,
-            evalClassloader: => ClassLoader): Pressy = new Pressy {
+            evalClassloader: => ClassLoader,
+            settings: Settings): Pressy = new Pressy {
 
     var cachedPressy: nsc.interactive.Global = null
 
     def initPressy = {
-      val (settings, reporter, _, jcp) = Compiler.initGlobalBits(
+      val (reporter, _, jcp) = Compiler.initGlobalBits(
         classpath,
         dynamicClasspath,
         _ => (),
         _ => (),
-        _ => ()
+        _ => (),
+        settings
       )
       new nsc.interactive.Global(settings, reporter) { g =>
         // Actually jcp, avoiding a path-dependent type issue in 2.10 here

--- a/repl/src/test/scala/ammonite/repl/session/AdvancedTests.scala
+++ b/repl/src/test/scala/ammonite/repl/session/AdvancedTests.scala
@@ -75,6 +75,18 @@ object AdvancedTests extends TestSuite{
       """)
 
     }
+    'predefSettings{
+      val check2 = new TestRepl{
+        override def predef = """
+          compiler.settings.Xexperimental.value = true
+        """
+      }
+      check2.session("""
+        @ compiler.settings.Xexperimental.value
+        res0: Boolean = true
+      """)
+
+    }
     'macros{
       check.session("""
         @ import language.experimental.macros


### PR DESCRIPTION
It is currently not possible to have a predef that manipulates compiler settings, because the compiler that is used during initialization is replaced before the REPL is available to the user. This PR fixes that as follows:

- `initGlobalBits ` now takes a `Settings` to use, rather than constructing a new one.
- `Compiler` and `Pressy` now take a `Settings`, which is passed to `initGlobalBits`.
- `Interpreter` now constructs a new `Settings` for the initial compiler, and thereafter uses a *copy* of the settings from the previous compiler.

The provided unit test fails in `master` at the moment, but passes with these changes.