### PR TITLE
[Issue 432] Follow links when executing `cd`

### DIFF
--- a/ops/src/main/scala/ammonite/ops/Path.scala
+++ b/ops/src/main/scala/ammonite/ops/Path.scala
@@ -287,6 +287,8 @@ extends FilePath with BasePathImpl with Readable{
     RelPath(segments.drop(s2.length), newUps)
   }
 
+  def followLinks = Path(toIO.getCanonicalPath)
+
   def toIO = toNIO.toFile
 
   override def getBytes = java.nio.file.Files.readAllBytes(toNIO)

--- a/shell/src/main/scala/ammonite/shell/ShellSession.scala
+++ b/shell/src/main/scala/ammonite/shell/ShellSession.scala
@@ -19,7 +19,7 @@ case class ShellSession() extends OpsAPI {
    * gets appended on to the current `wd`, if it's absolute it replaces.
    */
   val cd = (arg: Path) => {
-    if (!stat(arg).isDir) throw new NotDirectoryException(arg.toString)
+    if (!stat(arg.followLinks).isDir) throw new NotDirectoryException(arg.toString)
     else {
       wd0 = arg
       wd0

--- a/shell/src/test/scala/ammonite/shell/SessionTests.scala
+++ b/shell/src/test/scala/ammonite/shell/SessionTests.scala
@@ -62,5 +62,40 @@ object SessionTests extends TestSuite{
       """)
 
     }
+    'cdToNestedSymlink{
+      check.session(s"""
+        @ import ammonite.ops._
+
+        @ interp.load.module($bareSrc)
+
+        @ val originalWd = wd
+
+        @ val names = Seq('test123, 'test124, 'test125, 'test126)
+
+        @ names.foreach(p => rm! wd/p)
+
+        @ mkdir! wd/'test123
+
+        @ ln.s(wd/'test123, wd/'test124)
+
+        @ ln.s(wd/'test124, wd/'test125)
+
+        @ ln.s(wd/'test125, wd/'test126)
+
+        @ cd! 'test126
+
+        @ assert(wd == originalWd/'test126)
+
+        @ assert(wd.followLinks == originalWd/'test123)
+
+        @ cd! originalWd
+
+        @ assert(wd == originalWd)
+
+        @ names.foreach(p => rm! wd/p)
+
+        @ names.foreach(p => assert(!exists(wd/p)))
+      """)
+    }
   }
 }


### PR DESCRIPTION
- Adding a method `Path#followLinks` that follows symlinks transitively (if the Path is a symlink).

- Fixing `cd` so that you can go to a symlinked directory.

This fixes issue https://github.com/lihaoyi/Ammonite/issues/432