### PR TITLE
Fix compiler plugin instance duplication

### DIFF
--- a/amm/interp/src/main/scala/ammonite/runtime/Compiler.scala
+++ b/amm/interp/src/main/scala/ammonite/runtime/Compiler.scala
@@ -174,7 +174,12 @@ object Compiler{
           Console.err.println(s"Implementation $className of plugin $name not found.")
       }
 
-      plugins.collect{case (name, _, Some(cls)) => name -> cls }
+      /*
+       * If there's also a '-sources' jar for the plugin in the classpath,
+       * there will be >= 1 plugins registered which may cause cryptic error messages
+       * and break the REPL completely, so `.distinct` is called.
+       */
+      plugins.collect{case (name, _, Some(cls)) => name -> cls }.distinct
     }
 
     var errorLogger: String => Unit = s => ()

--- a/amm/src/test/scala/ammonite/session/AdvancedTests.scala
+++ b/amm/src/test/scala/ammonite/session/AdvancedTests.scala
@@ -290,6 +290,15 @@ object AdvancedTests extends TestSuite{
         @ assert(repl.prompt() == "B")
       """)
     }
+    'macroParadiseWorks{
+      val c1 = new TestRepl()
+      c1.session("""
+        @ interp.load.plugin.ivy("org.scalamacros" % "paradise_2.11.8" % "2.1.0")
+      """)
+      c1.session("""
+        @ val x = 1
+      """)
+    }
     'desugar{
       if (!scala2_10) check.session("""
         @ desugar{1 + 2 max 3}

--- a/amm/src/test/scala/ammonite/session/AdvancedTests.scala
+++ b/amm/src/test/scala/ammonite/session/AdvancedTests.scala
@@ -291,9 +291,10 @@ object AdvancedTests extends TestSuite{
       """)
     }
     'macroParadiseWorks{
-      val c1 = new TestRepl()
-      c1.session("""
-        @ interp.load.plugin.ivy("org.scalamacros" % "paradise_2.11.8" % "2.1.0")
+      val scalaVersion: String = scala.util.Properties.versionNumberString
+      val c1: TestRepl = new TestRepl()
+      c1.session(s"""
+        @ interp.load.plugin.ivy("org.scalamacros" % "paradise_${scalaVersion}" % "2.1.0")
       """)
       c1.session("""
         @ val x = 1

--- a/amm/src/test/scala/ammonite/session/AdvancedTests.scala
+++ b/amm/src/test/scala/ammonite/session/AdvancedTests.scala
@@ -290,6 +290,15 @@ object AdvancedTests extends TestSuite{
         @ assert(repl.prompt() == "B")
       """)
     }
+    'macroParadiseWorks{
+      val c1 = new TestRepl()
+      c1.session("""
+        @ interp.load.plugin.ivy("org.scalamacros" % "paradise_2.11.7" % "2.1.0")
+      """)
+      c1.session("""
+        @ val x = 1
+      """)
+    }
     'desugar{
       if (!scala2_10) check.session("""
         @ desugar{1 + 2 max 3}

--- a/amm/src/test/scala/ammonite/session/AdvancedTests.scala
+++ b/amm/src/test/scala/ammonite/session/AdvancedTests.scala
@@ -290,15 +290,6 @@ object AdvancedTests extends TestSuite{
         @ assert(repl.prompt() == "B")
       """)
     }
