### PR TITLE
Add an overloaded version of LoadJar.cp that takes a sequence of paths

### DIFF
--- a/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
@@ -370,7 +370,7 @@ class Interpreter(val printer: Printer,
         (source, verboseOutput) match {
           case (ImportHook.Source.File(fName), true) =>
             printer.out("Compiling " + fName.last + "\n")
-          case (ImportHook.Source.URL(url), true) => 
+          case (ImportHook.Source.URL(url), true) =>
             printer.out("Compiling " + url + "\n")
           case _ =>
         }
@@ -626,6 +626,10 @@ class Interpreter(val printer: Printer,
 
     def cp(jar: Path): Unit = {
       handleClasspath(new java.io.File(jar.toString))
+      reInit()
+    }
+    def cp(jars: Seq[Path]): Unit = {
+      jars.map(_.toString).map(new java.io.File(_)).foreach(handleClasspath)
       reInit()
     }
     def ivy(coordinates: (String, String, String), verbose: Boolean = true): Unit = {

--- a/amm/runtime/src/main/scala/ammonite/runtime/InterpAPI.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/InterpAPI.scala
@@ -23,7 +23,7 @@ trait InterpAPI {
   def load: Load
 
   /**
-   * resolvers to use when loading jars 
+   * resolvers to use when loading jars
    */
   def resolvers: Ref[List[Resolver]]
 
@@ -36,6 +36,10 @@ trait LoadJar {
    * Load a `.jar` file or directory into your JVM classpath
    */
   def cp(jar: Path): Unit
+  /**
+   * Load one or more `.jar` files or directories into your JVM classpath
+   */
+  def cp(jars: Seq[Path]): Unit
   /**
    * Load a library from its maven/ivy coordinates
    */
@@ -53,7 +57,7 @@ trait Load extends (String => Unit) with LoadJar{
    * Loads and executes the scriptfile on the specified path.
    * Compilation units separated by `@\n` are evaluated sequentially.
    * If an error happens it prints an error message to the console.
-   */ 
+   */
   def exec(path: Path): Unit
 
   def module(path: Path): Unit

--- a/readme/Scripts.scalatex
+++ b/readme/Scripts.scalatex
@@ -164,10 +164,16 @@
       @p
         These are plain-old-Scala-functions that let you pass in a
         @hl.scala{Path} to a script to load, or load different Ivy artifacts
-        depending on runtime values. However, since these functions get run
-        *after* the current compilation block is compiled, you need to split
-        your script into two compilation blocks, and can only use the results
-        of the @hl.scala{load}ed code in subsequent blocks:
+        depending on runtime values. Additionally, there is an overloaded
+        version of @hl.scala{interp.load.cp} which takes a @hl.scala{Seq[Path]}
+        of classpath entries. This variant is much more efficient for adding
+        multiple classpath entries at once.
+
+      @p
+        Since these functions get run *after* the current compilation block is
+        compiled, you need to split your script into two compilation blocks,
+        and can only use the results of the @hl.scala{load}ed code in
+        subsequent blocks:
 
       @hl.scala
         // print banner


### PR DESCRIPTION
Add an overloaded version of `LoadJar.cp` that takes a sequence of paths for efficiency. In testing performance adding 226 jars, the overloaded version is about two orders of magnitude faster than the original method.

Also, trim some EOL whitespace and add an EOF newline (BSR)