### PR TITLE
Makes `..` work with $file imports as described in docs

### DIFF
--- a/amm/runtime/src/main/scala/ammonite/runtime/ImportHook.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/ImportHook.scala
@@ -62,9 +62,10 @@ object ImportHook{
   def resolveFiles(tree: ImportTree, currentScriptPath: Path, extensions: Seq[String])
                   : (Seq[(RelPath, Option[String])], Seq[Path], Seq[Path]) = {
     val relative =
-      tree.prefix
-        .map{case ammonite.util.Util.upPathSegment => up; case x => ammonite.ops.empty/x}
-        .reduce(_/_)
+      tree.prefix.map {
+          case ammonite.util.Util.upPathSegment | ".." => up
+          case x => ammonite.ops.empty / x
+        }.reduce(_ / _)
     val relativeModules = tree.mappings match{
       case None => Seq(relative -> None)
       case Some(mappings) => for((k, v) <- mappings) yield relative/k -> v

--- a/amm/src/test/scala/ammonite/session/ImportHookTests.scala
+++ b/amm/src/test/scala/ammonite/session/ImportHookTests.scala
@@ -23,6 +23,20 @@ object ImportHookTests extends TestSuite{
           res1: Int = 31337
         """)
 
+        'upSegment1 - check.session("""
+          @ import $file.amm.src.`^`.src.test.resources.importHooks.Basic
+
+          @ Basic.basicValue
+          res1: Int = 31337
+        """)
+
+        'upSegment2 - check.session("""
+          @ import $file.amm.src.`..`.src.test.resources.importHooks.Basic
+
+          @ Basic.basicValue
+          res1: Int = 31337
+        """)
+
         'inline - check.session("""
           @ import $file.amm.src.test.resources.importHooks.Basic, Basic.basicValue
 


### PR DESCRIPTION
This will solve problems like the one in #503. Also, with this PR, both `^` and `..` will work as 'up' directives, so there's a possibility that instead of this PR we should just have the docs fixed (http://www.lihaoyi.com/Ammonite/#MagicImports uses `..` now).