### PR TITLE
Fix import file docs to reflect changes to parent dir introduced in 0.7.2

### DIFF
--- a/readme/Repl.scalatex
+++ b/readme/Repl.scalatex
@@ -275,7 +275,7 @@
           Or if the script is in an @i{outer} folder,
 
         @hl.scala
-          @@ import $file.`..`.MyScript
+          @@ import $file.^.MyScript
 
         @p
           Or if we want to import the contents of the script in one go:


### PR DESCRIPTION
Update docs to match changes introduced in 0.7.2:

Changed the syntax for import $file segments outside your current directory from import $file.`..`.foo to import $file.^.foo. This makes it a lot shorter and mitigates a problems caused by the file-name being too long.

Instead of introducing second version of parent separator as in https://github.com/lihaoyi/Ammonite/pull/504

Aligned with current implementation:
https://github.com/lihaoyi/Ammonite/blob/master/amm/util/src/main/scala/ammonite/util/Util.scala#L13