### PR TITLE
Add options to disable Ammonite's defalt argument parser (for scripts)

### DIFF
--- a/amm/src/main/scala/ammonite/Main.scala
+++ b/amm/src/main/scala/ammonite/Main.scala
@@ -146,6 +146,7 @@ object Main{
     var predefFiles: Seq[Path] = Vector.empty
     var continually = false
     var replApi = false
+    var shouldParseScriptArguments = true
     val replParser = new scopt.OptionParser[Main]("ammonite") {
       // Primary arguments that correspond to the arguments of
       // the `Main` configuration object
@@ -203,7 +204,14 @@ object Main{
             |normally not available in scripts and only provided in the
             |interactive REpl
           """.stripMargin)
-
+      opt[Unit]('n', "no-arg-parse")
+        .foreach {_ =>
+          shouldParseScriptArguments = false}
+        .text(
+          """Do not use Ammonite's default argument parser to parse
+            |any arguments after '--'. If you use this option, the main method
+            |of your script should expect a String* as its only parameter
+          """.stripMargin)
     }
 
     val (take, drop) = args0.indexOf("--") match {
@@ -211,24 +219,16 @@ object Main{
       case n => (n, n+1)
     }
 
-    val before = args0.take(take)
-    var keywordTokens = args0.drop(drop).toList
-    var kwargs = Vector.empty[(String, String)]
+    // arguments before the lone '--' used to separate the
+    // ammonite arguments & script arguments
+    val argumentsBefore = args0.take(take)
+    val argumentsToParse = args0.drop(drop).toList
 
-    while(keywordTokens.nonEmpty){
-      if (keywordTokens(0).startsWith("--")){
-        kwargs = kwargs :+ (keywordTokens(0).drop(2), keywordTokens(1))
-        keywordTokens = keywordTokens.drop(2)
-      }else{
-        passThroughArgs = passThroughArgs :+ keywordTokens(0)
-        keywordTokens = keywordTokens.drop(1)
-      }
-    }
     def ifContinually[T](b: Boolean)(f: => T) = {
       if (b) while(true) f
       else f
     }
-    for(c <- replParser.parse(before, Main())) ifContinually(continually){
+    for(c <- replParser.parse(argumentsBefore, Main())) ifContinually(continually){
       def main(isRepl: Boolean) = Main(
         c.predef,
         c.defaultPredef,
@@ -248,8 +248,12 @@ object Main{
       )
       (fileToExecute, codeToExecute) match {
         case (None, None) => println("Loading..."); main(true).run()
-        case (Some(path), None) =>
-          main(false).runScript(path, passThroughArgs, kwargs, replApi) match {
+        case (Some(path), None) => {
+          val (additionalPassThroughArgs, kwargs) = if (shouldParseScriptArguments) {
+            parseScriptArguments(argumentsToParse)
+          }
+          else (Seq.empty[String], Vector.empty[(String, String)])
+          main(false).runScript(path, passThroughArgs ++ additionalPassThroughArgs, kwargs, replApi) match {
             case Res.Failure(exOpt, msg) =>
               Console.err.println(msg)
               System.exit(1)
@@ -261,6 +265,7 @@ object Main{
             case Res.Success(_) =>
             // do nothing on success, everything's already happened
           }
+        }
 
         case (None, Some(code)) => main(false).runCode(code, replApi)
 
@@ -271,6 +276,23 @@ object Main{
 
   def maybeDefaultPredef(enabled: Boolean, predef: String) =
     if (enabled) predef else ""
+
+  def parseScriptArguments(argumentsToParse: Seq[String]): (Seq[String], Vector[(String, String)]) = {
+    var keywordTokens = argumentsToParse
+    var kwargs = Vector.empty[(String, String)]
+    var additionalPassThroughArgs = Seq.empty[String]
+
+    while (keywordTokens.nonEmpty) {
+      if (keywordTokens(0).startsWith("--")) {
+        kwargs = kwargs :+ (keywordTokens(0).drop(2), keywordTokens(1))
+        keywordTokens = keywordTokens.drop(2)
+      } else {
+        additionalPassThroughArgs = additionalPassThroughArgs :+ keywordTokens(0)
+        keywordTokens = keywordTokens.drop(1)
+      }
+    }
+    (additionalPassThroughArgs, kwargs)
+  }
 
 
 }

--- a/readme/Scripts.scalatex
+++ b/readme/Scripts.scalatex
@@ -228,20 +228,23 @@
         The @hl.scala{main} method does not get automatically called when you
         @hl.scala{load.module} or @hl.scala{load.exec} a script from @i{within}
         the Ammonite REPL. It gets imported into scope like any other method or
-        value defined in the script, and you can just call it normally.
+        value defined in tmhe script, and you can just call it normally.
 
       @p
-        @hl.scala{vararg*} arguments work as you would expect as well, allowing one or
-        more arguments to be passed from the command-line and aggregated into
-        a @code{Seq} for your function to use. This also allows you to use a
-        custom argument-parser (e.g. @lnk("Eugene Yokota",
+        By making your main method receive @hl.scala{vararg*} arguments and running
+        Ammonite with the @code{-n / --no-arg-parse} flag, Ammonite will not attempt
+        to parse the arguments for the script but instead pass them through to the main
+        method. This allows you to use a custom argument-parser (e.g. @lnk("Eugene Yokota",
         "https://github.com/eed3si9n")'s excellent @lnk("Scopt",
-        "https://github.com/scopt/scopt")) library by defining your function
-        as taking @hl.scala{String*}:
+        "https://github.com/scopt/scopt")) for your script:
+
+      @hl.sh
+        amm -n CustomArgumentParsing.sc -- --custom -f hi
 
       @hl.scala
         @@main
         def entrypoint(args: String*) = {
+          // args == Array("--custom", "-f", "hi")
           ...
         }
 

--- a/readme/Scripts.scalatex
+++ b/readme/Scripts.scalatex
@@ -228,10 +228,10 @@
         The @hl.scala{main} method does not get automatically called when you
         @hl.scala{load.module} or @hl.scala{load.exec} a script from @i{within}
         the Ammonite REPL. It gets imported into scope like any other method or
-        value defined in tmhe script, and you can just call it normally.
+        value defined in the script, and you can just call it normally.
 
       @p
-        By making your main method receive @hl.scala{vararg*} arguments and running
+        By making your main method receive a vararg @hl.scala{String*} argument and running
         Ammonite with the @code{-n / --no-arg-parse} flag, Ammonite will not attempt
         to parse the arguments for the script but instead pass them through to the main
         method. This allows you to use a custom argument-parser (e.g. @lnk("Eugene Yokota",
@@ -244,14 +244,9 @@
       @hl.scala
         @@main
         def entrypoint(args: String*) = {
-          // args == Array("--custom", "-f", "hi")
+          // args == Seq("--custom", "-f", "hi")
           ...
         }
-
-      @p
-        In which case Ammonite will take all arguments and forward them to your
-        main method un-checked and un-validated, from which point you can deal
-        with the raw @code{Seq[String]} however you wish.
 
     @sect{Multiple Main Methods}
       @p


### PR DESCRIPTION
This fixes #479

This PR adds a `-n / --no-arg-parse` flag to ammonite executable which stops Ammonite from parsing command line arguments intended for the script (after `--`).

Previously this will break because Ammonite is expecting something after the `--world` flag (keyword arguments):

`amm hello.sc -- --world`

But now with `-n` flag, Ammonite will not try to parse anything after `--`. The script with a main function that takes a `String*` vararg will now have `varargs == Array('--world')` and we can plumb that to our custom command line argument parser.

`amm -n hello.sc -- --world`

Happy to rename the flag if you got a better name.

I'll need some pointers as to how I can write tests for this. I couldn't find an example to test command line arguments + script.