### PR TITLE
Make output silent with -s flag

### DIFF
--- a/amm/interp/src/main/scala/ammonite/runtime/Interpreter.scala
+++ b/amm/interp/src/main/scala/ammonite/runtime/Interpreter.scala
@@ -33,7 +33,7 @@ class Interpreter(val printer: Printer,
                   // the REPL before it starts
                   extraBridges: Interpreter => Seq[(String, String, AnyRef)],
                   val wd: Path,
-                  verboseIvy: Boolean = true)
+                  verboseOutput: Boolean = true)
   extends ImportHook.InterpreterInterface{ interp =>
 
 
@@ -365,6 +365,13 @@ class Interpreter(val printer: Printer,
       tag
     ) match {
       case None =>
+        (source, verboseOutput) match {
+          case (ImportHook.Source.File(fName), true) =>
+            printer.out("Compiling " + fName.last + "\n")
+          case (ImportHook.Source.URL(url), true) => 
+            printer.out("Compiling " + url + "\n")
+          case _ =>
+        }
         init()
         val res = processModule0(
           source, code, wrapperName, pkgName,
@@ -581,7 +588,7 @@ class Interpreter(val printer: Printer,
         val resolved = ammonite.runtime.tools.IvyThing(
           () => interpApi.resolvers(),
           printer,
-          verboseIvy
+          verboseOutput
         ).resolveArtifact(
           groupId,
           artifactId,
@@ -605,7 +612,7 @@ class Interpreter(val printer: Printer,
     lazy val ivyThing = ammonite.runtime.tools.IvyThing(
       () => interpApi.resolvers(),
       printer,
-      verboseIvy
+      verboseOutput
     )
 
     def handleClasspath(jar: File): Unit
@@ -708,7 +715,7 @@ object Interpreter{
     Name(wrapperName.raw + (if (wrapperIndex == 1) "" else "_" + wrapperIndex))
   }
 
-  def initPrinters(output: OutputStream, error: OutputStream) = {
+  def initPrinters(output: OutputStream, error: OutputStream, verboseOutput: Boolean) = {
     val colors = Ref[Colors](Colors.Default)
     val printStream = new PrintStream(output, true)
     val errorPrintStream = new PrintStream(error, true)

--- a/amm/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -25,7 +25,7 @@ class Repl(input: InputStream,
   var history = new History(Vector())
 
   val (colors, printStream, errorPrintStream, printer) =
-    Interpreter.initPrinters(output, error)
+    Interpreter.initPrinters(output, error, true)
 
 
 

--- a/amm/runtime/src/main/scala/ammonite/runtime/tools/IvyThing.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/tools/IvyThing.scala
@@ -30,7 +30,7 @@ trait IvyConstructor{
  *
  * And transliterated into Scala. I have no idea how or why it works.
  */
-case class IvyThing(resolvers: () => List[Resolver], printer: Printer, verboseIvy: Boolean) {
+case class IvyThing(resolvers: () => List[Resolver], printer: Printer, verboseOutput: Boolean) {
 
   case class IvyResolutionException(failed: Seq[String]) extends Exception(
     "failed to resolve ivy dependencies " + failed.mkString(", ")
@@ -41,7 +41,7 @@ case class IvyThing(resolvers: () => List[Resolver], printer: Printer, verboseIv
   Message.setDefaultLogger(new AbstractMessageLogger {
     def doEndProgress(msg: String) = Console.err.println("Done")
     def doProgress() = Console.err.print(".")
-    def log(msg: String, level: Int) =  if (level <= maxLevel) verboseIvy match {
+    def log(msg: String, level: Int) =  if (level <= maxLevel) verboseOutput match {
       case true => printer.info(msg)
       case false => silentIvyLogs += msg
     }

--- a/amm/src/main/scala/ammonite/Main.scala
+++ b/amm/src/main/scala/ammonite/Main.scala
@@ -50,7 +50,7 @@ case class Main(predef: String = "",
                 inputStream: InputStream = System.in,
                 outputStream: OutputStream = System.out,
                 errorStream: OutputStream = System.err,
-                verboseIvy: Boolean = true
+                verboseOutput: Boolean = true
                ){
   /**
     * Instantiates an ammonite.Repl using the configuration
@@ -72,7 +72,7 @@ case class Main(predef: String = "",
     val augmentedPredef = Main.maybeDefaultPredef(defaultPredef, Defaults.predefString)
 
     val (colors, printStream, errorPrintStream, printer) =
-      Interpreter.initPrinters(outputStream, errorStream)
+      Interpreter.initPrinters(outputStream, errorStream, verboseOutput)
 
 
     val interp: Interpreter = new Interpreter(
@@ -99,7 +99,7 @@ case class Main(predef: String = "",
           Seq(("ammonite.repl.ReplBridge", "repl", replApi))
         },
       wd,
-      verboseIvy
+      verboseOutput
     )
     interp
   }
@@ -139,7 +139,7 @@ object Main{
   def main(args0: Array[String]) = {
     var fileToExecute: Option[Path] = None
     var codeToExecute: Option[String] = None
-    var verboseIvy: Boolean = true
+    var verboseOutput: Boolean = true
     var ammoniteHome: Option[Path] = None
     var passThroughArgs: Seq[String] = Vector.empty
     var predefFile: Option[Path] = None
@@ -190,7 +190,7 @@ object Main{
             |see where all the time is being spent.
           """.stripMargin)
       opt[Unit]('s', "silent")
-        .foreach(x => verboseIvy = false)
+        .foreach(x => verboseOutput = false)
         .text(
           "Make ivy logs go silent instead of printing though failures will still throw exception"
         )
@@ -236,7 +236,7 @@ object Main{
             case Some(pf) => pf
           }
         },
-        verboseIvy = verboseIvy
+        verboseOutput = verboseOutput
       )
       (fileToExecute, codeToExecute) match {
         case (None, None) => println("Loading..."); main(true).run()

--- a/integration/src/test/resources/ammonite/integration/basic/Failure.sc
+++ b/integration/src/test/resources/ammonite/integration/basic/Failure.sc
@@ -1,0 +1,1 @@
+println(x)


### PR DESCRIPTION
Passing -s flag will make program output free from any noisy string not printed by the program itself eg. "Compiling ScriptName" printed when script is compiled instead of using from cache.

```
abhishek@abhishek-Inspiron-3542:~/Ammonite$ ./a i.sc
Compiling Main.sc
Compiling Main.sc
Compiling Main.sc
Compiling Main.sc
Compiling Main.sc
Compiling i.sc
Hello

abhishek@abhishek-Inspiron-3542:~/Ammonite$ 
```

```
abhishek@abhishek-Inspiron-3542:~/Ammonite$ rm ~/.ammonite/cache/ -rf
abhishek@abhishek-Inspiron-3542:~/Ammonite$ ./a i.sc -s
Hello

```

Besides this -s also makes ivy silent

