### PR TITLE
ls.rec handle inaccessible files

### DIFF
--- a/ops/src/main/scala/ammonite/ops/FileOps.scala
+++ b/ops/src/main/scala/ammonite/ops/FileOps.scala
@@ -207,9 +207,13 @@ object ls extends StreamableOp1[Path, Path, LsSeq] with ImplicitOp[LsSeq]{
 
   object iter extends (Path => geny.Generator[Path]){
     def apply(arg: Path) = geny.Generator.selfClosing{
-      val dirStream = Files.newDirectoryStream(arg.toNIO)
-      import collection.JavaConverters._
-      (dirStream.iterator().asScala.map(Path(_)), () => dirStream.close())
+        try {
+          val dirStream = Files.newDirectoryStream(arg.toNIO)
+          import collection.JavaConverters._
+          (dirStream.iterator().asScala.map(Path(_)), () => dirStream.close())
+        } catch {
+          case _: AccessDeniedException => (Iterator[Path](), () => ())
+        }
     }
   }
 

--- a/ops/src/test/scala/test/ammonite/ops/OpTests.scala
+++ b/ops/src/test/scala/test/ammonite/ops/OpTests.scala
@@ -42,6 +42,11 @@ object OpTests extends TestSuite{
         )
       )
     }
+    'lsRecPermissions{
+      if(Unix()){
+        assert(ls.rec(root/'var/'run).nonEmpty)
+      }
+    }
     'readResource{
       'positive{
         'absolute{

--- a/readme/Footer.scalatex
+++ b/readme/Footer.scalatex
@@ -1423,3 +1423,7 @@
           can be accessed later:
           @hl.scala
             remote.product(1, List(2, 3, 4))
+        @li  
+          Fix for issue @issue(679) when running @code{ls.rec} on path including
+          inaccessible files would throw @hl.scala{java.nio.file.AccessDeniedException}
+          thanks to @lnk("Piotr Kwiecinski", "https://github.com/piotrkwiecinski")


### PR DESCRIPTION
Attempt to fix https://github.com/lihaoyi/Ammonite/issues/679

For now without tests, but I'll try to figure our reliable way to verify it on travis.

1) Bare minimum would be to check if directory with no access doesn't throw Exception and we get empty LsSeq
2) Better would be to have directory with at least file inaccessible file and check if we get non empty LsSeq

Maybe we can use /tmp