### PR TITLE
Include @doc annotations for main methods in usage

### DIFF
--- a/amm/src/main/scala/ammonite/main/Scripts.scala
+++ b/amm/src/main/scala/ammonite/main/Scripts.scala
@@ -161,8 +161,12 @@ object Scripts {
           val rhsPadded = rhs.lines.mkString(Util.newLine)
            s"$leftIndentStr  $lhsPadded  $rhsPadded"
         }
+    val mainDocSuffix = main.doc match{
+      case Some(d) => Util.newLine + leftIndentStr + softWrap(d, leftIndent, 80)
+      case None => ""
+    }
 
-    s"""$leftIndentStr${main.name}
+    s"""$leftIndentStr${main.name}${mainDocSuffix}
        |${argStrings.map(_ + Util.newLine).mkString}""".stripMargin
   }
   def runMainMethod(mainMethod: Router.EntryPoint,

--- a/amm/src/test/scala/ammonite/main/MainTests.scala
+++ b/amm/src/test/scala/ammonite/main/MainTests.scala
@@ -100,6 +100,7 @@ object MainTests extends TestSuite{
                 mainA
 
                 functionB
+                This explains what the function does
                   --i     Int: how many times to repeat the string to make it very very long,
                           more than it originally was
                   --s     String: the string to repeat
@@ -121,6 +122,7 @@ object MainTests extends TestSuite{
                 mainA
 
                 functionB
+                This explains what the function does
                   --i     Int: how many times to repeat the string to make it very very long,
                           more than it originally was
                   --s     String: the string to repeat


### PR DESCRIPTION
@doc annotations for main methods are described in documentation.  Everything is already in place to process them, but they're not displayed in the usage.
With this change, those docs are included on the line following the method name.