### PR TITLE
Fix SshdRepl ignoring predef string

### DIFF
--- a/sshd/src/main/scala/ammonite/sshd/SshdRepl.scala
+++ b/sshd/src/main/scala/ammonite/sshd/SshdRepl.scala
@@ -59,7 +59,7 @@ object SshdRepl {
         )
         new Repl(
           in, out, out,
-          new Storage.Folder(homePath), augmentedPredef,
+          new Storage.Folder(homePath), augmentedPredef + "\n" + predef,
           wd, Some(ammonite.main.Defaults.welcomeBanner), replArgs
         ).run()
       } catch {


### PR DESCRIPTION
This helps using the workaround from https://github.com/lihaoyi/Ammonite/issues/330 without having to create the predef file the server.