### PR TITLE
Fix object Properties is not a member of package ammonite.util in example-predef.sc

### DIFF
--- a/shell/src/main/resources/ammonite/shell/example-predef.sc
+++ b/shell/src/main/resources/ammonite/shell/example-predef.sc
@@ -1,6 +1,6 @@
 interp.load.ivy(
   "com.lihaoyi" %
-  s"ammonite-shell_${util.Properties.versionNumberString}" %
+  s"ammonite-shell_${scala.util.Properties.versionNumberString}" %
   ammonite.Constants.version
 )
 @


### PR DESCRIPTION
After downloading new predef introduced in 0.9.5 I get:

```
.ammonite/predef.sc:3: object Properties is not a member of package ammonite.util
  s"ammonite-shell_${util.Properties.versionNumberString}" %
```
There is difference between example-predef.sc and example-predef-bare.sc