### PR TITLE
Clipboard operations: xclip or pbcopy/pbpaste style operations.

### DIFF
--- a/amm/repl/src/main/scala/ammonite/repl/ReplAPI.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/ReplAPI.scala
@@ -1,5 +1,6 @@
 package ammonite.repl
 
+import ammonite.ops.Internals
 import ammonite.util._
 
 import scala.reflect.runtime.universe._
@@ -160,6 +161,8 @@ trait ReplAPI {
   def sess: Session
 
   def load: ReplLoad
+
+  def clipboard: Clipboard
 }
 trait ReplLoad{
   /**
@@ -206,4 +209,17 @@ trait Session{
     */
   def delete(name: String): Unit
 }
-
+trait Clipboard{
+  /**
+    * Reads contents from the system clipboard.
+    * @return System clipboard contents if they are readable as `String`,
+    *         empty string otherwise.
+    */
+  def read: String
+  /**
+    * Sets the contents of the system clipboard.
+    *
+    * @param data New contents for the clipboard.
+    */
+  def write(data: Internals.Writable): Unit
+}

--- a/amm/repl/src/test/scala/ammonite/unit/ClipboardTests.scala
+++ b/amm/repl/src/test/scala/ammonite/unit/ClipboardTests.scala
@@ -1,0 +1,44 @@
+package ammonite.unit
+
+import ammonite.repl.{Clipboard, ClipboardImpl}
+
+import java.awt.Toolkit
+import java.awt.datatransfer.DataFlavor
+
+import utest._
+
+import scala.util.Try
+
+object ClipboardTests extends TestSuite{
+
+  val clipboard: Clipboard = ClipboardImpl
+
+  /**
+    * This test suite requires an environment with access to a window
+    * service (either under, Windows, MacOs, X11, ...) CI environment
+    * doesn't satisfy that condition and that is detected in the following
+    * check in order to skip [[Clipboard]] test when running on CI.
+    */
+  val canTest = Try(
+    Toolkit.getDefaultToolkit.getSystemClipboard.isDataFlavorAvailable(
+      DataFlavor.stringFlavor
+    )
+  ).getOrElse(false)
+
+  override def tests = Tests {
+    println("ClipboardTests")
+    'clipboard {
+      val newClipboardContents = "hello Ammonite"
+      'copyandpaste - {
+        if (canTest) {
+          clipboard.write(newClipboardContents)
+          assert(clipboard.read == newClipboardContents)
+        } else {
+          println(
+            "The environment doesn't allow testing clipboard - skipping"
+          )
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
One of production booster when working with terminals is the ability to read and write from and to the system clipboard. 

This will be extremely useful to run Scala programs on data brought from selected text. An example is selecting part of Ammonite README file on GitHub:

![Selected text](http://i.imgur.com/yFszk4m.png)

And counting words in the selected text:

```
val words = clipboard.read.split("\n").flatMap(_.split(" ").map(_.toLowerCase))

val wordCount = (Map.empty[String, Int] /: words) { (count, word) =>
    count + (word -> (count.getOrElse(word, 0)+1)) 
}

```

![Result](http://i.imgur.com/p6e2thR.png)

I am open to discuss & change implementation details. I have some doubts:

- I  didn't consider this should be under `FileOps` so I created `ClipboardOps`
- If the idea is welcomed further functionality could be added.
- The code could be more abstract and generic.
- ...