### PR TITLE
add beforeExitHooks for cleanup before repl exits

### DIFF
--- a/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
@@ -55,6 +55,7 @@ class Interpreter(val printer: Printer,
   val dynamicClasspath = new VirtualDirectory("(memory)", None)
   var compiler: Compiler = null
   var pressy: Pressy = _
+  val beforeExitHooks = mutable.Buffer.empty[Any ⇒ Any]
 
   def evalClassloader = eval.frames.head.classloader
 

--- a/amm/repl/src/main/scala/ammonite/repl/ApiImpls.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/ApiImpls.scala
@@ -70,6 +70,7 @@ class ReplApiImpl(val interp: Interpreter,
   val colors = colors0
   val prompt = prompt0
   val frontEnd = frontEnd0
+  val beforeExitHooks = interp.beforeExitHooks
 
   implicit def tprintColors = pprint.TPrintColors(
     typeColor = colors().`type`()

--- a/amm/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -119,6 +119,10 @@ class Repl(input: InputStream,
     }
     loop()
   }
+
+  def beforeExit(exitValue: Any): Any = {
+    Function.chain(interp.beforeExitHooks)(exitValue)
+  }
 }
 
 object Repl{

--- a/amm/repl/src/main/scala/ammonite/repl/ReplAPI.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/ReplAPI.scala
@@ -12,6 +12,7 @@ import acyclic.file
 import ammonite.runtime.{APIHolder, Frame, History, ReplExit}
 
 import scala.util.control.ControlThrowable
+import scala.collection.mutable
 import acyclic.file
 
 
@@ -25,6 +26,11 @@ trait ReplAPI {
    * Exit the Ammonite REPL. You can also use Ctrl-D to exit
    */
   def exit(value: Any) = throw ReplExit(value)
+  /**
+    * Functions that will be chained and called on the
+    * exitValue before the repl exits
+    */
+  val beforeExitHooks: mutable.Buffer[Any ⇒ Any]
 
 
   /**

--- a/amm/src/main/scala/ammonite/Main.scala
+++ b/amm/src/main/scala/ammonite/Main.scala
@@ -106,7 +106,8 @@ case class Main(predef: String = "",
   }
   def run(replArgs: Bind[_]*) = {
     val repl = instantiateRepl(replArgs)
-    repl.run()
+    val exitValue = repl.run()
+    repl.beforeExit(exitValue)
   }
 
   /**


### PR DESCRIPTION
inspired by #121 but not exactly what we were discussing there
not sure if this is the best (or even a good 😅 ) way to do this
but really just wanted something that worked [like this](https://github.com/emanresusername/.ammonite/blob/akkators/predef.sc#L112-L125) and this handled that usecase well enough for me :)

glad to hear other thoughts/suggestions/improvements/etc