### PR TITLE
Cookbook HTTP Requests update scalaj-http to work with scala 2.12.x

### DIFF
--- a/readme/Cookbook.scalatex
+++ b/readme/Cookbook.scalatex
@@ -36,7 +36,7 @@
 
     @hl.scala
       Welcome to the Ammonite Repl
-      @@ interp.load.ivy("org.scalaj" %% "scalaj-http" % "2.2.0")
+      @@ interp.load.ivy("org.scalaj" %% "scalaj-http" % "2.3.0")
       :: loading settings ::
       :: resolving dependencies ::
       ...


### PR DESCRIPTION
Updated docs to make sure that HTTP Requests example compiles with Scala 2.12