### PR TITLE
Implement script level cache

### DIFF
--- a/repl/src/main/scala/ammonite/repl/Main.scala
+++ b/repl/src/main/scala/ammonite/repl/Main.scala
@@ -9,6 +9,9 @@ import scala.reflect.internal.annotations.compileTimeOnly
 import scala.reflect.runtime.universe.TypeTag
 import language.experimental.macros
 import reflect.macros.Context
+import scala.collection.mutable
+import scala.util._
+import Util.CompileCache
 
 
 /**
@@ -90,7 +93,7 @@ case class Main(predef: String = "",
     ) match{
       case x: Res.Failing => x
       case Res.Success(imports) =>
-        repl.interp.init()
+        repl.interp.reInit()
         imports.value.find(_.toName == Name("main")) match {
           case None => Res.Success(imports)
           case Some(i) =>

--- a/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -78,6 +78,7 @@ class Repl(input: InputStream,
 
   def run(): Any = {
     welcomeBanner.foreach(printStream.println)
+    interp.init()
     @tailrec def loop(): Any = {
       val actionResult = action()
       Timer("End Of Loop")

--- a/repl/src/main/scala/ammonite/repl/Util.scala
+++ b/repl/src/main/scala/ammonite/repl/Util.scala
@@ -6,6 +6,7 @@ import ammonite.ops._
 import acyclic.file
 import fansi.Attrs
 import pprint.{PPrint, PPrinter}
+import ammonite.repl.Parsers.ImportTree
 
 import scala.collection.mutable
 import scala.reflect.NameTransformer
@@ -124,7 +125,8 @@ case class Catching(handler: PartialFunction[Throwable, Res.Failing]) {
 }
 
 case class Evaluated(wrapper: Seq[Name],
-                     imports: Imports)
+                     imports: Imports,
+                     tag: String)
 
 /**
   * Represents the importing of a single name in the Ammonite REPL, of the
@@ -307,8 +309,12 @@ object Util{
   }
 
   // Type aliases for common things
+
+  type CacheDetails = (String, String)
+  //                   Wrapper HashVal
   type IvyMap = Map[(String, String, String, String), Set[String]]
   type ClassFiles = Traversable[(String, Array[Byte])]
+  type CacheOutput = (Seq[String], Seq[ClassFiles], Imports, Seq[ImportTree])
   type CompileCache = (ClassFiles, Imports)
 
 

--- a/repl/src/main/scala/ammonite/repl/interp/ClassLoaders.scala
+++ b/repl/src/main/scala/ammonite/repl/interp/ClassLoaders.scala
@@ -107,7 +107,6 @@ class SpecialClassLoader(parent: ClassLoader, parentHash: Array[Byte])
       if (!specialLocalClasses(name)) None
       else{
         import ammonite.ops._
-        //          println("Custom finding class! " + name)
         val bytes = read.bytes(
           this.getResourceAsStream(name.replace('.', '/') + ".class")
         )

--- a/repl/src/test/resources/scriptLevelCaching/QuickSort.scala
+++ b/repl/src/test/resources/scriptLevelCaching/QuickSort.scala
@@ -1,0 +1,13 @@
+def fib(n : Int): Int = {
+  if (n == 0) 0
+  else if (n == 1) 1
+  else fib(n-1) + fib(n-2)
+}
+
+def quicksort(unsorted : List[Int]): List[Int] = {
+  if(unsorted.length <= 1) unsorted
+  else{
+    val pivot = unsorted.head
+    quicksort(unsorted.filter(_ < pivot)):::List(pivot):::quicksort(unsorted.filter(_ > pivot))
+  }
+}

--- a/repl/src/test/resources/scriptLevelCaching/fileToBeImported.scala
+++ b/repl/src/test/resources/scriptLevelCaching/fileToBeImported.scala
@@ -1,0 +1,2 @@
+import ammonite.ops._
+def listScalaFiles = ls(cwd) |? (_.last.endsWith(".scala"))

--- a/repl/src/test/resources/scriptLevelCaching/ivyCacheTest.scala
+++ b/repl/src/test/resources/scriptLevelCaching/ivyCacheTest.scala
@@ -1,0 +1,4 @@
+import $ivy.`com.lihaoyi::scalatags:0.5.3`, scalatags.Text.all._
+
+val rendered = div("Moo").render
+

--- a/repl/src/test/resources/scriptLevelCaching/runTimeExceptions.scala
+++ b/repl/src/test/resources/scriptLevelCaching/runTimeExceptions.scala
@@ -1,0 +1,4 @@
+import ammonite.ops._
+println(5/read(cwd/'repl/'target/'test/'resources/'scriptLevelCaching/"num.value").trim.toInt)
+rm(cwd/'repl/'target/'test/'resources/'scriptLevelCaching/"num.value")
+write(cwd/'repl/'target/'test/'resources/'scriptLevelCaching/"num.value", "0")

--- a/repl/src/test/resources/scriptLevelCaching/scriptOne.scala
+++ b/repl/src/test/resources/scriptLevelCaching/scriptOne.scala
@@ -1,0 +1,14 @@
+// Test Code
+object test{
+
+import scala.tools.nsc._
+
+val x = repl
+}
+println(test.x)
+
+@
+
+def f = "Hello"
+println("\n\nIt has executed")
+

--- a/repl/src/test/resources/scriptLevelCaching/scriptToBeLoaded.scala
+++ b/repl/src/test/resources/scriptLevelCaching/scriptToBeLoaded.scala
@@ -1,0 +1,20 @@
+
+println(repl)
+println("First Block")
+
+@
+
+println(repl)
+println("Second Block")
+
+@
+
+println(repl)
+println("Third Block")
+
+@
+
+println(repl)
+println("Fourth Block")
+
+val x = repl

--- a/repl/src/test/resources/scriptLevelCaching/scriptTwo.scala
+++ b/repl/src/test/resources/scriptLevelCaching/scriptTwo.scala
@@ -1,0 +1,4 @@
+
+println("Test Script")
+println(repl)
+

--- a/repl/src/test/resources/scriptLevelCaching/testFileImport.scala
+++ b/repl/src/test/resources/scriptLevelCaching/testFileImport.scala
@@ -1,0 +1,9 @@
+import $file.repl.src.test.resources.scriptLevelCaching.fileToBeImported
+
+@
+
+println("Hope It works!!")
+
+@
+println(fileToBeImported.listScalaFiles)
+println("Yup!! It worked :) ")

--- a/repl/src/test/resources/scriptLevelCaching/testLoadModule.scala
+++ b/repl/src/test/resources/scriptLevelCaching/testLoadModule.scala
@@ -1,0 +1,10 @@
+// Test case to check whether it can load modules from cache and use the imports successfully
+
+import ammonite.ops._
+println("Script starts!!")
+val scriptDir = cwd/'repl/'src/'test/'resources/'scriptLevelCaching
+load.module(scriptDir/"scriptToBeLoaded.scala")
+
+@
+
+println(x)

--- a/repl/src/test/scala/ammonite/repl/TestRepl.scala
+++ b/repl/src/test/scala/ammonite/repl/TestRepl.scala
@@ -29,19 +29,23 @@ class TestRepl {
     errorBuffer.append(_),
     infoBuffer.append(_)
   )
-  val interp = try new Interpreter(
-    Ref[String](""),
-    Ref(null),
-    80,
-    80,
-    Ref(Colors.BlackWhite),
-    printer,
-    storage = new Storage.Folder(tempDir),
-    new History(Vector()),
-    predef = ammonite.repl.Main.defaultPredefString + "\n" + predef,
-    wd = ammonite.ops.cwd,
-    replArgs = Seq()
-  ) catch{ case e =>
+  val interp = try {
+    val i = new Interpreter(
+      Ref[String](""),
+      Ref(null),
+      80,
+      80,
+      Ref(Colors.BlackWhite),
+      printer,
+      storage = new Storage.Folder(tempDir),
+      new History(Vector()),
+      predef = ammonite.repl.Main.defaultPredefString + "\n" + predef,
+      wd = ammonite.ops.cwd,
+      replArgs = Seq()
+    )
+    i.init()
+    i
+  }catch{ case e =>
     println(infoBuffer.mkString)
     println(outBuffer.mkString)
     println(warningBuffer.mkString)

--- a/repl/src/test/scala/ammonite/repl/ToolsTests.scala
+++ b/repl/src/test/scala/ammonite/repl/ToolsTests.scala
@@ -38,12 +38,12 @@ object ToolsTests extends TestSuite{
           implicitly[pprint.Config]
           val displayed =
             for(g <- grepped)
-            yield {
-              pprint.tokenize(g)
-                    .mkString
-                    .replace(fansi.Color.Red.escape, "<")
-                    .replace(fansi.Color.Reset.escape, ">")
-            }
+              yield {
+                pprint.tokenize(g)
+                  .mkString
+                  .replace(fansi.Color.Red.escape, "<")
+                  .replace(fansi.Color.Reset.escape, ">")
+              }
           assert(displayed == expected)
         }
         'string{


### PR DESCRIPTION
Program flow is like:

Speed improvement is achieved by making processModule cache anything( scripts, predefs, imports including $ivy and $file,etc.) it processes at script level( at block level it already gets) and tries to retrieve from cache next time it is asked to process same code.

Process Module checks if the script is available in cacheFolder i.e. `scriptCaches`. If it is not found, processModule0 is called which keeps the rest of program flow same as before this diff but passes back importHooks and other imports accumulated in `processCorrectScript` function. This data is stored by `classFilesListSave` which takes list of `pkgName` concatenated with `wrapperName` and hash values of blocks along with imports and stores them.

If script is found in cache, `classFilesListLoad` reads the list of names and hash values of blocks and loads those blocks from their cache folders made by `compileCacheLoad` function. Loaded import hooks are resolved by `resolveSingleImportHook`. Along with retrieved imports this data is passed to `eval.evalCacheClassFiles` which loads each classFile and evals the main function thus executing the code. 

The final imports are returned by processModule function whether evaled or loaded from cache, thus processModule is opaque from outside whether cache HIT or MISS, it behaves in exactly same way in return as well as side effects except cache save.
