### PR TITLE
Update jline to 2.14.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
 
   - env: CI_SCRIPT="ci/build.sc artifacts"
     jdk: oraclejdk8
-    scala: 2.11.8
+    scala: 2.11.11
 
 
   # Each `test` call is manually sharded out into `published/test` and
@@ -26,10 +26,10 @@ matrix:
 
   - env: CI_SCRIPT="ci/build.sc test published/test"
     jdk: oraclejdk8
-    scala: 2.11.8
+    scala: 2.11.11
   - env: CI_SCRIPT="ci/build.sc test integration/test"
     jdk: oraclejdk8
-    scala: 2.11.8
+    scala: 2.11.11
 
   - env: CI_SCRIPT="ci/build.sc test published/test"
     jdk: openjdk7
@@ -42,11 +42,11 @@ matrix:
   # These are relatively (?) quick so put them last
   - env: CI_SCRIPT="ci/build.sc docs"
     jdk: oraclejdk8
-    scala: 2.11.8
+    scala: 2.11.11
 
   - env: CI_SCRIPT="ci/build.sc executable"
     jdk: oraclejdk8
-    scala: 2.11.8
+    scala: 2.11.11
 
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,14 +21,14 @@ install:
   - cmd: SET SBT_OPTS=-XX:MaxPermSize=2g -Xmx4g
 
 build_script:
-  - sbt ++2.11.7 ops/compile
-  - sbt ++2.11.7 amm/compile
-  - sbt ++2.11.7 integration/compile
+  - sbt ++2.11.11 ops/compile
+  - sbt ++2.11.11 amm/compile
+  - sbt ++2.11.11 integration/compile
 #  - sbt ++2.10.6 ops/compile
 
 test_script:
-  - sbt ++2.11.7 ops/test
-  - sbt ++2.11.7 amm/test
-  - sbt ++2.11.7 integration/test
+  - sbt ++2.11.11 ops/test
+  - sbt ++2.11.11 amm/test
+  - sbt ++2.11.11 integration/test
 #  - sbt ++2.10.6 ops/test
 

--- a/build.sbt
+++ b/build.sbt
@@ -144,12 +144,6 @@ lazy val amm = project
       Seq("chmod", "+x", dest.getAbsolutePath).!
       dest
     },
-    assemblyMergeStrategy in assembly := {
-      case PathList("META-INF", xs @ _*) if xs.exists(_ contains "jansi") => MergeStrategy.last
-      case x =>
-        val oldStrategy = (assemblyMergeStrategy in assembly).value
-        oldStrategy(x)
-    },
     parallelExecution in Test := false
   )
 
@@ -218,7 +212,7 @@ lazy val ammRepl = project
     crossVersion := CrossVersion.full,
     name := "ammonite-repl",
     libraryDependencies ++= Seq(
-      "jline" % "jline" % "2.12"
+      "jline" % "jline" % "2.14.3"
     )
   )
 


### PR DESCRIPTION
2.14.3 is the latest bug fix release for 2.x.x branch. Update to 3.x.x branch isn't possible as it requires Java 8.

Assembly workaround is not needed any more, cause now jline versions in Scala  2.11.11, 2.12.x and Ammonite are the same.