### PR TITLE
Various improvements to ammonite-sshd:

### DIFF
--- a/readme/Repl.scalatex
+++ b/readme/Repl.scalatex
@@ -887,8 +887,7 @@
           SshServerConfig(
             address = "localhost", // or "0.0.0.0" for public-facing shells
             port = 22222, // Any available port
-            username = "repl", // Arbitrary
-            password = "your_secure_password" // or ""
+            passwordAuthenticator = Some(pwdAuth) // or publicKeyAuthenticator
           )
         )
         replServer.start()
@@ -913,8 +912,9 @@
       @p
         @b{Security notes:} It is probably unsafe to run this server publicly
         (on host @hl.scala{"0.0.0.0"}) in a production, public-facing
-        application. Currently it doesn't supports key-based auth, and
-        password-based auth is notoriously weak.
+        application.  If you insist on doing so, you probably want key-based
+        authentication, available by supplying @hl.scala{publicKeyAuthenticator}
+        in the @hl.scala{SshServerConfig}.
 
       @p
         Despite this, it is perfectly possible to run these on production

--- a/sshd/src/main/scala/ammonite/sshd/SshServer.scala
+++ b/sshd/src/main/scala/ammonite/sshd/SshServer.scala
@@ -1,6 +1,7 @@
 package ammonite.sshd
 
 import acyclic.file
+import java.security.PublicKey
 import java.util.Collections
 
 import ammonite.ops.Path
@@ -8,11 +9,12 @@ import org.apache.sshd.agent.SshAgentFactory
 import org.apache.sshd.common._
 import org.apache.sshd.common.file.FileSystemFactory
 import org.apache.sshd.common.session.{ConnectionService, Session}
+import org.apache.sshd.server.auth.keyboard.DefaultKeyboardInteractiveAuthenticator
+import org.apache.sshd.server.auth.password.PasswordAuthenticator
+import org.apache.sshd.server.auth.pubkey.PublickeyAuthenticator
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider
 import org.apache.sshd.server.session.ServerSession
-import org.apache.sshd.server.{Command, CommandFactory}
-import org.apache.sshd.server.auth.password.PasswordAuthenticator
-import org.apache.sshd.server.{SshServer => SshServerImpl}
+import org.apache.sshd.server.{Command, CommandFactory, SshServer => SshServerImpl}
 
 /**
  * A factory to simplify creation of ssh server
@@ -22,9 +24,13 @@ object SshServer {
     val sshServer = SshServerImpl.setUpDefaultServer()
     sshServer.setHost(options.address)
     sshServer.setPort(options.port)
-    sshServer.setPasswordAuthenticator(
-      passwordAuthenticator(options.username, options.password)
-    )
+    options.passwordAuthenticator.foreach { auth =>
+      sshServer.setPasswordAuthenticator(auth)
+      sshServer.setKeyboardInteractiveAuthenticator(new DefaultKeyboardInteractiveAuthenticator())
+    }
+    options.publicKeyAuthenticator.foreach { auth =>
+      sshServer.setPublickeyAuthenticator(auth)
+    }
     sshServer.setKeyPairProvider(keyPairProvider(options))
     sshServer.setShellFactory(new Factory[Command] {
       override def create(): Command = new ShellSession(shellServer)
@@ -36,7 +42,9 @@ object SshServer {
     val hostKeyFile = touch(
       options.hostKeyFile.getOrElse(fallbackHostkeyFilePath(options))
     )
-    new SimpleGeneratorHostKeyProvider(hostKeyFile.toNIO)
+    val provider = new SimpleGeneratorHostKeyProvider(hostKeyFile.toNIO)
+    provider.setAlgorithm("RSA")
+    provider
   }
 
   private def disableUnsupportedChannels(sshServer: SshServerImpl) = {
@@ -72,12 +80,4 @@ object SshServer {
     }
     file
   }
-
-  private def passwordAuthenticator(correctUsername: String,
-                                    correctPassword: String) =
-    new PasswordAuthenticator {
-      override def authenticate(username: String,
-                                password: String, session: ServerSession) =
-        username == correctUsername && password == correctPassword
-    }
 }

--- a/sshd/src/main/scala/ammonite/sshd/SshServerConfig.scala
+++ b/sshd/src/main/scala/ammonite/sshd/SshServerConfig.scala
@@ -1,26 +1,28 @@
 package ammonite.sshd
 
-import acyclic.file
 import ammonite.main.Defaults
 import ammonite.ops.Path
+import org.apache.sshd.server.auth.password.PasswordAuthenticator
+import org.apache.sshd.server.auth.pubkey.PublickeyAuthenticator
 
 /**
  * Ssh server parameters
  * @param port a port to be used by ssh server. Set it as `0` to let server choose some random port.
- * @param username username to authenticate on ssh server
- * @param password password to authenticate on ssh server
  * @param ammoniteHome path that ammonite repl sessions will be using as their home directory
  * @param hostKeyFile path to the place where to store server's identity key
  */
 case class SshServerConfig(address: String,
                            port: Int,
-                           username:String,
-                           password:String,
                            ammoniteHome: Path = Defaults.ammoniteHome,
-                           hostKeyFile: Option[Path] = None
+                           hostKeyFile: Option[Path] = None,
+                           passwordAuthenticator: Option[PasswordAuthenticator] = None,
+                           publicKeyAuthenticator: Option[PublickeyAuthenticator] = None
 ) {
-  require(username.nonEmpty, "username can't be an empty string")
+  require(passwordAuthenticator.orElse(publicKeyAuthenticator).isDefined,
+    "you must provide at least one authenticator")
   override def toString =
-    s"(port = $port, username = '$username'," +
-     s"home = '$ammoniteHome', hostKeyFile = $hostKeyFile)"
+    s"(port = $port," +
+      s"home = '$ammoniteHome', hostKeyFile = $hostKeyFile," +
+      s"passwordAuthenticator = $passwordAuthenticator," +
+      s"publicKeyAuthenticator = $publicKeyAuthenticator)"
 }

