### PR TITLE
Minor docs fixes

### DIFF
--- a/readme/Cookbook.scalatex
+++ b/readme/Cookbook.scalatex
@@ -366,7 +366,7 @@
       And can be run via
 
     @code
-      ./amm PlayFramework.scala
+      ./amm PlayFramework.sc
 
     @p
       Although this is just a hello world example, you can easily keep the server running (instead of exiting after a test request) and extend it with more functionality, possibly splitting it into multiple @sect.ref{Script Files}.

--- a/readme/Footer.scalatex
+++ b/readme/Footer.scalatex
@@ -93,7 +93,7 @@
   @sect{Scaladoc}
     @p
       Here's the Scaladoc for the various projects:
-  
+
     @ul
       @li
         @a("Ammonite-Ops", href:="https://lihaoyi.github.io/Ammonite/api/ops/index.html")
@@ -105,7 +105,7 @@
         @a("Ammonite-Shell", href:="https://lihaoyi.github.io/Ammonite/api/shell/index.html")
       @li
         @a("Ammonite-Sshd", href:="https://lihaoyi.github.io/Ammonite/api/sshd/index.html")
-  
+
     @p
       Although it's best to read the documentation on this page to learn how
       to use these projects, the Scaladoc is still useful as a reference.
@@ -117,13 +117,13 @@
     @sect{0.8.1}
       @ul
         @li
-          Cross-published for Scala 2.12, with the help of 
-          @lnk("Roman Tkalenko", "https://github.com/tkroman") who 
+          Cross-published for Scala 2.12, with the help of
+          @lnk("Roman Tkalenko", "https://github.com/tkroman") who
           investigated and fixed a gnarly classpath bug @issue(515)
         @li
           Handle multi-line shebang lines, thanks to @lnk("Greg Dorrell", "https://github.com/Grogs")
         @li
-          Fix @code{NullPointerException} on no-save-then-load situation in REPL, 
+          Fix @code{NullPointerException} on no-save-then-load situation in REPL,
           thanks to @lnk("Roman Tkalenko", "https://github.com/tkroman")
         @li
           Use Console for SSHD stream redirection to avoid inter-thread spillage
@@ -612,8 +612,8 @@
         @li
           Started the @sect.ref{Ammonite Cookbook}, examples of using the
           Ammonite REPL to do useful work.
-  
-  
+
+
     @sect{0.5.2}
       @ul
         @li
@@ -691,8 +691,8 @@
         @li
           Simplify the way shelling to to run files as subprocesses works,
           and align with documentation (@issue(234))
-  
-  
+
+
     @sect{0.4.9}
       @ul
         @li
@@ -788,7 +788,7 @@
           You can now use Ammonite as a @sect.ref{Debugging} tool like Python's
           pdb, placing an interactive breakpoint anywhere within a normal
           Scala application
-  
+
     @sect{0.4.4}
       @ul
         @li
@@ -900,7 +900,7 @@
           Fix pretty-printing of higher-kinded types.
         @li
           Drop support for 2.10.x; ammonite is 2.11.x-only now
-  
+
     @sect{0.3.1}
       @ul
         @li
@@ -916,7 +916,7 @@
         @li
           Operator-named two-param generic types are now printed infix by
           default.
-  
+
     @sect{0.3.0}
       @ul
         @li
@@ -934,13 +934,13 @@
         @li
           Output lines are now truncated past a certain length, which is
           configurable, thanks to @lnk("Laszlo Mero", "https://github.com/laci37")
-  
+
     @sect{0.2.9}
       @ul
         @li
           Lots of improvements to @code{Ctrl-C} and @code{Ctrl-D} handling, to
           make it behave more like other REPLs
-  
+
     @sect{0.2.8}
       @ul
         @li

--- a/readme/Repl.scalatex
+++ b/readme/Repl.scalatex
@@ -47,7 +47,7 @@
 
   @p
     If you want some initialization code available to the REPL, you can add
-    it to your @code{~/.ammonite/predef.scala}.
+    it to your @code{~/.ammonite/predef.sc}.
   @p
     If you have any questions, come hang out on the @sect.ref("Community",
      "mailing list or gitter channel") and get help!