-    'macroParadiseWorks{
-      val c1 = new TestRepl()
-      c1.session("""
-        @ interp.load.plugin.ivy("org.scalamacros" % "paradise_2.11.7" % "2.1.0")
-      """)
-      c1.session("""
-        @ val x = 1
-      """)
-    }
     'desugar{
       if (!scala2_10) check.session("""
         @ desugar{1 + 2 max 3}


### PR DESCRIPTION
Which was caused by the presence of both normal and source jars on the classpath and led to behaviour like this:

```
@ interp.load.plugin.ivy("org.scalamacros" % "paradise_2.11.7" % "2.1.0")

@ var x = 1
cmd2.sc:2: both org.scalamacros.paradise.typechecker.AnalyzerPlugins$MacroPlugin$@4e3931 and org.scalamacros.paradise.typechecker.AnalyzerPlugins$MacroPlugin$@409e0e69 want to enter a symbol for this tree
package $sess
        ^
scala.reflect.internal.Types$TypeError: both org.scalamacros.paradise.typechecker.AnalyzerPlugins$MacroPlugin$@4e3931 and org.scalamacros.paradise.typechecker.AnalyzerPlugins$MacroPlugin$@409e0e69 want to enter a symbol for this tree
  scala.tools.nsc.typechecker.Contexts$ThrowingReporter.handleError(Contexts.scala:1402)
  scala.tools.nsc.typechecker.Contexts$ContextReporter.info0(Contexts.scala:1297)
  scala.tools.nsc.typechecker.Contexts$ContextReporter.info0(Contexts.scala:1250)
  scala.reflect.internal.Reporter.error(Reporting.scala:82)
  scala.tools.nsc.typechecker.Contexts$Context.error(Contexts.scala:577)
  scala.tools.nsc.typechecker.AnalyzerPlugins$class.invoke(AnalyzerPlugins.scala:373)
  scala.tools.nsc.typechecker.AnalyzerPlugins$class.pluginsEnterSym(AnalyzerPlugins.scala:423)
  ammonite.runtime.CompilerCompatibility$$anon$2.pluginsEnterSym(CompilerCompatibility.scala:10)
  scala.tools.nsc.typechecker.Namers$Namer.enterSym(Namers.scala:275)
  scala.tools.nsc.typechecker.Analyzer$namerFactory$$anon$1.apply(Analyzer.scala:43)
  scala.tools.nsc.Global$GlobalPhase$$anonfun$applyPhase$1.apply$mcV$sp(Global.scala:440)
  scala.tools.nsc.Global$GlobalPhase.withCurrentUnit(Global.scala:431)
  scala.tools.nsc.Global$GlobalPhase.applyPhase(Global.scala:440)
  scala.tools.nsc.Global$GlobalPhase$$anonfun$run$1.apply(Global.scala:398)
  scala.tools.nsc.Global$GlobalPhase$$anonfun$run$1.apply(Global.scala:398)
  scala.collection.Iterator$class.foreach(Iterator.scala:893)
  scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
  scala.tools.nsc.Global$GlobalPhase.run(Global.scala:398)
  scala.tools.nsc.Global$Run.compileUnitsInternal(Global.scala:1501)
  scala.tools.nsc.Global$Run.compileUnits(Global.scala:1486)
  scala.tools.nsc.Global$Run.compileSources(Global.scala:1481)
  scala.tools.nsc.Global$Run.compileFiles(Global.scala:1571)
  ammonite.runtime.Compiler$$anon$4.compile(Compiler.scala:284)
  ammonite.runtime.Interpreter.compileClass(Interpreter.scala:258)
  ammonite.runtime.Interpreter$$anonfun$evaluateLine$2.apply(Interpreter.scala:278)
  ammonite.runtime.Interpreter$$anonfun$evaluateLine$2.apply(Interpreter.scala:277)
  ammonite.util.Catching.flatMap(Res.scala:108)
  ammonite.runtime.Interpreter.evaluateLine(Interpreter.scala:277)
  ammonite.runtime.Interpreter$$anonfun$processLine$2$$anonfun$apply$10$$anonfun$apply$12.apply(Interpreter.scala:233)
  ammonite.runtime.Interpreter$$anonfun$processLine$2$$anonfun$apply$10$$anonfun$apply$12.apply(Interpreter.scala:223)
  ammonite.util.Res$Success.flatMap(Res.scala:57)
  ammonite.runtime.Interpreter$$anonfun$processLine$2$$anonfun$apply$10.apply(Interpreter.scala:223)
  ammonite.runtime.Interpreter$$anonfun$processLine$2$$anonfun$apply$10.apply(Interpreter.scala:213)
  ammonite.util.Res$Success.flatMap(Res.scala:57)
  ammonite.runtime.Interpreter$$anonfun$processLine$2.apply(Interpreter.scala:213)
  ammonite.runtime.Interpreter$$anonfun$processLine$2.apply(Interpreter.scala:209)
  ammonite.util.Catching.flatMap(Res.scala:108)
  ammonite.runtime.Interpreter.processLine(Interpreter.scala:209)
  ammonite.repl.Repl$$anonfun$action$4$$anonfun$apply$2.apply(Repl.scala:88)
  ammonite.repl.Repl$$anonfun$action$4$$anonfun$apply$2.apply(Repl.scala:87)
  ammonite.repl.Scoped$$anonfun$flatMap$1.apply(Signaller.scala:44)
  ammonite.repl.Signaller.apply(Signaller.scala:29)
  ammonite.repl.Scoped$class.flatMap(Signaller.scala:44)
  ammonite.repl.Signaller.flatMap(Signaller.scala:11)
  ammonite.repl.Repl$$anonfun$action$4.apply(Repl.scala:87)
  ammonite.repl.Repl$$anonfun$action$4.apply(Repl.scala:74)
  ammonite.util.Res$Success.flatMap(Res.scala:57)
  ammonite.repl.Repl.action(Repl.scala:74)
  ammonite.repl.Repl.loop$1(Repl.scala:98)
  ammonite.repl.Repl.run(Repl.scala:117)
  ammonite.Main.run(Main.scala:108)
  ammonite.Main$$anonfun$main$1$$anonfun$apply$1.apply(Main.scala:249)
  ammonite.Main$.ammonite$Main$$ifContinually$1(Main.scala:228)
  ammonite.Main$$anonfun$main$1.apply(Main.scala:230)
  ammonite.Main$$anonfun$main$1.apply(Main.scala:230)
  scala.Option.foreach(Option.scala:257)
  ammonite.Main$.main(Main.scala:230)
  ammonite.Main.main(Main.scala:-1)
Something unexpected went wrong =(
```