### PR TITLE
Avoid github exceeded API rate limit error in tests

### DIFF
--- a/integration/src/test/resources/ammonite/integration/basic/HttpApi.sc
+++ b/integration/src/test/resources/ammonite/integration/basic/HttpApi.sc
@@ -1,33 +1,31 @@
 #!/usr/bin/env amm
 // HttpApi.sc
 import scalaj.http._
-/**
-  * Github URL shortener script using Scalaj-HTTP and the git.io API.
-  */
+
 @main
-def shorten(longUrl: String) = {
-  val res = Http("https://git.io")
-    .postForm(Seq("url" -> longUrl))
-    .asString
-    .headers("Location")
-    .head
+def addPost(title: String, body: String) = {
+  val res = upickle.json.read(
+    Http("http://jsonplaceholder.typicode.com/posts")
+      .postForm(Seq("title"  -> title,
+                    "body"   -> body,
+                    "userId" -> "1"))
+      .asString
+      .body
+  ).obj.get("id").map(_.num.toInt).getOrElse(0)
   println(res)
   res
 }
 
-/**
-  * Github URL shortener script using Scalaj-HTTP and the git.io API.
-  */
 @main
-def listReleases(project: String) = {
+def comments(postId: Int) = {
   val json = upickle.json.read(
-    Http(s"https://api.github.com/repos/$project/releases")
+    Http(s"http://jsonplaceholder.typicode.com/comments?postId=$postId")
       .asString
       .body
   )
-  val releaseNames = for{
+  val names = for{
     item <- json.arr
     name <- item.obj.get("name")
   } yield name.str
-  println(releaseNames.mkString(","))
+  println(names.mkString(","))
 }

--- a/integration/src/test/scala/ammonite/integration/BasicTests.scala
+++ b/integration/src/test/scala/ammonite/integration/BasicTests.scala
@@ -303,15 +303,15 @@ object BasicTests extends TestSuite{
 
       }
     }
-    'http{
-      'shorten {
-        val res = exec('basic / "HttpApi.sc", "shorten", "https://www.github.com", "-s")
-        assert(res.out.trim.startsWith("https://git.io"))
+    'httpApi{
+      'addPost {
+        val res = exec('basic / "HttpApi.sc", "addPost", "title", "some text", "-s")
+        assert(res.out.trim.startsWith("101"))
       }
-      'releases{
-        val res = exec('basic / "HttpApi.sc", "listReleases", "lihaoyi/Ammonite", "-s")
-        assert(res.out.trim.contains("0.7.0"))
-        assert(res.out.trim.contains("0.7.7"))
+      'comments{
+        val res = exec('basic / "HttpApi.sc", "comments", "40", "-s")
+        assert(res.out.trim.contains("totam vel saepe aut"))
+        assert(res.out.trim.contains("aperiam et omnis totam"))
       }
     }
   }


### PR DESCRIPTION
An attempt to remove this annoying error. I replaced github api  with [jsonplaceholder](http://jsonplaceholder.typicode.com/) ,which has no rate limits.