### PR TITLE
Shade coursier / scalaz / scala-xml

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -149,6 +149,9 @@ lazy val amm = project
         val oldStrategy = (assemblyMergeStrategy in assembly).value
         oldStrategy(x)
     },
+    assemblyShadeRules in assembly := shadedNs.toSeq.map { ns =>
+      ShadeRule.rename(s"$ns.**" -> s"$shadingNs.@0").inAll
+    },
     parallelExecution in Test := false
   )
 
@@ -168,6 +171,14 @@ lazy val ammUtil = project
     )
   )
 
+val shadedNs = Set(
+  "coursier",
+  "scala.xml",
+  "scalaz"
+)
+
+val shadingNs = "ammonite.shaded"
+
 lazy val ammRuntime = project
   .in(file("amm/runtime"))
   .enablePlugins(coursier.ShadingPlugin)
@@ -185,12 +196,8 @@ lazy val ammRuntime = project
 
     inConfig(coursier.ShadingPlugin.Shading)(com.typesafe.sbt.pgp.PgpSettings.projectSettings),
     coursier.ShadingPlugin.projectSettings,
-    shadingNamespace := "ammonite.shaded",
-    shadeNamespaces ++= Set(
-      "coursier",
-      "scala.xml",
-      "scalaz"
-    ),
+    shadingNamespace := shadingNs,
+    shadeNamespaces ++= shadedNs,
     publish := publish.in(Shading).value,
     publishLocal := publishLocal.in(Shading).value,
     PgpKeys.publishSigned := PgpKeys.publishSigned.in(Shading).value,

--- a/build.sbt
+++ b/build.sbt
@@ -170,6 +170,7 @@ lazy val ammUtil = project
 
 lazy val ammRuntime = project
   .in(file("amm/runtime"))
+  .enablePlugins(coursier.ShadingPlugin)
   .dependsOn(ops, ammUtil)
   .settings(
     macroSettings,
@@ -178,10 +179,22 @@ lazy val ammRuntime = project
 
     name := "ammonite-runtime",
     libraryDependencies ++= Seq(
-      "io.get-coursier" %% "coursier" % "1.0.0-RC3",
-      "io.get-coursier" %% "coursier-cache" % "1.0.0-RC3",
+      "io.get-coursier" %% "coursier-cache" % "1.0.0-RC3" % "shaded",
       "org.scalaj" %% "scalaj-http" % "2.3.0"
-    )
+    ),
+
+    inConfig(coursier.ShadingPlugin.Shading)(com.typesafe.sbt.pgp.PgpSettings.projectSettings),
+    coursier.ShadingPlugin.projectSettings,
+    shadingNamespace := "ammonite.shaded",
+    shadeNamespaces ++= Set(
+      "coursier",
+      "scala.xml",
+      "scalaz"
+    ),
+    publish := publish.in(Shading).value,
+    publishLocal := publishLocal.in(Shading).value,
+    PgpKeys.publishSigned := PgpKeys.publishSigned.in(Shading).value,
+    PgpKeys.publishLocalSigned := PgpKeys.publishLocalSigned.in(Shading).value
   )
 
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,6 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC3")
+
+// provides org.jboss.interceptor:jboss-interceptor-api:1.1 with valid checksums
+resolvers += "jboss-releases" at "https://repository.jboss.org/nexus/content/repositories/public/"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,6 +9,7 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC3")
+addSbtPlugin("io.get-coursier" % "sbt-shading" % "1.0.0-RC3")
 
 // provides org.jboss.interceptor:jboss-interceptor-api:1.1 with valid checksums
 resolvers += "jboss-releases" at "https://repository.jboss.org/nexus/content/repositories/public/"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,4 +8,4 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M15")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC3")

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC3")


### PR DESCRIPTION
This PR shows how coursier / scalaz / scala-xml (all brought by coursier) can be shaded into ammonite.

For this to work fine, the shaded coursier / scalaz shouldn't be used from the REPL, as shading doesn't adapt some scala-specific annotations in the JARs (discussed in https://github.com/coursier/coursier/issues/454 - should happen with any shading lib for now).