### PR TITLE
pass full path to script being compiled

### DIFF
--- a/amm/interp/src/main/scala/ammonite/runtime/Interpreter.scala
+++ b/amm/interp/src/main/scala/ammonite/runtime/Interpreter.scala
@@ -438,7 +438,11 @@ class Interpreter(val printer: Printer,
             processScriptBlock(
               processed, printer,
               Interpreter.indexWrapperName(wrapperName, wrapperIndex),
-              wrapperName.raw + ".sc", pkgName
+              source match {
+                case ImportHook.Source.File(fname) => fname.toString
+                case _ => wrapperName.raw + ".sc"
+              },
+              pkgName
             )
           ),
         autoImport,

--- a/integration/src/test/scala/ammonite/integration/ErrorTruncationTests.scala
+++ b/integration/src/test/scala/ammonite/integration/ErrorTruncationTests.scala
@@ -27,12 +27,15 @@ object ErrorTruncationTests extends TestSuite{
 
     assert(e == expected)
   }
+  def scriptFile(name: String): Path =
+    replStandaloneResources/'errorTruncation/name
+
   val tests = TestSuite {
     println("ErrorTruncationTests")
     'compileError - checkErrorMessage(
       file = 'errorTruncation/"compileError.sc",
       expected = Util.normalizeNewlines(
-        """compileError.sc:1: not found: value doesntexist
+        s"""${scriptFile("compileError.sc")}:1: not found: value doesntexist
           |val res = doesntexist
           |          ^
           |Compilation Failed
@@ -42,7 +45,7 @@ object ErrorTruncationTests extends TestSuite{
     'multiExpressionError - checkErrorMessage(
       file = 'errorTruncation/"compileErrorMultiExpr.sc",
       expected = Util.normalizeNewlines(
-        """compileErrorMultiExpr.sc:11: not found: value doesntexist
+        s"""${scriptFile("compileErrorMultiExpr.sc")}:11: not found: value doesntexist
           |val res_4 = doesntexist
           |            ^
           |Compilation Failed
@@ -66,13 +69,14 @@ object ErrorTruncationTests extends TestSuite{
     val tab = '\t'
     val runtimeErrorResourcePackage =
       "$file.integration.src.test.resources.ammonite.integration.errorTruncation"
+    val runtimeErrorSc = scriptFile("runtimeError.sc")
     'runtimeError - checkErrorMessage(
       file = 'errorTruncation/"runtimeError.sc",
       expected = Util.normalizeNewlines(
         s"""Exception in thread "main" java.lang.ArithmeticException: / by zero
-          |${tab}at $runtimeErrorResourcePackage.runtimeError$$.<init>(runtimeError.sc:1)
-          |${tab}at $runtimeErrorResourcePackage.runtimeError$$.<clinit>(runtimeError.sc)
-          |${tab}at $runtimeErrorResourcePackage.runtimeError.$$main(runtimeError.sc)
+          |${tab}at $runtimeErrorResourcePackage.runtimeError$$.<init>($runtimeErrorSc:1)
+          |${tab}at $runtimeErrorResourcePackage.runtimeError$$.<clinit>($runtimeErrorSc)
+          |${tab}at $runtimeErrorResourcePackage.runtimeError.$$main($runtimeErrorSc)
           |""".stripMargin
       )
     )

--- a/integration/src/test/scala/ammonite/integration/LineNumberTests.scala
+++ b/integration/src/test/scala/ammonite/integration/LineNumberTests.scala
@@ -106,7 +106,10 @@ object LineNumberTests extends TestSuite{
 
     'RuntimeCompilationErrorLineNumberTest - checkErrorMessage(
       file = 'lineNumbers/"RuntimeCompilationErrorLineNumberTest.sc",
-      expected = "(RuntimeCompilationErrorLineNumberTest.sc:6)"
+      expected = {
+        val p = replStandaloneResources/'lineNumbers
+        s"${p/"RuntimeCompilationErrorLineNumberTest.sc"}:6)"
+      }
     )
   }
 }


### PR DESCRIPTION
Hi,
this is my stab at #493. I took your advice and tracked the calls to this point in `Interpreter.scala`. But… I'm not quite sure if that is the correct place; or all of them. Also, I left the case for `ImportHook.Source.Url` unchanged, but maybe it is sensible to have a full url here, too? I thought an url as return value for `File()` looks strange. And to be honest,  I don't really understand what the url case means. 

I tested with the result of `amm/test:assembly`. 