### PR TITLE
[WIP]Attempt to fix #397

### DIFF
--- a/terminal/src/main/scala/ammonite/terminal/filters/BasicFilters.scala
+++ b/terminal/src/main/scala/ammonite/terminal/filters/BasicFilters.scala
@@ -100,7 +100,7 @@ object BasicFilters {
       }
     },
     // java.io.Reader.read() produces -1 on EOF
-    action((-1).toChar.toString)(_ => Exit)
+    wrap(ti => ti.ts.inputs.dropPrefix(Seq(-1)).map(_ => Exit))
   )
   def clearFilter: Filter =
     action(Ctrl('l')){case TS(rest, b, c, _) => ClearScreen(TS(rest, b, c))}


### PR DESCRIPTION
#397 was about accepting pipe's input.
The problem as I saw it was in the fact that `-1` designating EOF of Java's input streams was accepted by an incorrect filter. 
There was this weird thing, first stating that exit is done by encountering a `-1` in a stream supplying _ints_, then designating a pattern of `(-1).toChar.toString` instead (which was a single string of `0xffff` char since `Char[acter]`s are unsigned), then (@ Filter.scala:48) did `prefix.map(_.toInt)`, which resulted in `0xffff` again, which, of course, didn't match `-1` (int) in `LazyList#dropPrefix`.

I propose an implementation which avoids this casting, which makes an original example work (both on mac OS and Linux, but that's kinda irrelevant since the problem is not in the piping mechanisms after all).

No unit tests because I'm not sure this is the final solution and I'd like to know what you think about this. If/when you give it a green light, I guess a simple test not involving the piping simulation could be added to some `FilterTest` since this isn't really a buffer reading problem.