### PR TITLE
Fixed resolver pattern for local ivy

### DIFF
--- a/repl/src/main/scala/ammonite/repl/IvyThing.scala
+++ b/repl/src/main/scala/ammonite/repl/IvyThing.scala
@@ -178,7 +178,7 @@ object Resolvers {
    Resolver.File(
      "local",
      "/.ivy2/local",
-     "/[organisation]/[module]/[revision]/jars/[artifact].[ext]",
+     "/[organisation]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]",
      m2 = false
    ),
    Resolver.File(


### PR DESCRIPTION
Addresses this bug: #300 

Problem is that locally published jars in Ivy have a different pattern than they do in the remote repo. Specifically the Ivy.xml file, which lists the jar dependencies, is in a different subdirectory from the Jar. Annoyingly Ivy fails silently on this and just assumes you have no dependencies, and copies your local jar to the ivy cache with a default ivy.xml :/

I don't really grok Ivy that well, but I wonder if some of the other ivy issues are related (such as #387) to this. Maybe other patterns should be updated to include [type] and [classifier]?

