### PR TITLE
Fix home, end keys in urxvt

### DIFF
--- a/terminal/src/main/scala/ammonite/terminal/SpecialKeys.scala
+++ b/terminal/src/main/scala/ammonite/terminal/SpecialKeys.scala
@@ -63,6 +63,8 @@ object SpecialKeys {
   // case them
   val HomeScreen = Alt+"[1~"
   val EndScreen = Alt+"[4~"
+  val HomeLinuxXterm = Alt+"[7~"
+  val EndRxvt = Alt+"[8~"
 
   val ShiftUp = Alt+"[1;2A"
   val ShiftDown = Alt+"[1;2B"

--- a/terminal/src/main/scala/ammonite/terminal/filters/ReadlineFilters.scala
+++ b/terminal/src/main/scala/ammonite/terminal/filters/ReadlineFilters.scala
@@ -54,9 +54,11 @@ object ReadlineFilters {
     simple(LinuxCtrlRight)((b, c, m) => GUILikeFilters.wordRight(b, c)), // -> one word
     simple(Home)((b, c, m) => BasicFilters.moveStart(b, c, m.width)), // <- one line
     simple(HomeScreen)((b, c, m) => BasicFilters.moveStart(b, c, m.width)), // <- one line
+    simple(HomeLinuxXterm)((b, c, m) => BasicFilters.moveStart(b, c, m.width)), // <- one line
     simple(Ctrl('a'))((b, c, m) => BasicFilters.moveStart(b, c, m.width)),
     simple(End)((b, c, m) => BasicFilters.moveEnd(b, c, m.width)), // -> one line
     simple(EndScreen)((b, c, m) => BasicFilters.moveEnd(b, c, m.width)), // -> one line
+    simple(EndRxvt)((b, c, m) => BasicFilters.moveEnd(b, c, m.width)), // -> one line
     simple(Ctrl('e'))((b, c, m) => BasicFilters.moveEnd(b, c, m.width)),
     simple(Alt + "t")((b, c, m) => transposeWord(b, c)),
     simple(Alt + "T")((b, c, m) => transposeWord(b, c)),


### PR DESCRIPTION
Same issue as #152 but for urxvt. It emits `^[[7~` for Home and `^[[8~` for End.

By the way you can use your favorite Linux distro `/etc/inputrc` as a reference. Here is one from my Arch Linux: https://gist.github.com/aolshevskiy/cd4113179e22e1a831b65276614611de

Here is an excerpt with relevant screen and urxvt keycodes:
```
# for linux console and RH/Debian xterm
"\e[1~": beginning-of-line
"\e[4~": end-of-line
...
"\e[7~": beginning-of-line
...
# for rxvt
"\e[8~": end-of-line
```

And one more thing: you're doing great work here! Cheers :clap: