### PR TITLE
Fix + test for #430

### DIFF
--- a/amm/interp/src/main/scala/ammonite/runtime/Pressy.scala
+++ b/amm/interp/src/main/scala/ammonite/runtime/Pressy.scala
@@ -233,8 +233,8 @@ object Pressy {
 
       val run = Try(new Run(pressy, currentFile, allCode, index))
 
-      val (i, all): (Int, Seq[(String, Option[String])]) = run match {
-        case Success(runSuccess) => runSuccess.prefixed
+      val (i, all): (Int, Seq[(String, Option[String])]) = run.map(_.prefixed) match {
+        case Success(prefixed) => prefixed
         case Failure(throwable) => (0, Seq.empty)
       }
 

--- a/amm/src/test/scala/ammonite/AutocompleteTests.scala
+++ b/amm/src/test/scala/ammonite/AutocompleteTests.scala
@@ -59,6 +59,7 @@ object AutocompleteTests extends TestSuite{
         complete(
           """import scala.colltion.<caret>""", Set.empty[String] -- _
         )
+        complete("""object X { import y<caret> ; def y(z: Int)""", Set.empty[String] -- _)
       }
 
       'scope {


### PR DESCRIPTION
#430 describes a case when we ask for completion on an invalid input and `ammonite.runtime.Pressy.Run#prefixed` throws NPE and the whole REPL goes down.

The fix is basically to lift the `prefixed` call into a Try context that is already there.