### PR TITLE
Make sure scripts with symbols in path name work

### DIFF
--- a/amm/src/main/scala/ammonite/interp/Interpreter.scala
+++ b/amm/src/main/scala/ammonite/interp/Interpreter.scala
@@ -547,7 +547,7 @@ class Interpreter(prompt0: Ref[String],
               scriptImports ++ last,
               last,
               wrapperIndex + 1,
-              (ev.wrapper.map(_.backticked).mkString("."), ev.tag) :: compiledData
+              (ev.wrapper.map(_.encoded).mkString("."), ev.tag) :: compiledData
             )
           case Res.Skip => loop(
             blocks.tail,

--- a/integration/src/test/scala/ammonite/integration/BasicTests.scala
+++ b/integration/src/test/scala/ammonite/integration/BasicTests.scala
@@ -25,6 +25,33 @@ object BasicTests extends TestSuite{
       assert(evaled.out.trim == "Hello World")
     }
 
+    //make sure scripts with symbols in path names work fine
+    'scriptWithSymbols {
+      if (!Util.windowsPlatform){
+        val dirAddr =
+          cwd/'target/'test/'resources/'ammonite/'integration/'basic
+        val weirdScriptName = "script%#.@*+叉燒.sc"
+        val scriptAddr = dirAddr/weirdScriptName
+        rm(scriptAddr)
+        write(scriptAddr, """println("Script Worked!!")""")
+        val evaled = %%bash(
+          executable,
+          scriptAddr
+          )
+        assert(evaled.out.trim == "Script Worked!!" && evaled.err.string.isEmpty)
+      }
+    }
+
+    'scriptInSomeOtherDir{
+      val scriptAddr = tmp.dir()/"script.sc"
+      rm(scriptAddr)
+      write(scriptAddr, """println("Worked!!")""")
+      val evaled = %% bash(
+        executable,
+        scriptAddr
+        )
+      assert(evaled.out.trim == "Worked!!" && evaled.err.string.isEmpty)
+    }
 
     'complex {
       val evaled = exec('basic / "Complex.sc")


### PR DESCRIPTION
This PR is intended as a patch for https://github.com/lihaoyi/Ammonite/issues/418.
Before this PR any script having special chars in path name fails because while loadingClasses wrapperNames are encoded whereas while findClass is given non-encoded Name as argument. 
This PR fixes this issue.