### PR TITLE
update sshd

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -259,11 +259,13 @@ lazy val sshd = project
       crossVersion := CrossVersion.full,
       name := "ammonite-sshd",
       libraryDependencies ++= Seq(
-        "org.apache.sshd" % "sshd-core" % "0.14.0",
+        // sshd-core 1.3.0 requires java8
+        "org.apache.sshd" % "sshd-core" % "1.2.0",
+        "org.bouncycastle" % "bcprov-jdk15on" % "1.56",
         //-- test --//
         // slf4j-nop makes sshd server use logger that writes into the void
         "org.slf4j" % "slf4j-nop" % "1.7.12" % Test,
-        "com.jcraft" % "jsch" % "0.1.53" % Test,
+        "com.jcraft" % "jsch" % "0.1.54" % Test,
         "org.scalacheck" %% "scalacheck" % "1.12.6" % Test
       )
   )

--- a/sshd/src/main/scala/ammonite/sshd/SshServer.scala
+++ b/sshd/src/main/scala/ammonite/sshd/SshServer.scala
@@ -7,11 +7,12 @@ import ammonite.ops.Path
 import org.apache.sshd.agent.SshAgentFactory
 import org.apache.sshd.common._
 import org.apache.sshd.common.file.FileSystemFactory
-import org.apache.sshd.common.session.ConnectionService
+import org.apache.sshd.common.session.{ConnectionService, Session}
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider
 import org.apache.sshd.server.session.ServerSession
