### PR TITLE
Add output stream for results

### DIFF
--- a/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
@@ -730,11 +730,12 @@ object Interpreter{
     val printer = Printer(
       printStream,
       errorPrintStream,
+      printStream,
       printlnWithColor(errorPrintStream, colors().warning(), _),
       printlnWithColor(errorPrintStream, colors().error(), _),
       s => if (verboseOutput) printlnWithColor(errorPrintStream, colors().info(), s)
     )
-    (colors, printStream, errorPrintStream, printer)
+    (colors, printer)
   }
 
 }

--- a/amm/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -31,7 +31,7 @@ class Repl(input: InputStream,
 
   var history = new History(Vector())
 
-  val (colors, printStream, errorPrintStream, printer) =
+  val (colors, printer) =
     Interpreter.initPrinters(initialColors, output, error, true)
 
   val argString = replArgs.zipWithIndex.map{ case (b, idx) =>
@@ -160,14 +160,14 @@ class Repl(input: InputStream,
     }
     out <- interp.processLine(code, stmts, currentLine, false, () => currentLine += 1)
   } yield {
-    printStream.println()
+    printer.outStream.println()
     out
   }
 
 
 
   def run(): Any = {
-    welcomeBanner.foreach(printStream.println)
+    welcomeBanner.foreach(printer.outStream.println)
     @tailrec def loop(): Any = {
       val actionResult = action()
       remoteLogger.foreach(_.apply("Action"))

--- a/amm/runtime/src/main/scala/ammonite/runtime/Evaluator.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/Evaluator.scala
@@ -106,7 +106,7 @@ object Evaluator{
         // block, so any exceptions thrown get properly caught and handled
         val iter = evalMain(cls, contextClassLoader).asInstanceOf[Iterator[String]]
 
-        if (!silent) evaluatorRunPrinter(iter.foreach(printer.outStream.print))
+        if (!silent) evaluatorRunPrinter(iter.foreach(printer.resultStream.print))
         else evaluatorRunPrinter(iter.foreach(_ => ()))
 
         // "" Empty string as cache tag of repl code

--- a/amm/src/main/scala/ammonite/Main.scala
+++ b/amm/src/main/scala/ammonite/Main.scala
@@ -125,7 +125,7 @@ case class Main(predefCode: String = "",
     loadedPredefFile.right.flatMap { predefFileInfoOpt =>
       val augmentedPredef = Main.maybeDefaultPredef(defaultPredef, Defaults.predefString)
 
-      val (colorsRef, _, _, printer) = Interpreter.initPrinters(
+      val (colorsRef, printer) = Interpreter.initPrinters(
         colors,
         outputStream,
         errorStream,

--- a/amm/src/test/scala/ammonite/TestUtils.scala
+++ b/amm/src/test/scala/ammonite/TestUtils.scala
@@ -14,10 +14,11 @@ object TestUtils {
 
   def createTestInterp(storage: Storage, predef: String = "") = {
     val startFrame = Frame.createInitial()
+    val printStream = new PrintStream(System.out)
     val interp = new Interpreter(
 
       printer = Printer(
-        new PrintStream(System.out), new PrintStream(System.err),
+        printStream, new PrintStream(System.err), printStream,
         println, println, println
       ),
       storage = storage,

--- a/amm/src/test/scala/ammonite/interp/PrintTests.scala
+++ b/amm/src/test/scala/ammonite/interp/PrintTests.scala
@@ -1,0 +1,40 @@
+package ammonite.interp
+
+import ammonite.TestRepl
+import ammonite.util.Util.newLine
+import utest._
+
+object PrintTests extends TestSuite{
+  val tests = TestSuite{
+    println("PrintTests")
+    val check = new TestRepl()
+
+    'simple - {
+      val t @ (ev, out, res, warn, err, inf) = check.run("val n = 2", 0)
+      val expectedRes = "n: Int = 2"
+
+      assert({ identity(t); ev.isSuccess })
+      assert({ identity(t); out.isEmpty })
+      assert({ identity(t); res == expectedRes })
+    }
+
+    'out - {
+      val t @ (ev, out, res, warn, err, inf) = check.run("show(List(1, 2, 3))", 0)
+      val expectedOut = "List(1, 2, 3)" + newLine
+
+      assert({ identity(t); ev.isSuccess })
+      assert({ identity(t); out == expectedOut })
+      assert({ identity(t); res.isEmpty })
+    }
+
+    'both - {
+      val t @ (ev, out, res, warn, err, inf) = check.run("show(List(1, 2, 3)); val n = 3", 0)
+      val expectedOut = "List(1, 2, 3)" + newLine
+      val expectedRes = "n: Int = 3"
+
+      assert({ identity(t); ev.isSuccess })
+      assert({ identity(t); out == expectedOut })
+      assert({ identity(t); res == expectedRes })
+    }
+  }
+}

--- a/amm/util/src/main/scala/ammonite/util/Model.scala
+++ b/amm/util/src/main/scala/ammonite/util/Model.scala
@@ -252,6 +252,7 @@ object Bind{
   *
   * @param outStream Direct access to print to stdout
   * @param errStream Direct access to print to stderr
+  * @param resultStream Direct access to print the result of the entered code
   * @param warning How you want it to print a compile warning
   * @param error How you want it to print a compile error
   * @param info How you want to print compile info logging. *Not* the same
@@ -259,6 +260,7 @@ object Bind{
   */
 case class Printer(outStream: PrintStream,
                    errStream: PrintStream,
+                   resultStream: PrintStream,
                    warning: String => Unit,
                    error: String => Unit,
                    info: String => Unit)

--- a/amm/util/src/main/scala/ammonite/util/Res.scala
+++ b/amm/util/src/main/scala/ammonite/util/Res.scala
@@ -14,6 +14,11 @@ sealed abstract class Res[+T]{
   def map[V](f: T => V): Res[V]
   def filter(f: T => Boolean): Res[T] = this
   def withFilter(f: T => Boolean): Res[T] = filter(f)
+
+  final def isSuccess: Boolean = this match {
+    case _: Res.Success[T] => true
+    case _ => false
+  }
 }
 
 


### PR DESCRIPTION
This PR adds an extra field `resultStream` to `Printer`, and uses it solely to print the "result" of the user code (like `n: Int = 2` if the user entered `val n = 1 + 1`).

If one uses Ammonite via its API, that allows to get specifically these results, rather than whatever else can be printed via `outStream`. It's useful when these results are then treated in a specific way.