### PR TITLE
`mkdir -p` to make instructions work in any order (tiny change)

### DIFF
--- a/readme/Sample.scala
+++ b/readme/Sample.scala
@@ -20,7 +20,7 @@ object Sample{
   val replCurl = curlCommand(ammonite.Constants.curlUrl)
   val unstableCurl = curlCommand(ammonite.Constants.unstableCurlUrl)
   val filesystemCurl =
-    "$ mkdir ~/.ammonite && curl -L -o ~/.ammonite/predef.sc https://git.io/v6r5y"
+    "$ mkdir -p ~/.ammonite && curl -L -o ~/.ammonite/predef.sc https://git.io/v6r5y"
   val cacheVersion = 6
   def cached(key: Any)(calc: => String) = {
     val path = cwd/'target/'cache/(key.hashCode + cacheVersion).toString


### PR DESCRIPTION
There's no need to error on failing to create ~/.ammonite if it already exists, such as for those who have already downloaded Ammonite.