### PR TITLE
Dependency updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -260,8 +260,8 @@ lazy val ammRepl = project
     crossVersion := CrossVersion.full,
     name := "ammonite-repl",
     libraryDependencies ++= Seq(
-      "jline" % "jline" % "2.14.5",
-      "com.github.javaparser" % "javaparser-core" % "3.3.0"
+      "jline" % "jline" % "2.14.3",
+      "com.github.javaparser" % "javaparser-core" % "3.2.6"
     ),
     unmanagedSourceDirectories in Compile ++= {
       if (Set("2.12", "2.11").contains(scalaBinaryVersion.value))

--- a/build.sbt
+++ b/build.sbt
@@ -171,7 +171,7 @@ lazy val amm = project
     test in assembly := {},
     name := "ammonite",
     libraryDependencies ++= Seq(
-      "com.github.scopt" %% "scopt" % "3.5.0"
+      "com.github.scopt" %% "scopt" % "3.6.0"
     ),
     libraryDependencies ++= (
       if (scalaVersion.value startsWith "2.10.") Nil
@@ -219,8 +219,8 @@ lazy val ammRuntime = project
 
     name := "ammonite-runtime",
     libraryDependencies ++= Seq(
-      "io.get-coursier" %% "coursier" % "1.0.0-RC8",
-      "io.get-coursier" %% "coursier-cache" % "1.0.0-RC8",
+      "io.get-coursier" %% "coursier" % "1.0.0-RC9",
+      "io.get-coursier" %% "coursier-cache" % "1.0.0-RC9",
       "org.scalaj" %% "scalaj-http" % "2.3.0"
     )
   )
@@ -260,8 +260,8 @@ lazy val ammRepl = project
     crossVersion := CrossVersion.full,
     name := "ammonite-repl",
     libraryDependencies ++= Seq(
-      "jline" % "jline" % "2.14.3",
-      "com.github.javaparser" % "javaparser-core" % "3.2.5"
+      "jline" % "jline" % "2.14.5",
+      "com.github.javaparser" % "javaparser-core" % "3.3.0"
     ),
     unmanagedSourceDirectories in Compile ++= {
       if (Set("2.12", "2.11").contains(scalaBinaryVersion.value))
@@ -327,12 +327,12 @@ lazy val sshd = project
       libraryDependencies ++= Seq(
         // sshd-core 1.3.0 requires java8
         "org.apache.sshd" % "sshd-core" % "1.2.0",
-        "org.bouncycastle" % "bcprov-jdk15on" % "1.56",
+        "org.bouncycastle" % "bcprov-jdk15on" % "1.57",
         //-- test --//
         // slf4j-nop makes sshd server use logger that writes into the void
         "org.slf4j" % "slf4j-nop" % "1.7.12" % Test,
         "com.jcraft" % "jsch" % "0.1.54" % Test,
-        "org.scalacheck" %% "scalacheck" % "1.12.6" % Test
+        "org.scalacheck" %% "scalacheck" % "1.13.5" % Test
       )
   )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 
 addSbtPlugin("com.lihaoyi" % "scalatex-sbt-plugin" % "0.3.7")
 
@@ -8,7 +8,7 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M15")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC9")
 
 // https://github.com/sbt/sbt-assembly/issues/236
 resolvers += "JBoss" at "https://repository.jboss.org/"


### PR DESCRIPTION
sbt 0.13.15 -> 0.13.16
sbt-assembly 0.14.3 -> 0.14.5
sbt-coursier 1.0.0-M15 -> 1.0.0-RC9
scopt 3.5.0 -> 3.6.0
coursier and coursier-cache 1.0.0-RC8 -> 1.0.0-RC9
jline 2.14.3 -> 2.14.5
javaparser-core 3.2.5 -> 3.3.0
bcprov-jdk15on 1.56 -> 1.57
scalacheck 1.12.6 -> 1.13.5