### PR TITLE
`-s` cmd line switch makes ivy logs silent though failures will still be thrown as exception

### DIFF
--- a/amm/interp/src/main/scala/ammonite/runtime/Interpreter.scala
+++ b/amm/interp/src/main/scala/ammonite/runtime/Interpreter.scala
@@ -32,7 +32,8 @@ class Interpreter(val printer: Printer,
                   // running, so you can use them predef to e.g. configure
                   // the REPL before it starts
                   extraBridges: Interpreter => Seq[(String, String, AnyRef)],
-                  val wd: Path)
+                  val wd: Path,
+                  verboseIvy: Boolean = true)
   extends ImportHook.InterpreterInterface{ interp =>
 
 
@@ -571,7 +572,11 @@ class Interpreter(val printer: Printer,
     psOpt match{
       case Some(ps) => ps
       case None =>
-        val resolved = ammonite.runtime.tools.IvyThing(() => interpApi.resolvers()).resolveArtifact(
+        val resolved = ammonite.runtime.tools.IvyThing(
+          () => interpApi.resolvers(),
+          printer,
+          verboseIvy
+        ).resolveArtifact(
           groupId,
           artifactId,
           version,
@@ -588,7 +593,11 @@ class Interpreter(val printer: Printer,
   }
   abstract class DefaultLoadJar extends LoadJar {
 
-    lazy val ivyThing = ammonite.runtime.tools.IvyThing(() => interpApi.resolvers())
+    lazy val ivyThing = ammonite.runtime.tools.IvyThing(
+      () => interpApi.resolvers(),
+      printer,
+      verboseIvy
+    )
 
     def handleClasspath(jar: File): Unit
 

--- a/amm/src/main/scala/ammonite/Main.scala
+++ b/amm/src/main/scala/ammonite/Main.scala
@@ -49,7 +49,9 @@ case class Main(predef: String = "",
                 welcomeBanner: Option[String] = Some(Defaults.welcomeBanner),
                 inputStream: InputStream = System.in,
                 outputStream: OutputStream = System.out,
-                errorStream: OutputStream = System.err){
+                errorStream: OutputStream = System.err,
+                verboseIvy: Boolean = true
+               ){
   /**
     * Instantiates an ammonite.Repl using the configuration
     */
@@ -96,7 +98,8 @@ case class Main(predef: String = "",
           )
           Seq(("ammonite.repl.ReplBridge", "repl", replApi))
         },
-      wd
+      wd,
+      verboseIvy
     )
     interp
   }
@@ -136,6 +139,7 @@ object Main{
   def main(args0: Array[String]) = {
     var fileToExecute: Option[Path] = None
     var codeToExecute: Option[String] = None
+    var verboseIvy: Boolean = true
     var ammoniteHome: Option[Path] = None
     var passThroughArgs: Seq[String] = Vector.empty
     var predefFile: Option[Path] = None
@@ -185,6 +189,11 @@ object Main{
             |since it lets you hook up a profiler to the long-lived process and
             |see where all the time is being spent.
           """.stripMargin)
+      opt[Unit]('s', "silent")
+        .foreach(x => verboseIvy = false)
+        .text(
+          "Make ivy logs go silent instead of printing though failures will still throw exception"
+        )
       opt[Unit]("repl-api")
         .foreach(x => replApi= true)
         .text(
@@ -226,7 +235,8 @@ object Main{
             case None => super.predef
             case Some(pf) => pf
           }
-        }
+        },
+        verboseIvy = verboseIvy
       )
       (fileToExecute, codeToExecute) match {
         case (None, None) => println("Loading..."); main(true).run()

--- a/integration/src/test/resources/ammonite/integration/basic/scalaTags.sc
+++ b/integration/src/test/resources/ammonite/integration/basic/scalaTags.sc
@@ -1,0 +1,6 @@
+interp.load.ivy("com.lihaoyi" %% "scalatags" % "0.4.5")
+@
+import scalatags.Text.all._
+val res = a("omg", href:="www.google.com").render
+
+println(res)

--- a/integration/src/test/resources/ammonite/integration/basic/wrongIvyCordinates.sc
+++ b/integration/src/test/resources/ammonite/integration/basic/wrongIvyCordinates.sc
@@ -1,0 +1,2 @@
+interp.load.ivy("com.lihaoyi" %% "somethingWhichDoesNotExist" % "0.4.5")
+

--- a/integration/src/test/scala/ammonite/integration/BasicTests.scala
+++ b/integration/src/test/scala/ammonite/integration/BasicTests.scala
@@ -122,6 +122,21 @@ object BasicTests extends TestSuite{
       val evaled = exec('basic / "Resources.sc")
       assert(evaled.out.string.contains("1745"))
     }
+    'testSilentIvy{
+      val evaled1 = exec('basic/"scalaTags.sc")
+      //check ivy is printing all the logs
+      assert(evaled1.err.string.contains("resolving dependencies"))
+      val evaled2 = exec('basic/"scalaTags.sc", "-s")
+      //make sure ivy is not printing logs as expected from `-s` flag
+      assert(!evaled2.err.string.contains("resolving dependencies"))
+    }
+    'testSilentIvyExceptions{
+      val errorMsg = intercept[ShelloutException]{
+        exec('basic/"wrongIvyCordinates.sc", "-s")
+      }.result.err.string
+
+      assert(errorMsg.contains("IvyThing$IvyResolutionException"))
+    }
 
     'playframework- {
       if (!Util.windowsPlatform) {


### PR DESCRIPTION

Following repl session shows use of this diff
passing `-s` flag will make the ivy logs silent, though failures will still be thrown as Exception.
```
abhishek@abhishek-Inspiron-3542:~/Ammonite$ ./a i.sc 
:: loading settings :: url = jar:file:/home/abhishek/Ammonite/a!/org/apache/ivy/core/settings/ivysettings.xml
:: resolving dependencies :: com.lihaoyi#scalatags_2.11-caller;working
	confs: [default]
	found com.lihaoyi#scalatags_2.11;0.4.5 in central
	found org.scala-lang#scala-library;2.11.4 in m2
	found com.lihaoyi#acyclic_2.11;0.1.2 in central
	found org.scala-lang#scala-compiler;2.11.0 in central
	found org.scala-lang#scala-reflect;2.11.0 in central
	found org.scala-lang.modules#scala-xml_2.11;1.0.1 in central
	found org.scala-lang.modules#scala-parser-combinators_2.11;1.0.1 in m2
<a href="www.google.com">omg</a>


abhishek@abhishek-Inspiron-3542:~/Ammonite$ rm ~/.ammonite/cache/ -rf 

abhishek@abhishek-Inspiron-3542:~/Ammonite$ ./a i.sc -s 
<a href="www.google.com">omg</a> 

abhishek@abhishek-Inspiron-3542:~/Ammonite$ rm ~/.ammonite/cache/ -rf 

abhishek@abhishek-Inspiron-3542:~/Ammonite$ cat i.sc
interp.load.ivy("com.lihaoyi" %% "scalatags" % "0.4.5")
@
import scalatags.Text.all._
val res = a("omg", href:="www.google.com").render

println(res)


abhishek@abhishek-Inspiron-3542:~/Ammonite$ ./a i.sc -s 
Exception in thread "main" ammonite.runtime.tools.IvyThing$IvyResolutionException: failed to resolve ivy dependencies unresolved dependency: com.ll#scalatags_2.11;0.4.5: not found
	at ammonite.runtime.tools.IvyThing.resolveArtifact(IvyThing.scala:113)
	at ammonite.runtime.Interpreter.loadIvy(Interpreter.scala:579)
	at ammonite.runtime.Interpreter$DefaultLoadJar.ivy(Interpreter.scala:609)
	at $file.i$.<init>(i.sc:1)
	at $file.i$.<clinit>(i.sc)
	at $file.i.$main(i.sc)

```

before this diff there was no option to make things go silent like in the second case in above repl session with -s flag