### PR TITLE
Make scripts without extension throw correct exceptions

### DIFF
--- a/amm/src/main/scala/ammonite/util/Util.scala
+++ b/amm/src/main/scala/ammonite/util/Util.scala
@@ -19,7 +19,10 @@ object Util{
       val rest = relPath.segments
       (base ++ ups ++ rest).map(Name(_))
     }
-    val wrapper = path.last.take(path.last.lastIndexOf('.'))
+    val wrapper = path.last.lastIndexOf('.') match{
+      case -1 => path.last
+      case i => path.last.take(i)
+    }
     (pkg, Name(wrapper))
   }
   def md5Hash(data: Iterator[Array[Byte]]) = {

--- a/amm/src/test/scala/ammonite/CachingTests.scala
+++ b/amm/src/test/scala/ammonite/CachingTests.scala
@@ -4,7 +4,7 @@ import ammonite.interp.{History, Interpreter, Storage}
 import ammonite.main.Defaults
 import ammonite.ops._
 import ammonite.tools.IvyConstructor._
-import ammonite.util.{Colors, Printer, Ref, Util}
+import ammonite.TestUtils._
 import utest._
 
 object CachingTests extends TestSuite{
@@ -16,19 +16,6 @@ object CachingTests extends TestSuite{
     val resourcesPath = cwd/'amm/'src/'test/'resources
 
 
-    def createTestInterp(storage: Storage, predef: String = "") = new Interpreter(
-      Ref[String](""),
-      Ref(null),
-      80,
-      80,
-      Ref(Colors.BlackWhite),
-      printer = Printer(_ => (), _ => (), _ => (), _ => ()),
-      storage = storage,
-      new History(Vector()),
-      predef = predef,
-      wd = ammonite.ops.cwd,
-      replArgs = Seq()
-    )
     val tempDir = tmp.dir(prefix="ammonite-tester")
     'noAutoIncrementWrapper{
       val storage = Storage.InMemory()

--- a/amm/src/test/scala/ammonite/ScriptTests.scala
+++ b/amm/src/test/scala/ammonite/ScriptTests.scala
@@ -1,8 +1,10 @@
 package ammonite
 
-import ammonite.TestUtils.scala2_10
+import ammonite.TestUtils._
 import ammonite.ops._
+import ammonite.main.Defaults
 import utest._
+import ammonite.interp.{Storage}
 
 object ScriptTests extends TestSuite{
   val tests = TestSuite{
@@ -251,6 +253,17 @@ object ScriptTests extends TestSuite{
             error: java.nio.file.NoSuchFileException
             """
           )
+        }
+        'scriptWithoutExtension{
+          val res = intercept[java.nio.file.NoSuchFileException]{
+            val storage = new Storage.Folder(tmp.dir(prefix="ammonite-tester"))
+            val interp2 = createTestInterp(
+              storage,
+              Defaults.predefString
+            )
+            interp2.replApi.load.module(cwd/"scriptWithoutExtension")
+          }.toString
+          assert(res.contains("java.nio.file.NoSuchFileException"))
         }
         'multiBlockError{
           check.session(s"""

--- a/amm/src/test/scala/ammonite/TestUtils.scala
+++ b/amm/src/test/scala/ammonite/TestUtils.scala
@@ -1,6 +1,23 @@
 package ammonite
 
+import ammonite.interp.{History, Interpreter, Storage}
+import ammonite.util.{Colors, Printer, Ref, Util}
+
 object TestUtils {
   val sessionPrefix = if (scala2_10) "$sess." else ""
   def scala2_10 = scala.util.Properties.versionNumberString.contains("2.10")
+
+  def createTestInterp(storage: Storage, predef: String = "") = new Interpreter(
+    Ref[String](""),
+    Ref(null),
+    80,
+    80,
+    Ref(Colors.BlackWhite),
+    printer = Printer(_ => (), _ => (), _ => (), _ => ()),
+    storage = storage,
+    new History(Vector()),
+    predef = predef,
+    wd = ammonite.ops.cwd,
+    replArgs = Seq()
+  )
 }

--- a/readme/Footer.scalatex
+++ b/readme/Footer.scalatex
@@ -812,4 +812,7 @@
           Running scripts outside the current working directory tree, as well as
           scripts with non-alphanumeric symbols in their file path, now works
           thanks to @lnk("coderabhishek", "https://github.com/coderabhishek")
+        @li
+          Scripts without the `.sc` can now be run directly from the command line
+          rather than throwing an `IndexOutOfBoundsException`.
 


### PR DESCRIPTION
This patch is a fix for https://github.com/lihaoyi/Ammonite/issues/417.
It avoids the case where `pathToPackage` throws unwanted exception when it can not find '.' in file name.