### PR TITLE
Fix #432 (Can't cd into directories' symlinks)

### DIFF
--- a/destSymLink
+++ b/destSymLink
@@ -1,0 +1,1 @@
+/var/folders/c8/4ywd_y8n57q3d0qhbcmrx35h0000gn/T/713505513443399873

--- a/destSymLink
+++ b/destSymLink
@@ -1,1 +1,0 @@
-/var/folders/c8/4ywd_y8n57q3d0qhbcmrx35h0000gn/T/2296412342278325820

--- a/destSymLink
+++ b/destSymLink
@@ -1,1 +1,1 @@
-/var/folders/c8/4ywd_y8n57q3d0qhbcmrx35h0000gn/T/713505513443399873
+/var/folders/c8/4ywd_y8n57q3d0qhbcmrx35h0000gn/T/2296412342278325820

--- a/ops/src/main/scala/ammonite/ops/Model.scala
+++ b/ops/src/main/scala/ammonite/ops/Model.scala
@@ -65,7 +65,7 @@ object stat extends Function1[ops.Path, ops.stat]{
   }
   object full extends Function1[ops.Path, ops.stat.full] {
     def apply(p: ops.Path) = ops.stat.full.make(
-      p.last,
+      p.segments.lastOption.getOrElse("/"),
       Files.readAttributes(
         Paths.get(p.toString),
         classOf[BasicFileAttributes],

--- a/shell/src/main/scala/ammonite/shell/ShellSession.scala
+++ b/shell/src/main/scala/ammonite/shell/ShellSession.scala
@@ -5,27 +5,37 @@ import java.nio.file.attribute.PosixFilePermission
 
 import ammonite.ops._
 import ammonite.repl.FrontEndUtils
-import pprint.{Config, PPrinter, PPrint}
+import pprint.{Config, PPrinter}
+
+import scala.util.Try
 
 case class ShellSession() extends OpsAPI {
   var wd0 = pwd
   /**
-   * The current working directory of the shell, that will get picked up by
-   * any ammonite.ops commands you use
-   */
+    * The current working directory of the shell, that will get picked up by
+    * any ammonite.ops commands you use
+    */
   implicit def wd = wd0
   /**
-   * Change the working directory `wd`; if the provided path is relative it
-   * gets appended on to the current `wd`, if it's absolute it replaces.
-   */
+    * Change the working directory `wd`; if the provided path is relative it
+    * gets appended on to the current `wd`, if it's absolute it replaces.
+    */
   val cd = (arg: Path) => {
-    if (!stat(arg).isDir) throw new NotDirectoryException(arg.toString)
-    else {
-      wd0 = arg
-      wd0
-    }
+    /*
+     * `arg` should be a directory or a symlink to a directory
+     * `realPath will be None if that is not the case,
+     * otherwise - Some(realPath)
+     */
+    val realPath = Option(arg)
+      .filter(_.isDir)
+      .orElse(Try(Path(arg.toNIO.toRealPath())).toOption.filter(_.isDir))
 
+    realPath match {
+      case None => throw new NotDirectoryException(arg.toString)
+      case Some(path) => wd0 = path; wd0
+    }
   }
+
   implicit def Relativizer[T](p: T)(implicit b: Path, f: T => RelPath): Path = b/f(p)
 }
 
@@ -84,23 +94,23 @@ object PPrints{
 }
 trait OpsAPI{
   /**
-   * The current working directory of the shell, that will get picked up by
-   * any [[Relativizer]] below, and can be modified using [[cd]]
-   */
+    * The current working directory of the shell, that will get picked up by
+    * any [[Relativizer]] below, and can be modified using [[cd]]
+    */
   implicit def wd: Path
   /**
-   * Change the working directory `wd`; if the provided path is relative it
-   * gets appended on to the current `wd`, if it's absolute it replaces. It
-   * returns the resultant absolute path.
-   */
+    * Change the working directory `wd`; if the provided path is relative it
+    * gets appended on to the current `wd`, if it's absolute it replaces. It
+    * returns the resultant absolute path.
+    */
   val cd: ammonite.ops.Path => ammonite.ops.Path
 
   /**
-   * Allows you to use relative paths (and anything convertible to a relative
-   * path) as absolute paths when working in the REPL. Note that this isn't
-   * available when using Ammonite-Ops in a standalone project! In such cases,
-   * it's good practice to convert paths from relative to absolute explicitly.
-   */
+    * Allows you to use relative paths (and anything convertible to a relative
+    * path) as absolute paths when working in the REPL. Note that this isn't
+    * available when using Ammonite-Ops in a standalone project! In such cases,
+    * it's good practice to convert paths from relative to absolute explicitly.
+    */
   implicit def Relativizer[T](p: T)(implicit b: Path, f: T => RelPath): Path
 
 }

--- a/shell/src/test/scala/ammonite/shell/SessionTests.scala
+++ b/shell/src/test/scala/ammonite/shell/SessionTests.scala
@@ -69,23 +69,23 @@ object SessionTests extends TestSuite{
 
         @ interp.load.module($bareSrc)
 
-        @ rm! 'destSymLink
-
         @ val originalWd = wd
 
-        @ val srcDir0 = tmp.dir()
+        @ val tmpdir = tmp.dir()
 
-        @ ln.s!(srcDir0)! 'destSymLink
+        @ cd! tmpdir
+
+        @ mkdir! 'srcDir0
+
+        @ ln.s!('srcDir0)! 'destSymLink
 
         @ cd! 'destSymLink
 
-        @ assert(srcDir0.name == wd.name)
+        @ assert("srcDir0" == wd.name)
 
-        @ rm! 'destSymLink
+        @ cd! originalWd
 
-        @ cd! up
-
-        @ rm! srcDir0
+        @ rm! tmpdir
       """)
     }
   }

--- a/shell/src/test/scala/ammonite/shell/SessionTests.scala
+++ b/shell/src/test/scala/ammonite/shell/SessionTests.scala
@@ -60,7 +60,33 @@ object SessionTests extends TestSuite{
         src
         target
       """)
+    }
 
+    'cdIntoDirSymlink {
+      check.session(
+        s"""
+        @ import ammonite.ops._
+
+        @ interp.load.module($bareSrc)
+
+        @ rm! 'destSymLink
+
+        @ val originalWd = wd
+
+        @ val srcDir0 = tmp.dir()
+
+        @ ln.s!(srcDir0)! 'destSymLink
+
+        @ cd! 'destSymLink
+
+        @ assert(srcDir0.name == wd.name)
+
+        @ rm! 'destSymLink
+
+        @ cd! up
+
+        @ rm! srcDir0
+      """)
     }
   }
 }


### PR DESCRIPTION
This is a proposal to fix #432 via the mechanism of resolving 'real paths' + following symlinks (as described by the `j.n.f.Path`'s javadoc (https://docs.oracle.com/javase/8/docs/api/java/nio/file/Path.html#toRealPath-java.nio.file.LinkOption...-)). 

Also fixes the bug which caused the `stat.full` on the `root` variable to fail.

Test included.