-import org.apache.sshd.server.{Command, CommandFactory, PasswordAuthenticator}
-import org.apache.sshd.{SshServer => SshServerImpl}
+import org.apache.sshd.server.{Command, CommandFactory}
+import org.apache.sshd.server.auth.password.PasswordAuthenticator
+import org.apache.sshd.server.{SshServer => SshServerImpl}
 
 /**
  * A factory to simplify creation of ssh server
@@ -35,7 +36,7 @@ object SshServer {
     val hostKeyFile = touch(
       options.hostKeyFile.getOrElse(fallbackHostkeyFilePath(options))
     )
-    new SimpleGeneratorHostKeyProvider(hostKeyFile.toString(), "RSA")
+    new SimpleGeneratorHostKeyProvider(hostKeyFile.toNIO)
   }
 
   private def disableUnsupportedChannels(sshServer: SshServerImpl) = {
@@ -53,7 +54,7 @@ object SshServer {
       override def getChannelForwardingFactory = null
     })
     sshServer.setFileSystemFactory(new FileSystemFactory {
-      override def createFileSystemView(session: Session) = null
+      override def createFileSystem(session: Session) = null
     })
     sshServer
   }

--- a/sshd/src/test/scala/ammonite/sshd/SshTestingUtils.scala
+++ b/sshd/src/test/scala/ammonite/sshd/SshTestingUtils.scala
@@ -6,6 +6,7 @@ import java.util.concurrent.TimeoutException
 import ammonite.ops._
 import com.jcraft.jsch.{Channel, JSch, Session, UserInfo}
 import org.scalacheck.Gen
+import org.apache.sshd.server.{SshServer => SshServerImpl}
 
 import scala.annotation.tailrec
 import scala.concurrent.{Await, Future}
@@ -59,7 +60,7 @@ object SshTestingUtils {
   }
 
   def withTestSshServer[T](user: (String, String), testShell: () => Any = () => ???)
-                          (test: org.apache.sshd.SshServer => T)
+                          (test: SshServerImpl => T)
                           (implicit dir: Path): T = {
     val server = testSshServer(user, (_, _) => testShell.apply())
     server.start()
@@ -70,7 +71,7 @@ object SshTestingUtils {
     }
   }
 
-  def sshClient(creds: (String, String), sshServer: org.apache.sshd.SshServer): Session = {
+  def sshClient(creds: (String, String), sshServer: SshServerImpl): Session = {
     sshClient(creds, Option(sshServer.getHost).getOrElse("localhost"), sshServer.getPort)
   }
 
@@ -78,11 +79,20 @@ object SshTestingUtils {
     val client = new JSch
     val session = client.getSession(creds._1, host, port)
     session.setPassword(creds._2)
-    session.setConfig("server_host_key", Seq(
-        "ecdsa-sha2-nistp256",
-        "ecdsa-sha2-nistp384",
-        "ecdsa-sha2-nistp521",
-        "ssh-rsa").mkString(","))
+    // http://stackoverflow.com/a/28754307
+    // https://sourceforge.net/p/jsch/mailman/message/32975616/
+    val configuration = new java.util.Properties();
+    configuration.put(
+      "kex",
+      Seq(
+        "diffie-hellman-group1-sha1",
+        "diffie-hellman-group14-sha1",
+        "diffie-hellman-group-exchange-sha1",
+        "diffie-hellman-group-exchange-sha256"
+      ).mkString(",")
+    );
+    configuration.put("StrictHostKeyChecking", "no");
+    session.setConfig(configuration)
     session.setUserInfo(autoAcceptHostKeyUser(creds._2))
     session
   }


### PR DESCRIPTION
I was having issues trying to connect to the ssh server and i came across issue #508 
My error was different but the experience from the client of having the connection immediately closed was the same, and I've had this experience before in a different context (that I don't currently have all the details of)

I'm not sure what the root cause is, but i figured updating the dependencies and getting on a major version of `sshd-core` at least wouldn't hurt (and was hoping, with some luck, it might just fix the issues i was having)

The stack trace from the initial error that started all this for me was:
```txt
[sshd-SshServer[763300f]-nio2-thread-3] WARN org.apache.sshd.server.channel.ChannelSession - Error processing channel request auth-agent-req@openssh.com
org.apache.sshd.common.SshException
	at org.apache.sshd.agent.common.AgentForwardSupport.initialize(AgentForwardSupport.java:51)
	at org.apache.sshd.server.session.ServerConnectionService.initAgentForward(ServerConnectionService.java:60)
	at org.apache.sshd.server.channel.ChannelSession.handleAgentForwarding(ChannelSession.java:559)
	at org.apache.sshd.server.channel.ChannelSession.handleRequest(ChannelSession.java:327)
	at org.apache.sshd.server.channel.ChannelSession$ChannelSessionRequestHandler.process(ChannelSession.java:602)
	at org.apache.sshd.server.channel.ChannelSession$ChannelSessionRequestHandler.process(ChannelSession.java:600)
	at org.apache.sshd.common.channel.AbstractChannel.handleRequest(AbstractChannel.java:100)
	at org.apache.sshd.common.session.AbstractConnectionService.channelRequest(AbstractConnectionService.java:274)
	at org.apache.sshd.common.session.AbstractConnectionService.process(AbstractConnectionService.java:153)
	at org.apache.sshd.common.session.AbstractSession.doHandleMessage(AbstractSession.java:431)
	at org.apache.sshd.common.session.AbstractSession.handleMessage(AbstractSession.java:326)
	at org.apache.sshd.common.session.AbstractSession.decode(AbstractSession.java:780)
	at org.apache.sshd.common.session.AbstractSession.messageReceived(AbstractSession.java:308)
	at org.apache.sshd.common.AbstractSessionIoHandler.messageReceived(AbstractSessionIoHandler.java:54)
	at org.apache.sshd.common.io.nio2.Nio2Session$1.onCompleted(Nio2Session.java:184)
	at org.apache.sshd.common.io.nio2.Nio2Session$1.onCompleted(Nio2Session.java:170)
	at org.apache.sshd.common.io.nio2.Nio2CompletionHandler$1.run(Nio2CompletionHandler.java:32)
	at java.security.AccessController.doPrivileged(Native Method)
	at org.apache.sshd.common.io.nio2.Nio2CompletionHandler.completed(Nio2CompletionHandler.java:30)
	at sun.nio.ch.Invoker.invokeUnchecked(Invoker.java:126)
	at sun.nio.ch.Invoker$2.run(Invoker.java:218)
	at sun.nio.ch.AsynchronousChannelGroupImpl$1.run(AsynchronousChannelGroupImpl.java:112)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.NullPointerException
	at org.apache.sshd.agent.common.AgentForwardSupport.initialize(AgentForwardSupport.java:45)
	... 24 more
```