### PR TITLE
Update coursier to 1.0.0-RC10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -219,8 +219,8 @@ lazy val ammRuntime = project
 
     name := "ammonite-runtime",
     libraryDependencies ++= Seq(
-      "io.get-coursier" %% "coursier" % "1.0.0-RC8",
-      "io.get-coursier" %% "coursier-cache" % "1.0.0-RC8",
+      "io.get-coursier" %% "coursier" % "1.0.0-RC10",
+      "io.get-coursier" %% "coursier-cache" % "1.0.0-RC10",
       "org.scalaj" %% "scalaj-http" % "2.3.0"
     )
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M15")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC10")
 
 // https://github.com/sbt/sbt-assembly/issues/236
 resolvers += "JBoss" at "https://repository.jboss.org/"


### PR DESCRIPTION
It look like it fixes #664.

```
@ import $ivy.`org.apache.jena:apache-jena-libs:3.1.1` 
@ import org.apache.jena.rdf.model._ 
import org.apache.jena.rdf.model._

@ import org.apache.jena.util.FileManager; 
import org.apache.jena.util.FileManager;

@ val model = ModelFactory.createDefaultModel(); 
model: Model = <ModelCom   {} | >
```

Sources still fail during resolution:
```
Failed to load source dependencies
  not found: https://repo1.maven.org/maven2/org/apache/jena/apache-jena-libs/3.1.1/apache-jena-libs-3.1.1-sources.jar
```
