### PR TITLE
add "Path#tryFollowLinks"; "cd" will now change to symlinked directory

### DIFF
--- a/ops/src/main/scala/ammonite/ops/Path.scala
+++ b/ops/src/main/scala/ammonite/ops/Path.scala
@@ -6,6 +6,7 @@ import java.nio.charset.Charset
 import acyclic.file
 
 import scala.io.Codec
+import scala.util.Try
 
 /**
   * Enforces a standard interface for constructing [[BasePath]]-like things
@@ -276,7 +277,11 @@ extends FilePath with BasePathImpl with Readable{
 
   def startsWith(target: Path) = this.segments.startsWith(target.segments)
 
-  def followLinks: Path = Path(toNIO.toRealPath())
+  /**
+    * Obtain the final path to a file by resolving symlinks if any.
+    * @return Some(path) or else None if the symlink is invalid or other error.
+    */
+  def tryFollowLinks: Option[Path] = Try(Path(toNIO.toRealPath())).toOption
 
   def relativeTo(base: Path): RelPath = {
     var newUps = 0

--- a/ops/src/main/scala/ammonite/ops/Path.scala
+++ b/ops/src/main/scala/ammonite/ops/Path.scala
@@ -276,6 +276,8 @@ extends FilePath with BasePathImpl with Readable{
 
   def startsWith(target: Path) = this.segments.startsWith(target.segments)
 
+  def followLinks: Path = Path(toNIO.toRealPath())
+
   def relativeTo(base: Path): RelPath = {
     var newUps = 0
     var s2 = base.segments

--- a/ops/src/test/scala/test/ammonite/ops/PathTests.scala
+++ b/ops/src/test/scala/test/ammonite/ops/PathTests.scala
@@ -340,39 +340,37 @@ object PathTests extends TestSuite{
         }
       }
       'symlinks{
+
+        val names = Seq('test123, 'test124, 'test125, 'test126)
+        val twd = tmp.dir()
+
         'nestedSymlinks{
           if(Unix()) {
-            val names = Seq('test123, 'test124, 'test125, 'test126)
-            names.foreach(p => rm ! pwd / p)
-            mkdir ! pwd / 'test123
-            ln.s(pwd / 'test123, pwd / 'test124)
-            ln.s(pwd / 'test124, pwd / 'test125)
-            ln.s(pwd / 'test125, pwd / 'test126)
-
-            assert((pwd / 'test126).tryFollowLinks.get == pwd / 'test123)
-
-            names.foreach(p => rm ! pwd / p)
-            names.foreach(p => assert(!exists(pwd / p)))
+            names.foreach(p => rm ! twd/p)
+            mkdir ! twd/'test123
+            ln.s(twd/'test123, twd/'test124)
+            ln.s(twd/'test124, twd/'test125)
+            ln.s(twd/'test125, twd/'test126)
+            assert((twd/'test126).tryFollowLinks.get == (twd/'test123).tryFollowLinks.get)
+            names.foreach(p => rm ! twd/p)
+            names.foreach(p => assert(!exists(twd/p)))
           }
-
         }
+
         'danglingSymlink{
           if(Unix()) {
-            val names = Seq('test123, 'test124, 'test125, 'test126)
-            names.foreach(p => rm ! pwd / p)
-            mkdir ! pwd / 'test123
-            ln.s(pwd / 'test123, pwd / 'test124)
-            ln.s(pwd / 'test124, pwd / 'test125)
-            ln.s(pwd / 'test125, pwd / 'test126)
-
-            rm ! pwd / 'test123
-
-            assert( (pwd / 'test126).tryFollowLinks.isEmpty)
-
-            names.foreach(p => rm ! pwd / p)
-            names.foreach(p => assert(!exists(pwd / p)))
+            names.foreach(p => rm ! twd/p)
+            mkdir ! twd/'test123
+            ln.s(twd/'test123, twd/'test124)
+            ln.s(twd/'test124, twd/'test125)
+            ln.s(twd/'test125, twd/'test126)
+            rm ! twd / 'test123
+            assert( (twd / 'test126).tryFollowLinks.isEmpty)
+            names.foreach(p => rm ! twd / p)
+            names.foreach(p => assert(!exists(twd / p)))
+            names.foreach(p => rm ! twd/p)
+            names.foreach(p => assert(!exists(twd/p)))
           }
-
         }
       }
     }

--- a/ops/src/test/scala/test/ammonite/ops/PathTests.scala
+++ b/ops/src/test/scala/test/ammonite/ops/PathTests.scala
@@ -3,7 +3,6 @@ package test.ammonite.ops
 import java.nio.file.Paths
 
 import ammonite.ops._
-
 import utest._
 object PathTests extends TestSuite{
   val tests = TestSuite {
@@ -338,6 +337,42 @@ object PathTests extends TestSuite{
           intercept[PathError.AbsolutePathOutsideRoot.type]{
             Path(tooManyUpsStr)
           }
+        }
+      }
+      'symlinks{
+        'nestedSymlinks{
+          if(Unix()) {
+            val names = Seq('test123, 'test124, 'test125, 'test126)
+            names.foreach(p => rm ! pwd / p)
+            mkdir ! pwd / 'test123
+            ln.s(pwd / 'test123, pwd / 'test124)
+            ln.s(pwd / 'test124, pwd / 'test125)
+            ln.s(pwd / 'test125, pwd / 'test126)
+
+            assert((pwd / 'test126).tryFollowLinks.get == pwd / 'test123)
+
+            names.foreach(p => rm ! pwd / p)
+            names.foreach(p => assert(!exists(pwd / p)))
+          }
+
+        }
+        'danglingSymlink{
+          if(Unix()) {
+            val names = Seq('test123, 'test124, 'test125, 'test126)
+            names.foreach(p => rm ! pwd / p)
+            mkdir ! pwd / 'test123
+            ln.s(pwd / 'test123, pwd / 'test124)
+            ln.s(pwd / 'test124, pwd / 'test125)
+            ln.s(pwd / 'test125, pwd / 'test126)
+
+            rm ! pwd / 'test123
+
+            assert( (pwd / 'test126).tryFollowLinks.isEmpty)
+
+            names.foreach(p => rm ! pwd / p)
+            names.foreach(p => assert(!exists(pwd / p)))
+          }
+
         }
       }
     }

--- a/shell/src/main/scala/ammonite/shell/ShellSession.scala
+++ b/shell/src/main/scala/ammonite/shell/ShellSession.scala
@@ -28,11 +28,11 @@ case class ShellSession() extends OpsAPI {
      */
     val realPath = Option(arg)
       .filter(_.isDir)
-      .orElse(Try(Path(arg.toNIO.toRealPath())).toOption.filter(_.isDir))
+      .orElse(Try(arg.followLinks).toOption.filter(_.isDir))
 
     realPath match {
       case None => throw new NotDirectoryException(arg.toString)
-      case Some(path) => wd0 = path; wd0
+      case Some(path) => wd0 = arg; wd0
     }
   }
 

--- a/shell/src/main/scala/ammonite/shell/ShellSession.scala
+++ b/shell/src/main/scala/ammonite/shell/ShellSession.scala
@@ -28,7 +28,7 @@ case class ShellSession() extends OpsAPI {
      */
     val realPath = Option(arg)
       .filter(_.isDir)
-      .orElse(Try(arg.followLinks).toOption.filter(_.isDir))
+      .orElse(arg.tryFollowLinks.filter(_.isDir))
 
     realPath match {
       case None => throw new NotDirectoryException(arg.toString)

--- a/shell/src/test/scala/ammonite/shell/SessionTests.scala
+++ b/shell/src/test/scala/ammonite/shell/SessionTests.scala
@@ -81,11 +81,39 @@ object SessionTests extends TestSuite{
 
         @ cd! 'destSymLink
 
-        @ assert("srcDir0" == wd.name)
+        @ assert("srcDir0" == wd.followLinks.name)
+
+        @ assert("destSymLink" == wd.name)
 
         @ cd! originalWd
 
         @ rm! tmpdir
+
+        @ val names = Seq('test123, 'test124, 'test125, 'test126)
+
+        @ names.foreach(p => rm! wd/p)
+
+        @ mkdir! wd/'test123
+
+        @ ln.s(wd/'test123, wd/'test124)
+
+        @ ln.s(wd/'test124, wd/'test125)
+
+        @ ln.s(wd/'test125, wd/'test126)
+
+        @ cd! 'test126
+
+        @ assert(wd.followLinks == originalWd/'test123)
+
+        @ assert(wd == originalWd/'test126)
+
+        @ cd! originalWd
+
+        @ assert(wd == originalWd)
+
+        @ names.foreach(p => rm! wd/p)
+
+        @ names.foreach(p => assert(!exists(wd/p)))
       """)
     }
   }

--- a/shell/src/test/scala/ammonite/shell/SessionTests.scala
+++ b/shell/src/test/scala/ammonite/shell/SessionTests.scala
@@ -100,9 +100,11 @@ object SessionTests extends TestSuite{
 
         @ val originalWd = wd
 
-        @ val names = Seq('test123, 'test124, 'test125, 'test126)
+        @ val tmpdir = tmp.dir()
 
-        @ names.foreach(p => rm! wd/p)
+        @ cd! tmpdir
+
+        @ val names = Seq('test123, 'test124, 'test125, 'test126)
 
         @ mkdir! wd/'test123
 
@@ -114,22 +116,121 @@ object SessionTests extends TestSuite{
 
         @ cd! 'test126
 
-        @ assert(wd.tryFollowLinks.get == originalWd/'test123)
+        @ assert(wd.tryFollowLinks.get == (tmpdir/'test123).tryFollowLinks.get)
 
-        @ assert(wd == originalWd/'test126)
+        @ assert(wd == tmpdir/'test126)
 
-        @ cd! originalWd
+        @ cd! tmpdir
 
-        @ assert(wd == originalWd)
+        @ assert(wd == tmpdir)
 
         @ rm! 'test123
 
-        @ assert( (wd / 'test126).tryFollowLinks == None )
+        @ assert( (wd/'test126).tryFollowLinks == None)
 
         @ names.foreach(p => rm! wd/p)
 
         @ names.foreach(p => assert(!exists(wd/p)))
+
+        @ cd! originalWd
+
+        @ rm! tmpdir
       """)
     }
+    'opsInSymlinkedDir {
+      // test mkdir, write, read, stat/stat.full, cp, and ls inside a symlinked directory
+      // (both while wd = symlinked and outside)
+      check.session(
+        s"""
+        @ import ammonite.ops._
+
+        @ interp.load.module($bareSrc)
+
+        @ val originalWd = wd
+
+        @ val tmpdir = tmp.dir()
+
+        @ cd! tmpdir
+
+        @ mkdir! wd/'test123
+
+        @ ln.s(wd/'test123, wd/'test124)
+
+        @ ln.s(wd/'test124, wd/'test125)
+
+        @ ln.s(wd/'test125, wd/'test126)
+
+        @ cd! 'test126
+
+        @ mkdir! 'test130
+
+        @ assert(exists(wd/'test130))
+
+        @ cd! 'test130
+
+        @ assert(wd == tmpdir/'test126/'test130)
+
+        @ write('test131, "abcdef") // writing while inside symlinked dir
+
+        @ assert(read('test131) == "abcdef") // reading while inside symlinked dir
+
+        @ cp('test131, 'test132)
+
+        @ cd! up
+
+        @ assert(wd == tmpdir/'test126)
+
+        @ write('test132, "qqq")
+
+        @ assert(read('test132) == "qqq")
+
+        @ cp('test132, 'test133) // cp inside symlinked dir while inside that dir
+
+        @ assert( (ls!).toList == List(wd/'test130, wd/'test132, wd/'test133)) // ls inside dir
+
+        @ assert(!stat('test132).isDir && !stat('test132).isSymLink && stat('test130).isDir)
+
+        @ assert(!stat.full('test132).isDir && !stat.full('test132).isSymLink)
+
+        @ assert(stat.full('test130).isDir)
+
+        @ assert(ls.rec(wd).length == 5)
+
+        @ cd! originalWd
+
+        @ val t = tmpdir/'test126 // this dir is symlinked
+
+        @ assert(read(t/'test130/'test131) == "abcdef") // reading while outside symlinked dir
+
+        @ assert(read(t/'test132) == "qqq")
+
+        @ write.over(t/'test132, "www") // writing into file in symlinked dir
+
+        @ assert(read(t/'test132) == "www")
+
+        @ assert(read(t/'test133) == "qqq")
+
+        @ assert(ls(t).toList == List(t/'test130, t/'test132, t/'test133))
+
+        @ cp(t/'test133, t/'test134) // cp inside symlinked dir while outside that dir
+
+        @ assert(read(t/'test134) == "qqq")
+
+        @ assert(ls.rec(tmpdir).length == 10) // ls.rec of symlinked dirs while outside that dir
+
+        @ assert(ls.rec(t).length == 6)
+
+        @ assert(!stat(t/'test132).isDir && !stat(t/'test132).isSymLink)
+
+        @ assert(!stat.full(t/'test132).isDir && !stat.full(t/'test132).isSymLink)
+
+        @ assert(stat(t/'test130).isDir && stat(t).isSymLink)
+
+        @ assert(stat.full(t/'test130).isDir && stat.full(t).isSymLink)
+
+        @ rm! tmpdir
+      """)
+    }
+
   }
 }

--- a/shell/src/test/scala/ammonite/shell/SessionTests.scala
+++ b/shell/src/test/scala/ammonite/shell/SessionTests.scala
@@ -81,13 +81,24 @@ object SessionTests extends TestSuite{
 
         @ cd! 'destSymLink
 
-        @ assert("srcDir0" == wd.followLinks.name)
+        @ assert("srcDir0" == wd.tryFollowLinks.get.name)
 
         @ assert("destSymLink" == wd.name)
 
         @ cd! originalWd
 
         @ rm! tmpdir
+      """)
+    }
+
+    'nestedSymlinks {
+      check.session(
+        s"""
+        @ import ammonite.ops._
+
+        @ interp.load.module($bareSrc)
+
+        @ val originalWd = wd
 
         @ val names = Seq('test123, 'test124, 'test125, 'test126)
 
@@ -103,13 +114,17 @@ object SessionTests extends TestSuite{
 
         @ cd! 'test126
 
-        @ assert(wd.followLinks == originalWd/'test123)
+        @ assert(wd.tryFollowLinks.get == originalWd/'test123)
 
         @ assert(wd == originalWd/'test126)
 
         @ cd! originalWd
 
         @ assert(wd == originalWd)
+
+        @ rm! 'test123
+
+        @ assert( (wd / 'test126).tryFollowLinks == None )
 
         @ names.foreach(p => rm! wd/p)
 


### PR DESCRIPTION
I think `cd! symlinkedDir` should actually change into a symlinked directory and not into the directory the symlink points to.

As it is now, `tmp` is symlinked on a Mac OS X, and you can't do something like this:
```
cd! root/'tmp
ls! up/'home // "up" does not point to root
```

This PR makes `cd` change to the symlinked directory (if it exists).

This PR also adds `Path#tryFollowLinks : Option[Path]`, which will return the link target (if it exists).