--- a/sshd/src/test/scala/ammonite/sshd/Main.scala
+++ b/sshd/src/test/scala/ammonite/sshd/Main.scala
@@ -1,19 +1,45 @@
 package ammonite.sshd
 
+import java.security.PublicKey
+import org.apache.sshd.common.config.keys.{KeyUtils, PublicKeyEntryResolver}
+import org.apache.sshd.server.auth.password.PasswordAuthenticator
+import org.apache.sshd.server.auth.pubkey.PublickeyAuthenticator
+import org.apache.sshd.server.config.keys.AuthorizedKeysAuthenticator
+import org.apache.sshd.server.session.ServerSession
 import scala.annotation.tailrec
+import scala.collection.JavaConverters._
 
 object Main {
   def main(args:Array[String]): Unit = {
-    val config = SshServerConfig("localhost", 2222, currentUserName, getPassword)
+    val config = SshServerConfig("localhost", 2222,
+      passwordAuthenticator = Some(passwordChecker),
+      publicKeyAuthenticator = Some(publicKeyChecker)
+    )
     val ammoniteServer = new SshdRepl(config)
 
     ammoniteServer.start()
     println(s"Ammonite server started. $helpMessage." +
-            s"To connect use ssh [${config.username}@]<host> -p${config.port}")
+            s"To connect use ssh [${currentUserName}@]<host> -p${config.port}")
     exitAwaitLoop()
     ammoniteServer.stop()
 
     println("Ammonite server finished")
+  }
+
+  object publicKeyChecker extends PublickeyAuthenticator {
+    def authenticate(username: String, key: PublicKey, session: ServerSession): Boolean = {
+      username == currentUserName &&
+        AuthorizedKeysAuthenticator.readDefaultAuthorizedKeys().asScala
+          .exists { entry =>
+            KeyUtils.compareKeys(entry.resolvePublicKey(PublicKeyEntryResolver.IGNORING), key)
+          }
+    }
+  }
+
+  object passwordChecker extends PasswordAuthenticator {
+    def authenticate(username: String, password: String, session: ServerSession): Boolean = {
+      username == currentUserName && password == getPassword
+    }
   }
 
   def currentUserName = System.getProperty("user.name")

--- a/sshd/src/test/scala/ammonite/sshd/SshTestingUtils.scala
+++ b/sshd/src/test/scala/ammonite/sshd/SshTestingUtils.scala
@@ -5,6 +5,8 @@ import java.util.concurrent.TimeoutException
 
 import ammonite.ops._
 import com.jcraft.jsch.{Channel, JSch, Session, UserInfo}
+import org.apache.sshd.server.auth.password.PasswordAuthenticator
+import org.apache.sshd.server.session.ServerSession
 import org.scalacheck.Gen
 import org.apache.sshd.server.{SshServer => SshServerImpl}
 
@@ -52,9 +54,12 @@ object SshTestingUtils {
     def config = SshServerConfig(
       "localhost",
       port = 0,
-      username = user._1,
-      password = user._2,
-      ammoniteHome = dir
+      ammoniteHome = dir,
+      passwordAuthenticator = Some(new PasswordAuthenticator {
+        def authenticate(username: String, password: String, session: ServerSession): Boolean = {
+          (username, password) == user
+        }
+      })
     )
     SshServer(config, shell)
   }
@@ -62,7 +67,7 @@ object SshTestingUtils {
   def withTestSshServer[T](user: (String, String), testShell: () => Any = () => ???)
                           (test: SshServerImpl => T)
                           (implicit dir: Path): T = {
-    val server = testSshServer(user, (_, _) => testShell.apply())
+    val server = testSshServer(user, (_, _, _) => testShell.apply())
     server.start()
     try {
       test(server)


### PR DESCRIPTION
* Modern OpenSSH clients will refuse to accept an ssh-dss server key; generate using RSA instead
* Enable keyboard-interactive authentication as well as password-based
* Allow password-based and/or publickey-based authentication