### PR TITLE
make the required use of ampersand a bit clearer in docs

### DIFF
--- a/readme/Scripts.scalatex
+++ b/readme/Scripts.scalatex
@@ -206,7 +206,7 @@
         val scalazVersion = "7.2.7"
         interp.load.ivy("org.scalaz" %% "scalaz-core" % scalazVersion)
 
-        // This @@ is necessary for Ammonite to proecess the `interp.load.ivy` 
+        // This @@ is necessary for Ammonite to process the `interp.load.ivy` 
         // before continuing
         @@
 

--- a/readme/Scripts.scalatex
+++ b/readme/Scripts.scalatex
@@ -206,6 +206,8 @@
         val scalazVersion = "7.2.7"
         interp.load.ivy("org.scalaz" %% "scalaz-core" % scalazVersion)
 
+        // This @@ is necessary for Ammonite to proecess the `interp.load.ivy` 
+        // before continuing
         @@
 
         // common imports


### PR DESCRIPTION
I originally confused the use of `@` in docs as part of the formatting for the README.

This snippet should make it clear that 

  * it's code
  * it's required

Inspired by my errant bug here: https://github.com/lihaoyi/Ammonite/issues/546