### PR TITLE
sync existing sbt project integration with bridge docs

### DIFF
--- a/readme/Repl.scalatex
+++ b/readme/Repl.scalatex
@@ -84,7 +84,7 @@
 
     sourceGenerators in Test += Def.task {
       val file = (sourceManaged in Test).value / "amm.scala"
-      IO.write(file, """object amm extends App { ammonite.Main().run() }""")
+      IO.write(file, """object amm extends App { ammonite.Main.main(args) }""")
       Seq(file)
     }.taskValue
 


### PR DESCRIPTION
was just browsing through the site today and notice the `AmmoniteBridge` section had appeared since i last checked in and figured i'd update this section to follow that 
came up in a random other project i was working on and wanted to use the `--no-home-predef` flag to eliminate some variables and saw that didn't work with the `Main().run()` version 😢 
couple questions

0. is there some larger (bad) implication to doing this globally such that it should remain the way it is now
0. if not. should i just put `@hl.ref('integration/'src/'test/'scala/'ammonite/'integration/"AmmoniteBridge.scala")` inside the `"""`s there like [here](https://github.com/lihaoyi/Ammonite/blob/5dc7e0b8102832515d57aa548e282d5437dcea08/readme/Scripts.scalatex#L749) just to keep those sections always in sync?