@@ -227,8 +227,8 @@
           Each block of typing, deletes, or navigation counts as one undo. This
           should make it much more convenient to recover from botched copy-pastes
           or bulk-deletions.
-        
-    
+
+
     @sect{Magic Imports}
       @p
         Ammonite provides a set of magic imports that let you load additional
@@ -377,20 +377,20 @@
           "https://github.com/scalaz/scalaz") or @lnk("Shapeless",
           "https://github.com/milessabin/shapeless") and immediately start
           working with them in the REPL:
-  
+
         @hl.ref(ammoniteTests/"ProjectTests.scala", Seq("shapeless", "@"), "\"\"\"")
-  
+
         @p
           Even non-trivial web frameworks like Finagle or Akka-HTTP can be
           simply pulled down and run in the REPL!
-  
+
         @hl.ref(ammoniteTests/"ProjectTests.scala", Seq("finagle", "@"), "\"\"\"")
 
 
       @p
         Ammonite-REPL is configured with a set of default resolvers but you
         can add your own
-        
+
       @hl.ref(ammoniteTests/"ProjectTests.scala", Seq("resolvers", "@"), "\"\"\"")
 
     @sect{Builtins}
@@ -706,7 +706,7 @@
           @li(a("SI-"+bug, href:="https://issues.scala-lang.org/browse/SI-"+bug))
         }
 
- 
+
   @sect{Configuration}
     @p
       Ammonite is configured via Scala code, that can live in the
@@ -715,7 +715,7 @@
       @code{--predef='...'}.
 
     @p
-      Anything that you put in @code{predef.scala} will be executed when you
+      Anything that you put in @code{predef.sc} will be executed when you
       load the Ammonite REPL. This is a handy place to put common imports,
       setup code, or even call @hl.scala{import $ivy} to
       @sect.ref("import $ivy", "load third-party jars"). The compilation
@@ -765,7 +765,7 @@
 
       @p
         If you want these changes to always be present, place them in your
-        @code{~/.ammonite/predef.scala}.
+        @code{~/.ammonite/predef.sc}.
 
     @sect{JVM Flags}
       @p

--- a/readme/Scripts.scalatex
+++ b/readme/Scripts.scalatex
@@ -40,7 +40,7 @@
       the REPL; this can be used to save common functionality so it can be
       used at a later date. In the simplest case, a script file is simply a
       sequence of Scala statements, e.g.
-  
+
     @hl.scala
       // MyScript.sc
       // print banner
@@ -72,7 +72,7 @@
       Hello World!!
       x is 123
       ...
-  
+
     @sect{Script Imports}
       @p
         No code stands alone; scripts depend on other scripts. Often they depend
@@ -96,26 +96,26 @@
           need to set up a @code{src/main/scala} folder, and create a build file,
           and all these other things: simply split your script into two files, and
           import one from the other using @sect.ref{import $file}:
