### PR TITLE
upgrade org.apache.sshd sshd-core from 0.14 to 1.3.0 to fix openssh errors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -255,7 +255,7 @@ lazy val sshd = project
       crossVersion := CrossVersion.full,
       name := "ammonite-sshd",
       libraryDependencies ++= Seq(
-        "org.apache.sshd" % "sshd-core" % "0.14.0",
+        "org.apache.sshd" % "sshd-core" % "1.3.0",
         //-- test --//
         // slf4j-nop makes sshd server use logger that writes into the void
         "org.slf4j" % "slf4j-nop" % "1.7.12" % "test",

--- a/sshd/src/main/scala/ammonite/sshd/SshServer.scala
+++ b/sshd/src/main/scala/ammonite/sshd/SshServer.scala
@@ -6,12 +6,15 @@ import java.util.Collections
 import ammonite.ops.Path
 import org.apache.sshd.agent.SshAgentFactory
 import org.apache.sshd.common._
+import org.apache.sshd.common.session.Session
 import org.apache.sshd.common.file.FileSystemFactory
 import org.apache.sshd.common.session.ConnectionService
+import org.apache.sshd.common.config.keys.KeyUtils
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider
 import org.apache.sshd.server.session.ServerSession
-import org.apache.sshd.server.{Command, CommandFactory, PasswordAuthenticator}
-import org.apache.sshd.{SshServer => SshServerImpl}
+import org.apache.sshd.server.{Command, CommandFactory}
+import org.apache.sshd.server.auth.password.PasswordAuthenticator
+import org.apache.sshd.server.{SshServer => SshServerImpl}
 
 /**
  * A factory to simplify creation of ssh server
@@ -35,7 +38,9 @@ object SshServer {
     val hostKeyFile = touch(
       options.hostKeyFile.getOrElse(fallbackHostkeyFilePath(options))
     )
-    new SimpleGeneratorHostKeyProvider(hostKeyFile.toString())
+    val hostKeyProvider = new SimpleGeneratorHostKeyProvider(new java.io.File(hostKeyFile.toString))
+    hostKeyProvider.setAlgorithm(KeyUtils.RSA_ALGORITHM)
+    hostKeyProvider
   }
 
   private def disableUnsupportedChannels(sshServer: SshServerImpl) = {
@@ -53,7 +58,7 @@ object SshServer {
       override def getChannelForwardingFactory = null
     })
     sshServer.setFileSystemFactory(new FileSystemFactory {
-      override def createFileSystemView(session: Session) = null
+      override def createFileSystem(session: Session) = null
     })
     sshServer
   }

--- a/sshd/src/test/scala/ammonite/sshd/SshTestingUtils.scala
+++ b/sshd/src/test/scala/ammonite/sshd/SshTestingUtils.scala
@@ -59,7 +59,7 @@ object SshTestingUtils {
   }
 
   def withTestSshServer[T](user: (String, String), testShell: () => Any = () => ???)
-                          (test: org.apache.sshd.SshServer => T)
+                          (test: org.apache.sshd.server.SshServer => T)
                           (implicit dir: Path): T = {
     val server = testSshServer(user, (_, _) => testShell.apply())
     server.start()
@@ -70,7 +70,7 @@ object SshTestingUtils {
     }
   }
 
-  def sshClient(creds: (String, String), sshServer: org.apache.sshd.SshServer): Session = {
+  def sshClient(creds: (String, String), sshServer: org.apache.sshd.server.SshServer): Session = {
     sshClient(creds, Option(sshServer.getHost).getOrElse("localhost"), sshServer.getPort)
   }
 


### PR DESCRIPTION
As of version 7.0, OpenSSH comes with DSA host key authentication [disabled by default](http://www.openssh.com/legacy.html). Ammonite's `sshd` subproject was using `org.apache.sshd` `sshd-core` version 0.14, which by default offered the DSA host key authentication. Thus, sshing to an embedded ammonite shell in a running application would not work with newer versions of the OpenSSH client, failing with an error like `Unable to negotiate with 127.0.0.1 port 2222: no matching host key type found. Their offer: ssh-dss`. You can replicate this by checking out the latest version of Ammonite from the official repo, running `sbt sshd/test:run`, following the instructions, and then trying to ssh to port 2222 on localhost using an up-to-date version of the OpenSSH ssh client.

Since I was in there, I upgraded `sshd-core` to version 1.3.0. Some files were moved to different packages, so I changed some imports and code in `SshTestingUtils.scala` and `SshServer.scala`. I then added some extra code to `SshServer.scala` to use the RSA host key authentication algorithm. There are a few extra details in my commit message. I verified that at least in my own environment, these changes eliminate the `...Thei offer: ssh-dss` error message.
