### PR TITLE
Make Spark2 example more idiomatic

### DIFF
--- a/integration/src/test/resources/ammonite/integration/basic/Spark2.json
+++ b/integration/src/test/resources/ammonite/integration/basic/Spark2.json
@@ -1,6 +1,4 @@
-[
-  {"hello": 1},
-  {"hello": 2},
+{"hello": 1},
+{"hello": 2},
 
-  {"hello": 3}
-]
+{"hello": 3}

--- a/integration/src/test/resources/ammonite/integration/basic/Spark2.sc
+++ b/integration/src/test/resources/ammonite/integration/basic/Spark2.sc
@@ -3,19 +3,16 @@ import $ivy.{
   `org.apache.spark::spark-sql:2.1.0`
 }
 import ammonite.ops._
-import org.apache.spark.{SparkContext, SparkConf}
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.SparkSession
 
-val conf = new SparkConf().setMaster("local[*]").setAppName("bxm")
-val sc = new SparkContext(conf)
-val sqlContext = new SQLContext(sc)
+val spark = SparkSession.builder.master("local[*]").appName("bxm").getOrCreate
 
-val df = sqlContext.read.json(
+val df = spark.read.json(
   "integration/src/test/resources/ammonite/integration/basic/Spark2.json"
 )
 
-df.foreachPartition{records =>
-  records.foreach{
+df.foreachPartition { records =>
+  records.foreach {
     record => println("fake db write")
   }
 }


### PR DESCRIPTION
The idea is to use SparkSession for Spark integration example as it's more idiomatic way in Spark 2.