-    
+
         @hl.ref('amm/'src/'test/'resources/'importHooks/"Basic.sc")
-    
+
         @hl.ref('amm/'src/'test/'resources/'importHooks/"FileImport.sc")
-    
+
         @p
-          Here, we are defining a simple @hl.scala{val} in @code{Basic.scala}, and
-          then importing it from @code{FileImport.scala}. And of course, we can
-          use what we defined in @code{FileImport.scala} and import it in another
+          Here, we are defining a simple @hl.scala{val} in @code{Basic.sc}, and
+          then importing it from @code{FileImport.sc}. And of course, we can
+          use what we defined in @code{FileImport.sc} and import it in another
           file
-    
+
         @hl.ref('amm/'src/'test/'resources/'importHooks/"IndirectFileImport.sc")
-    
+
         @p
           And so on, importing files as many or as deep as you want. You can
           use @hl.scala{^} segments at the start of your @hl.scala{import $file}
           to import things from outside your current working directory, e.g.
           @hl.scala{import $file.^.^.foo} will import the script file
           @code{../../foo.sc} and make it available for you to use.
-    
+
         @p
           @hl.scala{$file} imports inside Scala Scripts behave the same as
           @hl.scala{$file} imports @sect.ref("import $file",
@@ -168,19 +168,19 @@
         *after* the current compilation block is compiled, you need to split
         your script into two compilation blocks, and can only use the results
         of the @hl.scala{load}ed code in subsequent blocks:
-    
+
       @hl.scala
         // print banner
         println("Welcome to the XYZ custom REPL!!")
         val scalazVersion = "7.1.1"
         interp.load.ivy("org.scalaz" %% "scalaz-core" % scalazVersion)
-    
+
         @@
-    
+
         // common imports
         import scalaz._
         import Scalaz._
-    
+
         // use Scalaz!
         ...
 
@@ -190,7 +190,7 @@
         Nevertheless, sometimes you may find yourself needing to get "under the
         hood" and use these @hl.scala{load}ing functions directly. When that
         happens, using @sect.ref{Multi-stage Scripts} is the way to go.
-    
+
     @sect{Script Arguments}
       @p
         Often when calling a script from the external command-line (e.g.
@@ -350,7 +350,7 @@
         @replCurl
 
       @hl.scala
-        bash$ amm path/to/script.scala
+        bash$ amm path/to/script.sc
 
       @p
         All types, values and imports defined in scripts are available to
@@ -359,7 +359,7 @@
       @p
         You can also make an Ammonite script self-executable by using a shebang
         @hl.scala{#!}. This is an example script named @hl.scala{hello}. There
-        is no need to add the @hl.scala{.scala} extension. The @hl.scala{amm}
+        is no need to add the @hl.scala{.sc} extension. The @hl.scala{amm}
         command needs to be in the @hl.scala{PATH}:
       @hl.sh
         #!/usr/bin/env amm
@@ -377,7 +377,7 @@
         a custom memory limit via
 
       @hl.scala
-        bash$ JAVA_OPTS="-Xmx1024m" amm path/to/script.scala
+        bash$ JAVA_OPTS="-Xmx1024m" amm path/to/script.sc
 
       @p
         To let it use only up to 1024 megabytes of memory
@@ -391,7 +391,7 @@
       @hl.scala
         @@ x // doesn't work yet
         Compilation Failed
-        cmd0.scala:1: not found: value x
+        cmd0.sc:1: not found: value x
         val res0 = x // doesn't work yet
                    ^
         @@ import $file.MyScript
@@ -412,7 +412,7 @@
       @hl.scala
         @@ x // doesn't work yet
         Compilation Failed
-        cmd0.scala:1: not found: value x
+        cmd0.sc:1: not found: value x
         val res0 = x // doesn't work yet
                    ^
         @@ import $file.MyScript, MyScript._
@@ -431,7 +431,7 @@
         Welcome to the XYZ custom REPL!!
         import $file.$
         @@ mutable.Buffer(x)
-        cmd1.scala:1: not found: value mutable
+        cmd1.sc:1: not found: value mutable
         val res1 = mutable.Buffer(x)
                    ^
         Compilation Failed
@@ -497,7 +497,7 @@
           Otherwise, the source code for this script is then wrapped in a
           @hl.scala{package}/@hl.scala{object} wrapper, corresponding to the
           path to the script from the current working directory. For example,
-          a script at path @code{foo/bar/baz/Qux.scala} will be wrapped in:
+          a script at path @code{foo/bar/baz/Qux.sc} will be wrapped in:
 
           @hl.scala
 
@@ -521,7 +521,7 @@
         Although this is much slower than other scripting languages like Bash
         (which starts up in ~4ms) or Python (~30ms), in practice it is
         acceptable for many use cases. You probably do not want to
-        @code{find . | xargs amm Foo.scala} on large numbers of files, where
+        @code{find . | xargs amm Foo.sc} on large numbers of files, where
         the 100ms overhead will add up, but for individual scripts it should
         be fine.
       @p


### PR DESCRIPTION
Just fixed remaining .scala extensions and removed trailing white-spaces.

Looks like you already did all necessary docs changes for #558.  But if there is still something I could help with, please let me know.