### PR TITLE
Fix test in 2.12.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ matrix:
   # separate, sequential processes.
   - env: CI_SCRIPT="ci/build.sc test published/test"
     jdk: oraclejdk8
-    scala: 2.12.1
+    scala: 2.12.2
   - env: CI_SCRIPT="ci/build.sc test integration/test"
     jdk: oraclejdk8
-    scala: 2.12.1
+    scala: 2.12.2
 
   - env: CI_SCRIPT="ci/build.sc test published/test"
     jdk: oraclejdk8

--- a/amm/src/test/scala/ammonite/session/EulerTests.scala
+++ b/amm/src/test/scala/ammonite/session/EulerTests.scala
@@ -557,7 +557,7 @@ object EulerTests extends TestSuite{
       // What is the first term in the Fibonacci sequence to contain 1000 digits?*
       check.session("""
         @ lazy val fs: Stream[BigInt] =
-        @  0 #:: 1 #:: fs.zip(fs.tail).map(p => p._1 + p._2)
+        @  (0: BigInt) #:: (1: BigInt) #:: fs.zip(fs.tail).map(p => p._1 + p._2)
 
         @ val r = fs.view.takeWhile(_.toString.length < 1000).size
         r: Int = 4782


### PR DESCRIPTION
The `p25` test of `EulerTests` seems not to compile anymore in `2.12.2` (haven't investigated why... - changes in the typer?). This PR fixes it, and makes the CI use `2.12.2`.