### PR TITLE
Use RSA host keys instead of DSA

### DIFF
--- a/sshd/src/main/scala/ammonite/sshd/SshServer.scala
+++ b/sshd/src/main/scala/ammonite/sshd/SshServer.scala
@@ -35,7 +35,7 @@ object SshServer {
     val hostKeyFile = touch(
       options.hostKeyFile.getOrElse(fallbackHostkeyFilePath(options))
     )
-    new SimpleGeneratorHostKeyProvider(hostKeyFile.toString())
+    new SimpleGeneratorHostKeyProvider(hostKeyFile.toString(), "RSA")
   }
 
   private def disableUnsupportedChannels(sshServer: SshServerImpl) = {

--- a/sshd/src/test/scala/ammonite/sshd/SshTestingUtils.scala
+++ b/sshd/src/test/scala/ammonite/sshd/SshTestingUtils.scala
@@ -78,6 +78,11 @@ object SshTestingUtils {
     val client = new JSch
     val session = client.getSession(creds._1, host, port)
     session.setPassword(creds._2)
+    session.setConfig("server_host_key", Seq(
+        "ecdsa-sha2-nistp256",
+        "ecdsa-sha2-nistp384",
+        "ecdsa-sha2-nistp521",
+        "ssh-rsa").mkString(","))
     session.setUserInfo(autoAcceptHostKeyUser(creds._2))
     session
   }


### PR DESCRIPTION
OpenSSH 7.x deprecated DSA keys, requiring them now to be explicitly allowed via the "HostKeyAlgorithms" option. For more info, see:
https://www.openssh.com/releasenotes.html#7.0
http://security.stackexchange.com/questions/112802/why-openssh-deprecated-dsa-keys

As the SSH daemon most often will be used on localhost, it will often be used with the OpenSSH client. The slow upgrade process of enterprise distros has left OpenSSH on 6.x, but this has already changed for Ubuntu 16.04 LTS, and the next versions of Debian & RHEL will be 7.x too.

This patch resolves this problem by replacing DSA with RSA (which has wider compatibility than elliptic curve) for key generation.

Tests have also been modified so the client only uses host key algorithms that both appear in the JSch supported algorithms list and OpenSSH 7 default HostKeyAlgorithms list.
