### PR TITLE
Small clean up in ammonite.ops

### DIFF
--- a/ops/src/main/scala/ammonite/ops/FileOps.scala
+++ b/ops/src/main/scala/ammonite/ops/FileOps.scala
@@ -6,12 +6,8 @@
  */
 package ammonite.ops
 
-import java.io.{File, InputStream, OutputStream}
-import java.nio.charset.Charset
+import java.io.File
 import java.nio.file._
-import java.util.Objects
-
-
 
 import scala.io.Codec
 
@@ -202,7 +198,7 @@ trait ImplicitOp[V] extends Function1[Path, V]{
   */
 object ls extends StreamableOp1[Path, Path, LsSeq] with ImplicitOp[LsSeq]{
   def materialize(src: Path, i: geny.Generator[Path]) =
-    new LsSeq(src, i.map(_ relativeTo src).toVector.sorted:_*)
+    LsSeq(src, i.map(_ relativeTo src).toVector.sorted:_*)
 
 
   object iter extends (Path => geny.Generator[Path]){

--- a/ops/src/main/scala/ammonite/ops/Model.scala
+++ b/ops/src/main/scala/ammonite/ops/Model.scala
@@ -49,13 +49,13 @@ object stat extends Function1[ops.Path, ops.stat]{
     )).toOption
   )
   def make(name: String, attrs: BasicFileAttributes, posixAttrs: Option[PosixFileAttributes]) = {
-    import collection.JavaConversions._
+    import collection.JavaConverters._
     new stat(
       name,
       attrs.size(),
       attrs.lastModifiedTime(),
-      posixAttrs.map(_.owner).getOrElse(null),
-      posixAttrs.map(a => new PermSet(a.permissions.toSet)).getOrElse(null),
+      posixAttrs.map(_.owner).orNull,
+      posixAttrs.map(a => new PermSet(a.permissions.asScala.toSet)).orNull,
       if (attrs.isRegularFile) FileType.File
       else if (attrs.isDirectory) FileType.Dir
       else if (attrs.isSymbolicLink) FileType.SymLink
@@ -78,16 +78,16 @@ object stat extends Function1[ops.Path, ops.stat]{
       )).toOption
     )
     def make(name: String, attrs: BasicFileAttributes, posixAttrs: Option[PosixFileAttributes]) = {
-      import collection.JavaConversions._
+      import collection.JavaConverters._
       new full(
         name,
         attrs.size(),
         attrs.lastModifiedTime(),
         attrs.lastAccessTime(),
         attrs.creationTime(),
-        posixAttrs.map(_.group()).getOrElse(null),
-        posixAttrs.map(_.owner()).getOrElse(null),
-        posixAttrs.map(a => new PermSet(a.permissions.toSet)).getOrElse(null),
+        posixAttrs.map(_.group()).orNull,
+        posixAttrs.map(_.owner()).orNull,
+        posixAttrs.map(a => new PermSet(a.permissions.asScala.toSet)).orNull,
         if (attrs.isRegularFile) FileType.File
         else if (attrs.isDirectory) FileType.Dir
         else if (attrs.isSymbolicLink) FileType.SymLink

--- a/ops/src/main/scala/ammonite/ops/PathUtils.scala
+++ b/ops/src/main/scala/ammonite/ops/PathUtils.scala
@@ -2,11 +2,7 @@ package ammonite.ops
 
 import java.io.InputStream
 
-
-
 import scala.io.Codec
-
-
 
 /**
   * A path that can be read from, either a [[Path]] or a [[ResourcePath]].

--- a/ops/src/main/scala/ammonite/ops/Shellout.scala
+++ b/ops/src/main/scala/ammonite/ops/Shellout.scala
@@ -11,12 +11,12 @@ import scala.language.dynamics
   * Internal utilities to support spawning subprocesses
   */
 object Shellout{
-  val % = new Command(Vector.empty, Map.empty, Shellout.executeInteractive)
-  val %% = new Command(Vector.empty, Map.empty, Shellout.executeStream)
+  val % = Command(Vector.empty, Map.empty, Shellout.executeInteractive)
+  val %% = Command(Vector.empty, Map.empty, Shellout.executeStream)
   def executeInteractive(wd: Path, cmd: Command[_]) = {
     val builder = new java.lang.ProcessBuilder()
-    import collection.JavaConversions._
-    builder.environment().putAll(cmd.envArgs)
+    import collection.JavaConverters._
+    builder.environment().putAll(cmd.envArgs.asJava)
     builder.directory(new java.io.File(wd.toString))
 
     val proc =
@@ -55,8 +55,8 @@ object Shellout{
 
   def executeStream(wd: Path, cmd: Command[_]) = {
     val builder = new java.lang.ProcessBuilder()
-    import collection.JavaConversions._
-    builder.environment().putAll(cmd.envArgs)
+    import collection.JavaConverters._
+    builder.environment().putAll(cmd.envArgs.asJava)
     builder.directory(new java.io.File(wd.toString))
     val process =
       builder
@@ -102,7 +102,7 @@ case class Command[T](cmd: Vector[String],
                       envArgs: Map[String, String],
                       execute: (Path, Command[_]) => T) extends Dynamic {
   def extend(cmd2: Traversable[String], envArgs2: Traversable[(String, String)]) =
-    new Command(cmd ++ cmd2, envArgs ++ envArgs2, execute)
+    Command(cmd ++ cmd2, envArgs ++ envArgs2, execute)
   def selectDynamic(name: String)(implicit wd: Path) = execute(wd, extend(Vector(name), Map()))
   def opArg(op: String) = if (op == "apply") Nil else Vector(op)
 

--- a/ops/src/main/scala/ammonite/ops/package.scala
+++ b/ops/src/main/scala/ammonite/ops/package.scala
@@ -91,7 +91,7 @@ package object ops extends Extensions with RelPathStuff{
     */
   object /{
     def unapply[T <: BasePath](p: T): Option[(p.ThisType, String)] = {
-      if (p.segments.length > 0)
+      if (p.segments.nonEmpty)
         Some((p / up, p.last))
       else None
     }


### PR DESCRIPTION
- Replace collection.JavaConversions with collection.JavaConverters
- Remove unused import statements
- Replace .length > 0 by .nonEmpty
- Replace getOrElse(null) with .orNull on option
- Remove `new` on case classes