### PR TITLE
Make all amm and integration pass on windows except the Syntax Error ones

### DIFF
--- a/amm/src/main/scala/ammonite/interp/ClassLoaders.scala
+++ b/amm/src/main/scala/ammonite/interp/ClassLoaders.scala
@@ -118,7 +118,7 @@ class SpecialClassLoader(parent: ClassLoader, parentSignature: Seq[(Path, Long)]
   }
 
   private def jarSignature(url: URL) = {
-    val path = Path(url.getFile, root)
+    val path = Path(file.Paths.get(url.toURI()).toFile(), root)
     path -> path.mtime.toMillis
   }
 

--- a/amm/src/main/scala/ammonite/interp/Storage.scala
+++ b/amm/src/main/scala/ammonite/interp/Storage.scala
@@ -10,6 +10,7 @@ import org.apache.ivy.plugins.resolver.RepositoryResolver
 import scala.util.Try
 import scala.collection.generic.CanBuildFrom
 import scala.collection.{IndexedSeqLike, mutable}
+import scala.reflect.NameTransformer.encode
 
 
 /**
@@ -125,7 +126,7 @@ object Storage{
 
     def compileCacheSave(path: String, tag: String, data: CompileCache): Unit = timer{
       val (classFiles, imports) = data
-      val tagCacheDir = compileCacheDir/path.replace("/", "$div").replace(":", "$colon")/tag
+      val tagCacheDir = compileCacheDir/encode(path)/tag
 
       if(!exists(tagCacheDir)){
         mkdir(tagCacheDir)
@@ -144,7 +145,7 @@ object Storage{
                            imports: Imports,
                            tag: String,
                            importTreesList: Seq[ImportTree]): Unit = timer{
-      val dir = pkg.replace("/", "$div") + "." + wrapper.replace("/", "$div")
+      val dir = encode(pkg) + "." + encode(wrapper)
       val codeCacheDir = cacheDir/'scriptCaches/dir/tag
       if (!exists(codeCacheDir)){
         mkdir(codeCacheDir)
@@ -175,7 +176,7 @@ object Storage{
                            wrapper: String,
                            cacheTag: String): Option[CacheOutput] = timer{
 
-      val dir = pkg.replace("/", "$div") + "." + wrapper.replace("/", "$div")
+      val dir = encode(pkg) + "." + encode(wrapper)
       val codeCacheDir = cacheDir/'scriptCaches/dir/cacheTag
       if(!exists(codeCacheDir)) None
       else {
@@ -207,7 +208,7 @@ object Storage{
     }
 
     def compileCacheLoad(path: String, tag: String): Option[CompileCache] = timer{
-      val tagCacheDir = compileCacheDir/path.replace("/", "$div").replace(":", "$colon")/tag
+      val tagCacheDir = compileCacheDir/encode(path)/tag
       if(!exists(tagCacheDir)) None
       else for{
         (loadedTag, metadata) <- readJson[(String, Imports)](tagCacheDir/metadataFile)

--- a/amm/src/test/scala/ammonite/CachingTests.scala
+++ b/amm/src/test/scala/ammonite/CachingTests.scala
@@ -82,11 +82,7 @@ object CachingTests extends TestSuite{
       'testThree - check('scriptLevelCaching/"QuickSort.sc")
       'testLoadModule - check('scriptLevelCaching/"testLoadModule.sc")
       'testFileImport - check('scriptLevelCaching/"testFileImport.sc")
-      'testIvyImport -{
-        if(!Util.windowsPlatform){
-          check('scriptLevelCaching/"ivyCacheTest.sc")
-        }
-      }
+      'testIvyImport - check('scriptLevelCaching/"ivyCacheTest.sc")
 
     }
 
@@ -130,16 +126,14 @@ object CachingTests extends TestSuite{
       assert(n2 == 0) // all three should be cached
     }
     'tags{
-      if (!Util.windowsPlatform){
-        val storage = Storage.InMemory()
-        val interp = createTestInterp(storage)
-        interp.replApi.load.module(scriptPath/"TagBase.sc")
-        interp.replApi.load.module(scriptPath/"TagPrevCommand.sc")
-        interp.replApi.load.ivy("com.lihaoyi" %% "scalatags" % "0.4.5")
-        interp.replApi.load.module(scriptPath/"TagBase.sc")
-        val n = storage.compileCache.size
-        assert(n == 5) // predef + two blocks for initial load
-      }
+      val storage = Storage.InMemory()
+      val interp = createTestInterp(storage)
+      interp.replApi.load.module(scriptPath/"TagBase.sc")
+      interp.replApi.load.module(scriptPath/"TagPrevCommand.sc")
+      interp.replApi.load.ivy("com.lihaoyi" %% "scalatags" % "0.4.5")
+      interp.replApi.load.module(scriptPath/"TagBase.sc")
+      val n = storage.compileCache.size
+      assert(n == 5) // predef + two blocks for initial load
     }
 
     'changeScriptInvalidation{
@@ -149,50 +143,48 @@ object CachingTests extends TestSuite{
       // to the script being run. For each change, the caches should be
       // invalidated, and subsequently a single compile should be enough
       // to re-fill the caches
-      if(!Util.windowsPlatform){
-        val predefFile = tmp("""
-          val x = 1337
-          @
-          val y = x
-          import $ivy.`com.lihaoyi::scalatags:0.5.4`, scalatags.Text.all._
-          """)
-        val scriptFile = tmp("""div("<('.'<)", y).render""")
+      val predefFile = tmp("""
+        val x = 1337
+        @
+        val y = x
+        import $ivy.`com.lihaoyi::scalatags:0.5.4`, scalatags.Text.all._
+        """)
+      val scriptFile = tmp("""div("<('.'<)", y).render""")
 
-        def processAndCheckCompiler(f: ammonite.interp.Compiler => Boolean) ={
-          val interp = createTestInterp(
-            new Storage.Folder(tempDir){
-              override val predef = predefFile
-            },
-            Defaults.predefString
-          )
-          interp.replApi.load.module(scriptFile)
-          assert(f(interp.compiler))
-        }
-
-        processAndCheckCompiler(_ != null)
-        processAndCheckCompiler(_ == null)
-
-        rm! predefFile
-        write(
-          predefFile,
-          """
-          import $ivy.`com.lihaoyi::scalatags:0.5.4`; import scalatags.Text.all._
-          val y = 31337
-          """
+      def processAndCheckCompiler(f: ammonite.interp.Compiler => Boolean) ={
+        val interp = createTestInterp(
+          new Storage.Folder(tempDir){
+            override val predef = predefFile
+          },
+          Defaults.predefString
         )
-
-        processAndCheckCompiler(_ != null)
-        processAndCheckCompiler(_ == null)
-
-        rm! scriptFile
-        write(
-          scriptFile,
-          """div("(>'.')>", y).render"""
-        )
-
-        processAndCheckCompiler(_ != null)
-        processAndCheckCompiler(_ == null)
+        interp.replApi.load.module(scriptFile)
+        assert(f(interp.compiler))
       }
+
+      processAndCheckCompiler(_ != null)
+      processAndCheckCompiler(_ == null)
+
+      rm! predefFile
+      write(
+        predefFile,
+        """
+        import $ivy.`com.lihaoyi::scalatags:0.5.4`; import scalatags.Text.all._
+        val y = 31337
+        """
+      )
+
+      processAndCheckCompiler(_ != null)
+      processAndCheckCompiler(_ == null)
+
+      rm! scriptFile
+      write(
+        scriptFile,
+        """div("(>'.')>", y).render"""
+      )
+
+      processAndCheckCompiler(_ != null)
+      processAndCheckCompiler(_ == null)
     }
   }
 }

--- a/amm/src/test/scala/ammonite/ScriptTests.scala
+++ b/amm/src/test/scala/ammonite/ScriptTests.scala
@@ -21,18 +21,16 @@ object ScriptTests extends TestSuite{
     'exec{
       'compilationBlocks{
         'loadIvy - retry(3){ // ivy or maven central seems to be flaky =/ =/ =/
-            if(!Util.windowsPlatform){
-              check.session(s"""
-                @ import ammonite.ops._
+          check.session(s"""
+            @ import ammonite.ops._
 
-                @ load.exec($printedScriptPath/"LoadIvy.sc")
+            @ load.exec($printedScriptPath/"LoadIvy.sc")
 
-                @ val r = res
-                r: String = ${"\"\"\""}
-                <a href="www.google.com">omg</a>
-                ${"\"\"\""}
-                """)
-            }
+            @ val r = res
+            r: String = ${"\"\"\""}
+            <a href="www.google.com">omg</a>
+            ${"\"\"\""}
+            """)
           }
         'preserveImports{
           val typeString =
@@ -162,18 +160,16 @@ object ScriptTests extends TestSuite{
     'module{
       'compilationBlocks{
         'loadIvy{
-          if(!Util.windowsPlatform){
-            check.session(s"""
-              @ import ammonite.ops._
+          check.session(s"""
+            @ import ammonite.ops._
 
-              @ load.module($printedScriptPath/"LoadIvy.sc")
+            @ load.module($printedScriptPath/"LoadIvy.sc")
 
-              @ val r = res
-              r: String = ${"\"\"\""}
-              <a href="www.google.com">omg</a>
-              ${"\"\"\""}
-             """)
-          }
+            @ val r = res
+            r: String = ${"\"\"\""}
+            <a href="www.google.com">omg</a>
+            ${"\"\"\""}
+           """)
         }
         'preserveImports{
           val typeString =

--- a/amm/src/test/scala/ammonite/session/AdvancedTests.scala
+++ b/amm/src/test/scala/ammonite/session/AdvancedTests.scala
@@ -241,36 +241,34 @@ object AdvancedTests extends TestSuite{
       """)
     }
     'compilerPlugin{
-      if(!Util.windowsPlatform){
-        check.session("""
-          @ // Make sure plugins from eval class loader are not loaded
+      check.session("""
+        @ // Make sure plugins from eval class loader are not loaded
 
-          @ import $ivy.`org.spire-math::kind-projector:0.6.3`
+        @ import $ivy.`org.spire-math::kind-projector:0.6.3`
 
-          @ trait TC0[F[_]]
-          defined trait TC0
+        @ trait TC0[F[_]]
+        defined trait TC0
 
-          @ type TC0EitherStr = TC0[Either[String, ?]]
-          error: not found: type ?
+        @ type TC0EitherStr = TC0[Either[String, ?]]
+        error: not found: type ?
 
-          @ // This one must be loaded
+        @ // This one must be loaded
 
-          @ import $plugin.$ivy.`org.spire-math::kind-projector:0.6.3`
+        @ import $plugin.$ivy.`org.spire-math::kind-projector:0.6.3`
 
-          @ trait TC[F[_]]
-          defined trait TC
+        @ trait TC[F[_]]
+        defined trait TC
 
-          @ type TCEitherStr = TC[Either[String, ?]]
-          defined type TCEitherStr
+        @ type TCEitherStr = TC[Either[String, ?]]
+        defined type TCEitherStr
 
-          @ // Useless - does not add plugins, and ignored by eval class loader
+        @ // Useless - does not add plugins, and ignored by eval class loader
 
-          @ import $plugin.$ivy.`com.lihaoyi::scalatags:0.4.5`
+        @ import $plugin.$ivy.`com.lihaoyi::scalatags:0.4.5`
 
-          @ import scalatags.Text
-          error: not found: value scalatags
-        """)
-      }
+        @ import scalatags.Text
+        error: not found: value scalatags
+      """)
     }
     'replApiUniqueness{
       // Make sure we can instantiate multiple copies of Interpreter, with each

--- a/amm/src/test/scala/ammonite/session/BuiltinTests.scala
+++ b/amm/src/test/scala/ammonite/session/BuiltinTests.scala
@@ -1,7 +1,6 @@
 package ammonite.session
 
 import ammonite.TestRepl
-import ammonite.util.Util.windowsPlatform
 import utest._
 
 import scala.collection.{immutable => imm}
@@ -55,24 +54,22 @@ object BuiltinTests extends TestSuite{
     }
 
     'loadCP{
-      if(!windowsPlatform){
-        check.session("""
-          @ import ammonite.ops._, ImplicitWd._
+      check.session("""
+        @ import ammonite.ops._, ImplicitWd._
 
-          @ val javaSrc = cwd/'amm/'src/'test/'resources/'loadable/'hello/"Hello.java"
+        @ val javaSrc = cwd/'amm/'src/'test/'resources/'loadable/'hello/"Hello.java"
 
-          @ mkdir! cwd/'target/'loadCP/'hello
+        @ mkdir! cwd/'target/'loadCP/'hello
 
-          @ cp.over(javaSrc, cwd/'target/'loadCP/'hello/"Hello.java")
+        @ cp.over(javaSrc, cwd/'target/'loadCP/'hello/"Hello.java")
 
-          @ %javac 'target/'loadCP/'hello/"Hello.java"  //This line causes problems in windows
+        @ %javac 'target/'loadCP/'hello/"Hello.java"  //This line causes problems in windows
 
-          @ import $cp.target.loadCP  //This line causes problems in windows
+        @ import $cp.target.loadCP  //This line causes problems in windows
 
-          @ hello.Hello.hello()
-          res6: String = "Hello!"
-        """)
-      }
+        @ hello.Hello.hello()
+        res6: String = "Hello!"
+      """)
     }
     'settings{
       val fruitlessTypeTestWarningMessageBlahBlahBlah =
@@ -131,46 +128,44 @@ object BuiltinTests extends TestSuite{
 
 
     'saveLoad {
-      if(!windowsPlatform){
-        check.session(
-          """
-          @ val veryImportant = 1
-          veryImportant: Int = 1
+      check.session(
+        """
+        @ val veryImportant = 1
+        veryImportant: Int = 1
 
-          @ sess.save()
+        @ sess.save()
 
-          @ val oopsDontWantThis = 2
-          oopsDontWantThis: Int = 2
+        @ val oopsDontWantThis = 2
+        oopsDontWantThis: Int = 2
 
-          @ // Let's try this new cool new library
+        @ // Let's try this new cool new library
 
-          @ import $ivy.`com.lihaoyi::scalatags:0.5.3`
+        @ import $ivy.`com.lihaoyi::scalatags:0.5.3`
 
-          @ veryImportant
-          res4: Int = 1
+        @ veryImportant
+        res4: Int = 1
 
-          @ oopsDontWantThis
-          res5: Int = 2
+        @ oopsDontWantThis
+        res5: Int = 2
 
-          @ import scalatags.Text.all._
+        @ import scalatags.Text.all._
 
-          @ div("Hello").render
-          res7: String = "<div>Hello</div>"
+        @ div("Hello").render
+        res7: String = "<div>Hello</div>"
 
-          @ // Oh no, maybe we don't want scalatags!
+        @ // Oh no, maybe we don't want scalatags!
 
-          @ sess.load()
+        @ sess.load()
 
-          @ veryImportant
-          res9: Int = 1
+        @ veryImportant
+        res9: Int = 1
 
-          @ oopsDontWantThis
-          error: not found: value oopsDontWantThis
+        @ oopsDontWantThis
+        error: not found: value oopsDontWantThis
 
-          @ import scalatags.Text.all._
-          error: not found: value scalatags
-          """)
-      }
+        @ import scalatags.Text.all._
+        error: not found: value scalatags
+        """)
     }
     'saveLoad2{
       check.session("""

--- a/amm/src/test/scala/ammonite/session/FailureTests.scala
+++ b/amm/src/test/scala/ammonite/session/FailureTests.scala
@@ -1,7 +1,6 @@
 package ammonite.session
 
 import ammonite.TestRepl
-import ammonite.util.Util.windowsPlatform
 import utest._
 
 import scala.collection.{immutable => imm}
@@ -45,12 +44,10 @@ object FailureTests extends TestSuite{
       """)
     }
     'ivyFail{
-      if(!windowsPlatform){
-        check.session("""
-          @ import $ivy.`com.lihaoyi::upickle:0.1.12312-DOESNT-EXIST`
-          error: failed to resolve ivy dependencies
-        """)
-      }
+      check.session("""
+        @ import $ivy.`com.lihaoyi::upickle:0.1.12312-DOESNT-EXIST`
+        error: failed to resolve ivy dependencies
+      """)
     }
 
     'exceptionHandling{

--- a/amm/src/test/scala/ammonite/session/ImportHookTests.scala
+++ b/amm/src/test/scala/ammonite/session/ImportHookTests.scala
@@ -71,81 +71,70 @@ object ImportHookTests extends TestSuite{
       }
       'ivy{
         'basic - {
-          if(!Util.windowsPlatform){
-            check.session("""
-              @ import scalatags.Text.all._
-              error: not found: value scalatags
+          check.session("""
+            @ import scalatags.Text.all._
+            error: not found: value scalatags
 
-              @ import $ivy.`com.lihaoyi::scalatags:0.5.3`
+            @ import $ivy.`com.lihaoyi::scalatags:0.5.3`
 
-              @ import scalatags.Text.all._
+            @ import scalatags.Text.all._
 
-              @ div("Hello").render
-              res2: String = "<div>Hello</div>"
-             """)
-          }
+            @ div("Hello").render
+            res2: String = "<div>Hello</div>"
+           """)
         }
 
         'explicitBinaryVersion - {
-          if(!Util.windowsPlatform){
-            check.session(s"""
-              @ import scalatags.Text.all._
-              error: not found: value scalatags
+          check.session(s"""
+            @ import scalatags.Text.all._
+            error: not found: value scalatags
 
-              @ import $$ivy.`com.lihaoyi:scalatags_${IvyThing.scalaBinaryVersion}:0.5.3`
+            @ import $$ivy.`com.lihaoyi:scalatags_${IvyThing.scalaBinaryVersion}:0.5.3`
 
-              @ import scalatags.Text.all._
+            @ import scalatags.Text.all._
 
-              @ div("Hello").render
-              res2: String = "<div>Hello</div>"
-             """)
-          }
+            @ div("Hello").render
+            res2: String = "<div>Hello</div>"
+           """)
         }
 
         'inline - {
-          if(!Util.windowsPlatform){
-            check.session("""
-              @ import scalatags.Text.all._
-              error: not found: value scalatags
+          check.session("""
+            @ import scalatags.Text.all._
+            error: not found: value scalatags
 
-              @ import $ivy.`com.lihaoyi::scalatags:0.5.3`, scalatags.Text.all._
+            @ import $ivy.`com.lihaoyi::scalatags:0.5.3`, scalatags.Text.all._
 
-              @ div("Hello").render
-              res1: String = "<div>Hello</div>"
-             """)
-          }
+            @ div("Hello").render
+            res1: String = "<div>Hello</div>"
+           """)
         }
       }
       'url{
         val scriptUrl =
           "https://raw.githubusercontent.com/lihaoyi/Ammonite/" +
           "master/amm/src/test/resources/scripts/Annotation.sc"
-        //has some problem with path on windows most prolly windows can't handle `$` in path
         'basic - {
-          if (!Util.windowsPlatform) {
-            check.session(s"""
-            @ import $$url.`$scriptUrl`
-            error: $$url import failed
+          check.session(s"""
+          @ import $$url.`$scriptUrl`
+          error: $$url import failed
 
-            @ import $$url.{`$scriptUrl` => remote}
+          @ import $$url.{`$scriptUrl` => remote}
 
-            @ remote.product(1, List(2, 3, 4))
-            res1: Int = 24
-          """)
-          }
+          @ remote.product(1, List(2, 3, 4))
+          res1: Int = 24
+        """)
         }
         'inline - {
-          if (!Util.windowsPlatform) {
-            check.session(s"""
-            @ import $$url.`$scriptUrl`
-            error: $$url import failed
+          check.session(s"""
+          @ import $$url.`$scriptUrl`
+          error: $$url import failed
 
-            @ import $$url.{`$scriptUrl` => remote}; val x = remote.product(1, List(2, 3, 4))
+          @ import $$url.{`$scriptUrl` => remote}; val x = remote.product(1, List(2, 3, 4))
 
-            @ x
-            res1: Int = 24
-          """)
-          }
+          @ x
+          res1: Int = 24
+        """)
         }
       }
     }
@@ -165,14 +154,12 @@ object ImportHookTests extends TestSuite{
        """)
 
       'ivy - {
-        if(!Util.windowsPlatform){
-          check.session("""
-            @ import $file.amm.src.test.resources.importHooks.IvyImport
+        check.session("""
+          @ import $file.amm.src.test.resources.importHooks.IvyImport
 
-            @ IvyImport.rendered
-            res1: String = "<div>Moo</div>"
-           """)
-        }
+          @ IvyImport.rendered
+          res1: String = "<div>Moo</div>"
+         """)
       }
 
       'deepImport - check.session("""

--- a/amm/src/test/scala/ammonite/session/ProjectTests.scala
+++ b/amm/src/test/scala/ammonite/session/ProjectTests.scala
@@ -2,7 +2,6 @@ package ammonite.session
 
 import ammonite.TestRepl
 import ammonite.TestUtils._
-import ammonite.util.Util.windowsPlatform
 import utest._
 
 import scala.collection.{immutable => imm}
@@ -14,30 +13,27 @@ object ProjectTests extends TestSuite{
     'load {
       'ivy {
         'standalone - {
-          if (!windowsPlatform) {
-            retry(3) {
-              // ivy or maven central are flaky =/
-              val tq = "\"\"\""
-              check.session(
-                s"""
-            @ import scalatags.Text.all._
-            error: not found: value scalatags
+          retry(3) {
+            // ivy or maven central are flaky =/
+            val tq = "\"\"\""
+            check.session(
+              s"""
+          @ import scalatags.Text.all._
+          error: not found: value scalatags
 
-            @ import $$ivy.`com.lihaoyi::scalatags:0.5.4`
+          @ import $$ivy.`com.lihaoyi::scalatags:0.5.4`
 
-            @ import scalatags.Text.all._
-            import scalatags.Text.all._
+          @ import scalatags.Text.all._
+          import scalatags.Text.all._
 
-            @ a("omg", href:="www.google.com").render
-            res2: String = $tq
-            <a href="www.google.com">omg</a>
-            $tq
-          """)
-            }
+          @ a("omg", href:="www.google.com").render
+          res2: String = $tq
+          <a href="www.google.com">omg</a>
+          $tq
+        """)
           }
         }
         'akkahttp{
-          if (!windowsPlatform) {
             check.session(
               """
               @ import $ivy.`com.typesafe.akka::akka-http-experimental:1.0-M3`
@@ -72,32 +68,29 @@ object ProjectTests extends TestSuite{
 
               @ system.shutdown()
              """)
-          }
         }
         'resolvers - {
-          if(!windowsPlatform){
-            retry(2){
-              // ivy flakyness...
-              check.session("""
-                @ import $ivy.`com.ambiata::mundane:1.2.1-20141230225616-50fc792`
-                error: IvyResolutionException
+          retry(2){
+            // ivy flakyness...
+            check.session("""
+              @ import $ivy.`com.ambiata::mundane:1.2.1-20141230225616-50fc792`
+              error: IvyResolutionException
 
-                @ import ammonite._, Resolvers._
+              @ import ammonite._, Resolvers._
 
-                @ val oss = Resolver.Http(
-                @   "ambiata-oss",
-                @   "https://ambiata-oss.s3-ap-southeast-2.amazonaws.com",
-                @   IvyPattern,
-                @   false
-                @ )
+              @ val oss = Resolver.Http(
+              @   "ambiata-oss",
+              @   "https://ambiata-oss.s3-ap-southeast-2.amazonaws.com",
+              @   IvyPattern,
+              @   false
+              @ )
 
-                @ resolvers() = resolvers() :+ oss
+              @ resolvers() = resolvers() :+ oss
 
-                @ import $ivy.`com.ambiata::mundane:1.2.1-20141230225616-50fc792`
+              @ import $ivy.`com.ambiata::mundane:1.2.1-20141230225616-50fc792`
 
-                @ import com.ambiata.mundane._
-              """)
-            }
+              @ import com.ambiata.mundane._
+            """)
           }
         }
       }
@@ -113,64 +106,56 @@ object ProjectTests extends TestSuite{
 
     'shapeless {
       // Shapeless 2.1.0 isn't published for scala 2.10
-      if (!windowsPlatform) {
-        if (!scala2_10) check.session("""
-          @ import $ivy.`com.chuusai::shapeless:2.2.5`, shapeless._
+      if (!scala2_10) check.session("""
+        @ import $ivy.`com.chuusai::shapeless:2.2.5`, shapeless._
 
-          @ (1 :: "lol" :: List(1, 2, 3) :: HNil)
-          res1: Int :: String :: List[Int] :: HNil = 1 :: lol :: List(1, 2, 3) :: HNil
+        @ (1 :: "lol" :: List(1, 2, 3) :: HNil)
+        res1: Int :: String :: List[Int] :: HNil = 1 :: lol :: List(1, 2, 3) :: HNil
 
-          @ res1(1)
-          res2: String = "lol"
+        @ res1(1)
+        res2: String = "lol"
 
-          @ import shapeless.syntax.singleton._
+        @ import shapeless.syntax.singleton._
 
-          @ 2.narrow
-          res4: 2 = 2
-        """)
-      }
+        @ 2.narrow
+        res4: 2 = 2
+      """)
     }
 
     'scalaz{
-      if(!windowsPlatform) {
-        check.session("""
-          @ import $ivy.`org.scalaz::scalaz-core:7.1.1`, scalaz._, Scalaz._
+      check.session("""
+        @ import $ivy.`org.scalaz::scalaz-core:7.1.1`, scalaz._, Scalaz._
 
-          @ (Option(1) |@| Option(2))(_ + _)
-          res1: Option[Int] = Some(3)
-        """)
-      }
+        @ (Option(1) |@| Option(2))(_ + _)
+        res1: Option[Int] = Some(3)
+      """)
     }
     'guava{
-      if(!windowsPlatform){
-        check.session("""
-          @ import $ivy.`com.google.guava:guava:18.0`, com.google.common.collect._
+      check.session("""
+        @ import $ivy.`com.google.guava:guava:18.0`, com.google.common.collect._
 
-          @ val bimap = ImmutableBiMap.of(1, "one", 2, "two", 3, "three")
+        @ val bimap = ImmutableBiMap.of(1, "one", 2, "two", 3, "three")
 
-          @ bimap.get(1)
-          res2: String = "one"
+        @ bimap.get(1)
+        res2: String = "one"
 
-          @ bimap.inverse.get("two")
-          res3: Int = 2
-        """)
-      }
+        @ bimap.inverse.get("two")
+        res3: Int = 2
+      """)
     }
     'resources{
-      if (!windowsPlatform) {
-        check.session("""
-          @ import ammonite.ops._
+      check.session("""
+        @ import ammonite.ops._
 
-          @ val path = resource/'org/'apache/'jackrabbit/'oak/'plugins/'blob/"blobstore.properties"
+        @ val path = resource/'org/'apache/'jackrabbit/'oak/'plugins/'blob/"blobstore.properties"
 
-          @ read! path
-          error: ResourceNotFoundException
+        @ read! path
+        error: ResourceNotFoundException
 
-          @ import $ivy.`org.apache.jackrabbit:oak-core:1.3.16`
+        @ import $ivy.`org.apache.jackrabbit:oak-core:1.3.16`
 
-          @ read! path // Should work now
-        """)
-      }
+        @ read! path // Should work now
+      """)
     }
     'scalaparse{
       // For some reason this blows up in 2.11.x
@@ -193,115 +178,111 @@ object ProjectTests extends TestSuite{
 
     'finagle{
       // Prevent regressions when wildcard-importing things called `macro` or `_`
-      if (!windowsPlatform) {
-        check.session("""
-          @ import $ivy.`com.twitter::finagle-httpx:6.26.0`
+      check.session("""
+        @ import $ivy.`com.twitter::finagle-httpx:6.26.0`
 
-          @ import com.twitter.finagle._, com.twitter.util._
+        @ import com.twitter.finagle._, com.twitter.util._
 
-          @ var serverCount = 0
+        @ var serverCount = 0
 
-          @ var clientResponse = 0
+        @ var clientResponse = 0
 
-          @ val service = new Service[httpx.Request, httpx.Response] {
-          @   def apply(req: httpx.Request): Future[httpx.Response] = {
-          @     serverCount += 1
-          @     Future.value(
-          @       httpx.Response(req.version, httpx.Status.Ok)
-          @     )
-          @   }
-          @ }
+        @ val service = new Service[httpx.Request, httpx.Response] {
+        @   def apply(req: httpx.Request): Future[httpx.Response] = {
+        @     serverCount += 1
+        @     Future.value(
+        @       httpx.Response(req.version, httpx.Status.Ok)
+        @     )
+        @   }
+        @ }
 
-          @ val server = Httpx.serve(":8080", service)
+        @ val server = Httpx.serve(":8080", service)
 
-          @ val client: Service[httpx.Request, httpx.Response] = Httpx.newService(":8080")
+        @ val client: Service[httpx.Request, httpx.Response] = Httpx.newService(":8080")
 
-          @ val request = httpx.Request(httpx.Method.Get, "/")
+        @ val request = httpx.Request(httpx.Method.Get, "/")
 
-          @ request.host = "www.scala-lang.org"
+        @ request.host = "www.scala-lang.org"
 
-          @ val response: Future[httpx.Response] = client(request)
+        @ val response: Future[httpx.Response] = client(request)
 
-          @ response.onSuccess { resp: httpx.Response =>
-          @   clientResponse = resp.getStatusCode
-          @ }
+        @ response.onSuccess { resp: httpx.Response =>
+        @   clientResponse = resp.getStatusCode
+        @ }
 
-          @ Await.ready(response)
+        @ Await.ready(response)
 
-          @ serverCount
-          res12: Int = 1
+        @ serverCount
+        res12: Int = 1
 
-          @ clientResponse
-          res13: Int = 200
+        @ clientResponse
+        res13: Int = 200
 
-          @ server.close()
-        """)
-      }
+        @ server.close()
+      """)
     }
     'spire{
       // Prevent regressions when wildcard-importing things called `macro` or `_`
-      if (!windowsPlatform) {
-        if (!scala2_10) //buggy in 2.10
-          check.session(s"""
-            @ import $$ivy.`org.spire-math::spire:0.11.0`
+      if (!scala2_10) //buggy in 2.10
+        check.session(s"""
+          @ import $$ivy.`org.spire-math::spire:0.11.0`
 
-            @ import spire.implicits._
+          @ import spire.implicits._
 
-            @ import spire.math._
+          @ import spire.math._
 
-            @ def euclidGcd[A: Integral](x: A, y: A): A = {
-            @   if (y == 0) x
-            @   else euclidGcd(y, x % y)
-            @ }
+          @ def euclidGcd[A: Integral](x: A, y: A): A = {
+          @   if (y == 0) x
+          @   else euclidGcd(y, x % y)
+          @ }
 
-            @ euclidGcd(42, 96)
-            res4: Int = 6
+          @ euclidGcd(42, 96)
+          res4: Int = 6
 
-            @ euclidGcd(42L, 96L)
-            res5: Long = 6L
+          @ euclidGcd(42L, 96L)
+          res5: Long = 6L
 
-            @ euclidGcd(BigInt(42), BigInt(96))
-            res6: BigInt = 6
+          @ euclidGcd(BigInt(42), BigInt(96))
+          res6: BigInt = 6
 
-            @ def mean[A: Fractional](xs: A*): A = xs.reduceLeft(_ + _) / xs.size
+          @ def mean[A: Fractional](xs: A*): A = xs.reduceLeft(_ + _) / xs.size
 
-            @ mean(0.5, 1.5, 0.0, -0.5)
-            res8: Double = 0.375
+          @ mean(0.5, 1.5, 0.0, -0.5)
+          res8: Double = 0.375
 
-            @ Interval(0, 10)
-            res9: Interval[Int] = [0, 10]
-          """)
-        else
-          check.session(s"""
-            @ import $$ivy.`org.spire-math::spire:0.11.0`
+          @ Interval(0, 10)
+          res9: Interval[Int] = [0, 10]
+        """)
+      else
+        check.session(s"""
+          @ import $$ivy.`org.spire-math::spire:0.11.0`
 
-            @ import spire.implicits._
+          @ import spire.implicits._
 
-            @ import spire.math._
+          @ import spire.math._
 
-            @ def euclidGcd[A: Integral](x: A, y: A): A = {
-            @   if (y == 0) x
-            @   else euclidGcd(y, x % y)
-            @ }
+          @ def euclidGcd[A: Integral](x: A, y: A): A = {
+          @   if (y == 0) x
+          @   else euclidGcd(y, x % y)
+          @ }
 
-            @ euclidGcd(42, 96)
-            res4: Int = 6
+          @ euclidGcd(42, 96)
+          res4: Int = 6
 
-            @ euclidGcd(42L, 96L)
-            res5: Long = 6L
+          @ euclidGcd(42L, 96L)
+          res5: Long = 6L
 
-            @ euclidGcd(BigInt(42), BigInt(96))
-            res6: math.BigInt = 6
+          @ euclidGcd(BigInt(42), BigInt(96))
+          res6: math.BigInt = 6
 
-            @ def mean[A: Fractional](xs: A*): A = xs.reduceLeft(_ + _) / xs.size
+          @ def mean[A: Fractional](xs: A*): A = xs.reduceLeft(_ + _) / xs.size
 
-            @ mean(0.5, 1.5, 0.0, -0.5)
-            res8: Double = 0.375
+          @ mean(0.5, 1.5, 0.0, -0.5)
+          res8: Double = 0.375
 
-            @ Interval(0, 10)
-            res9: spire.math.Interval[Int] = [0, 10]
-          """)
-      }
+          @ Interval(0, 10)
+          res9: spire.math.Interval[Int] = [0, 10]
+        """)
 
       // This fella is misbehaving but I can't figure out why :/
       //

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,11 @@
 # Adapted from https://github.com/sbt/sbt-native-packager/blob/master/appveyor.yml
 version: '{build}'
 os: Windows Server 2012
+
+#  To make the extended ascii characters work on Windows
+#  we need to set string encoding for jvm to utf-8 on windows
+environment:
+        JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8
 install:
   - ps: |
       Add-Type -AssemblyName System.IO.Compression.FileSystem
@@ -25,5 +30,5 @@ test_script:
 #  - sbt ++2.10.6 ops/test
 cache:
   - C:\sbt\
-  - C:\Users\appveyor\.ivy2
+  - C:\Users\appveyor\.ivy2 -> appveyor.yml
   - C:\Users\appveyor\.sbt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,5 +30,6 @@ test_script:
 #  - sbt ++2.10.6 ops/test
 cache:
   - C:\sbt\
+  # Just to make sure ivy cache is updated 'cause otherwise few tests misbehave
   - C:\Users\appveyor\.ivy2 -> appveyor.yml
   - C:\Users\appveyor\.sbt

--- a/integration/src/test/scala/ammonite/integration/BasicTests.scala
+++ b/integration/src/test/scala/ammonite/integration/BasicTests.scala
@@ -33,39 +33,33 @@ object BasicTests extends TestSuite{
     'linuxOnlyTests {
 
       'complex {
-        if (!Util.windowsPlatform) {
-          val evaled = exec('basic / "Complex.sc")
-          assert(evaled.out.trim.contains("Spire Interval [0, 10]"))
-        }
+        val evaled = exec('basic / "Complex.sc")
+        assert(evaled.out.trim.contains("Spire Interval [0, 10]"))
       }
 
 
       'shell {
         // make sure you can load the example-predef.sc, have it pull stuff in
         // from ivy, and make use of `cd!` and `wd` inside the executed script.
-        if (!Util.windowsPlatform) {
-          val res = %% bash(
-            executable,
-            "--predef-file",
-            exampleBarePredef,
-            "-c",
-            """val x = wd
-            |@
-            |cd! 'amm/'src
-            |@
-            |println(wd relativeTo x)""".stripMargin
-          )
+        val res = %% bash(
+          executable,
+          "--predef-file",
+          exampleBarePredef,
+          "-c",
+          """val x = wd
+          |@
+          |cd! 'amm/'src
+          |@
+          |println(wd relativeTo x)""".stripMargin
+        )
 
-          val output = res.out.trim
-          assert(output == "amm/src")
-        }
+        val output = res.out.trim
+        assert(output == "amm/src")
       }
 
       'classloaders{
-        if (!Util.windowsPlatform) {
-          val evaled = exec('basic / "Resources.sc")
-          assert(evaled.out.string.contains("1745"))
-        }
+        val evaled = exec('basic / "Resources.sc")
+        assert(evaled.out.string.contains("1745"))
       }
 
       'playframework- {

--- a/integration/src/test/scala/ammonite/integration/ErrorTruncationTests.scala
+++ b/integration/src/test/scala/ammonite/integration/ErrorTruncationTests.scala
@@ -18,7 +18,9 @@ object ErrorTruncationTests extends TestSuite{
     val e = fansi.Str(
       intercept[ShelloutException]{ exec(file) }.result.err.string
     ).plainText
-    assert(e == expected)
+    //This string gets included on windows due to environment variable set additionally
+    val extraStringOnWindows = "Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8\n"
+    assert(e.replace(extraStringOnWindows, "") == expected)
   }
   val tests = TestSuite {
 


### PR DESCRIPTION
Major Changes:
1) To make the extended ascii character things defined in `scalaz` and similar other problems with `shapeless` we need to set encoding to `utf-8` on windows, for which I have set environment var on appveyor     `JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8`

2) There are no other major changes except one liners like 

```
private def jarSignature(url: URL) = {
-    val path = Path(url.getFile, root)
+    val path = Path(file.Paths.get(url.toURI()).toFile(), root)
```

3) Few ivy tests are behaving unusual on appveyor but thats just caching problem so I have made `appveyor.yml` itself a dependency for `.ivy2` cache so any major change in appveyor will redownload ivy. Though I am not sure if this change should merge into master.
4) I have introduced a `sanitizePath` function in `Util.scala` to remove windows or linux restricted chars from file names and replace them by `$foo`.
5) Rest is just uncommenting `if(!Util.windowsPlatform)` guard etc.