### PR TITLE
Pass unmodified arguments to the interpreter

### DIFF
--- a/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
@@ -35,6 +35,7 @@ class Interpreter(val printer: Printer,
                   // the REPL before it starts
                   extraBridges: Interpreter => Seq[(String, String, AnyRef)],
                   val wd: Path,
+                  args: Seq[String] = Nil,
                   verboseOutput: Boolean = true)
   extends ImportHook.InterpreterInterface{ interp =>
 
@@ -684,6 +685,8 @@ class Interpreter(val printer: Printer,
       }
 
     }
+
+    lazy val args = Interpreter.this.args
   }
 
 }

--- a/amm/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -18,7 +18,8 @@ class Repl(input: InputStream,
            predef: String,
            wd: ammonite.ops.Path,
            welcomeBanner: Option[String],
-           replArgs: Seq[Bind[_]] = Nil) {
+           replArgs: Seq[Bind[_]] = Nil,
+           interpArgs: Seq[String] = Nil) {
 
   val prompt = Ref("@ ")
 
@@ -60,7 +61,8 @@ class Repl(input: InputStream,
       )
       Seq(("ammonite.repl.ReplBridge", "repl", replApi))
     },
-    wd
+    wd,
+    args = interpArgs
   )
 
   // Call `session.save` _after_ the interpreter is fully instantiated and

--- a/amm/runtime/src/main/scala/ammonite/runtime/InterpAPI.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/InterpAPI.scala
@@ -27,6 +27,11 @@ trait InterpAPI {
    */
   def resolvers: Ref[List[Resolver]]
 
+  /**
+   * Unmodified interpreter args
+   */
+  def args: Seq[String]
+
 }
 
 

--- a/amm/src/test/resources/scripts/InterpArgs.sc
+++ b/amm/src/test/resources/scripts/InterpArgs.sc
@@ -1,0 +1,1 @@
+val res = interp.args

--- a/amm/src/test/scala/ammonite/ScriptTests.scala
+++ b/amm/src/test/scala/ammonite/ScriptTests.scala
@@ -165,6 +165,32 @@ object ScriptTests extends TestSuite{
             """)
         }
       }
+      'interpArgs {
+        'none {
+          check.session(s"""
+            @  import ammonite.ops._
+
+            @ interp.load.exec($printedScriptPath/"InterpArgs.sc")
+
+            @ val r = res
+            r: Seq[String] = List()
+            """.stripMargin
+          )
+        }
+        'some {
+          val args = Seq("arg1", "--opt1", "value1", "--opt2", "arg2", "--", "arg3")
+          val checkArgs = new TestRepl(args)
+          checkArgs.session(s"""
+            @  import ammonite.ops._
+
+            @ interp.load.exec($printedScriptPath/"InterpArgs.sc")
+
+            @ val r = res
+            r: Seq[String] = List("arg1", "--opt1", "value1", "--opt2", "arg2", "--", "arg3")
+            """.stripMargin
+          )
+        }
+      }
 
     }
 

--- a/amm/src/test/scala/ammonite/TestRepl.scala
+++ b/amm/src/test/scala/ammonite/TestRepl.scala
@@ -13,7 +13,7 @@ import scala.collection.mutable
  * A test REPL which does not read from stdin or stdout files, but instead lets
  * you feed in lines or sessions programmatically and have it execute them.
  */
-class TestRepl {
+class TestRepl(interpArgs: Seq[String] = Nil) {
   var allOutput = ""
   def predef = ""
 
@@ -56,7 +56,8 @@ class TestRepl {
         )
 
         Seq(("ammonite.repl.ReplBridge", "repl", replApi))
-      }
+      },
+      args = interpArgs
     )
     i.init()
     i

--- a/integration/src/test/resources/ammonite/integration/basic/InterpArgs.sc
+++ b/integration/src/test/resources/ammonite/integration/basic/InterpArgs.sc
@@ -1,0 +1,1 @@
+println(interp.args)

--- a/integration/src/test/scala/ammonite/integration/BasicTests.scala
+++ b/integration/src/test/scala/ammonite/integration/BasicTests.scala
@@ -303,6 +303,25 @@ object BasicTests extends TestSuite{
 
       }
     }
+
+    'interpArgs {
+      'none {
+        val evaled = exec('basic/"InterpArgs.sc", "-s")
+        assert(evaled.out.string.contains("List()"))
+      }
+      'noneWithDDash {
+        val evaled = exec('basic/"InterpArgs.sc", "-s", "--")
+        assert(evaled.out.string.contains("List()"))
+      }
+      'some {
+        val evaled = exec('basic/"InterpArgs.sc", "-s", "--",
+          "arg1", "--opt1", "value1", "--opt2", "arg2", "--", "arg3")
+        assert(evaled.out.string.contains(
+          """List(arg1, --opt1, value1, --opt2, arg2, --, arg3)"""
+        ))
+      }
+    }
+
     'http{
       'shorten {
         val res = exec('basic / "HttpApi.sc", "shorten", "https://www.github.com", "-s")

--- a/integration/src/test/scala/ammonite/integration/TestMain.scala
+++ b/integration/src/test/scala/ammonite/integration/TestMain.scala
@@ -5,7 +5,7 @@ object TestMain {
     // Break into debug REPL with
     ammonite.Main(
       predef = "println(\"Starting Debugging!\")"
-    ).run(
+    ).run(Nil,
       "hello" -> hello,
       "fooValue" -> foo()
     )


### PR DESCRIPTION
As requested in #538 and attempted in #440, here is a commit to pass non-ammonite arguments to the interpreter, available as `interp.args` once amm is launched.

Comes with a unit test to have more chances to land ;)