### PR TITLE
Report predef initialization error during tests

### DIFF
--- a/amm/repl/src/test/scala/ammonite/TestRepl.scala
+++ b/amm/repl/src/test/scala/ammonite/TestRepl.scala
@@ -119,7 +119,23 @@ class TestRepl {
   }
 
 
-  interp.initializePredef()
+  for ((error, _) <- interp.initializePredef()) {
+    val (msgOpt, causeOpt) = error match {
+      case r: Res.Exception => (Some(r.msg), Some(r.t))
+      case r: Res.Failure => (Some(r.msg), None)
+      case _ => (None, None)
+    }
+
+    println(infoBuffer.mkString)
+    println(outString)
+    println(resString)
+    println(warningBuffer.mkString)
+    println(errorBuffer.mkString)
+    throw new Exception(
+      s"Error during predef initialization${msgOpt.fold("")(": " + _)}",
+      causeOpt.orNull
+    )
+  }
 
 
 


### PR DESCRIPTION
This is useful while debugging or changing things in the internals of Ammonite. Previously, errors during predefs where trapped. Now they are loudly reported.