### PR TITLE
enable parsing of multiple shebang lines for nix-shell

### DIFF
--- a/amm/src/test/scala/ammonite/unit/ParserTests.scala
+++ b/amm/src/test/scala/ammonite/unit/ParserTests.scala
@@ -32,6 +32,30 @@ object ParserTests extends TestSuite{
           |
           |println("Hello") """.stripMargin
       )
+      "nix-shell" - check(
+        """#! /usr/bin/env nix-shell
+          |#! nix-shell -i amm -p ammonite-repl
+          |
+          |println("Hello") """.stripMargin,
+        """
+          |
+          |
+          |println("Hello") """.stripMargin
+      )
+      "nix-shell-endshebang" - check(
+        """#! /usr/bin/env nix-shell
+          |#! nix-shell -i amm -p ammonite-repl
+          |
+          |!#
+          |
+          |println("Hello") """.stripMargin,
+        """
+          |
+          |
+          |
+          |
+          |println("Hello") """.stripMargin
+      )
     }
 
     // Sanity check the logic that runs when you press ENTER in the REPL and


### PR DESCRIPTION
The [NixOs](https://nixos.org/) nix-shell commonly uses multiple shebang lines.  This pull request enables parsing of multiple shebang lines.