### PR TITLE
[WIP] Interactive processes

### DIFF
--- a/ops/src/main/scala/ammonite/ops/package.scala
+++ b/ops/src/main/scala/ammonite/ops/package.scala
@@ -118,4 +118,8 @@ package object ops extends Extensions with RelPathStuff{
     * `%%('git, 'commit, "-am", "Hello!").exitCode`
     */
   val %% = Shellout.%%
+
+
+  val %%% = Shellout.%%%
+
 }

--- a/ops/src/test/scala/test/ammonite/ops/ShelloutTests.scala
+++ b/ops/src/test/scala/test/ammonite/ops/ShelloutTests.scala
@@ -3,6 +3,8 @@ package test.ammonite.ops
 import ammonite.ops._
 import utest._
 
+import scala.io.Codec
+
 object ShelloutTests extends TestSuite{
   val scriptFolder = pwd/'ops/'src/'test/'resources/'scripts
 
@@ -81,6 +83,32 @@ object ShelloutTests extends TestSuite{
 
         val res3 = %%('bash, "-c", "echo 'Hello'$ENV_ARG", ENV_ARG=123)
         assert(res3.out.lines == Seq("Hello123"))
+      }
+
+      'piping{
+
+        'simple {
+          val process = %%%('cat)
+          process.write("1\n2\n3")
+          assert(process.out.getLines().toList == List("1", "2", "3"))
+        }
+
+        'interactive {
+          val process = %%%('bash, "-c", "echo line1 && read x && echo line2 $x")
+          val lines = process.out.getLines()
+
+          assert(lines.next() == "line1")
+
+          process.write("xxxx\n")
+
+          assert(lines.next() == "line2 xxxx")
+        }
+
+        'fromFile {
+            (pwd/'ops/'src/'test/'resources/'testdata/"File.txt").getLines(Codec.UTF8) |> %%%('less).writeLines
+
+        }
+
       }
 
     }


### PR DESCRIPTION
This is a draft of a more interactive way of spawning processes. The goal is to provide a more convenient API to spawn a process and communicate with it. 

This implementation is just a first step and I would like to hear some voices on how it should look like, what to change and what to add. It would probably be good enough for my use case but not for general availability :)

I wanted to use `Internals.Writable` for `write` method but got into compile cycles and didn't want to waste time on solving it. I will do that if you agree that this is a correct thing to do.

Initially, I was thinking about something like `await` that would convert `CommandProcess` into `CommandResult` but I'm no longer sure it will give much benefit over current implementation.

This potentially solves #367  and #665 

I left following TODOs until we have some stable API

- [ ] inline comments
- [ ] documentation
- [ ] more tests