### PR TITLE
Fix #463

### DIFF
--- a/amm/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -128,6 +128,7 @@ object Repl{
                      source: fansi.Attrs) = {
     val src =
       if (f.isNativeMethod) source("Native Method")
+      else if (f.getFileName == null) source("Unknown Source")
       else source(f.getFileName) ++ error(":") ++ source(f.getLineNumber.toString)
 
     val prefix :+ clsName = f.getClassName.split('.').toSeq


### PR DESCRIPTION
According to the [API doc](https://docs.oracle.com/javase/8/docs/api/java/lang/StackTraceElement.html#getFileName--) it can return a null if the information is unavailable.
