### PR TITLE
Discard load command result

### DIFF
--- a/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
@@ -37,6 +37,7 @@ class Interpreter(val printer: Printer,
                   colors: Ref[Colors],
                   verboseOutput: Boolean = true,
                   getFrame: () => Frame,
+                  val createFrame: () => Frame,
                   replCodeWrapper: Preprocessor.CodeWrapper,
                   scriptCodeWrapper: Preprocessor.CodeWrapper)
   extends ImportHook.InterpreterInterface{ interp =>

--- a/amm/repl/src/main/scala/ammonite/repl/ApiImpls.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/ApiImpls.scala
@@ -26,7 +26,10 @@ class SessionApiImpl(frames0: => StableRef[List[Frame]]) extends Session{
 
   def save(name: String = "") = {
     if (name != "") namedFrames(name) = frames
-    frames0() = childFrame(frames.head) :: frames
+    // freezing the frame will trigger the creation of a new one later on,
+    // so that the saved one won't change any more
+    frames.head.freeze()
+    frames0() = frames
   }
 
   def pop(num: Int = 1) = {
@@ -35,14 +38,20 @@ class SessionApiImpl(frames0: => StableRef[List[Frame]]) extends Session{
       if (next.tail != Nil) next = next.tail
     }
     val out = SessionChanged.delta(frames.head, next.head)
-    frames0() = childFrame(next.head) :: next
+    // freezing the current frame, so that the result of the current command,
+    // that tangles with sessions, isn't added to it
+    next.head.freeze()
+    frames0() = next
     out
   }
   
   def load(name: String = "") = {
     val next = if (name == "") frames.tail else namedFrames(name)
     val out = SessionChanged.delta(frames.head, next.head)
-    frames0() = childFrame(next.head) :: next
+    // freezing the current frame, so that the result of the current command,
+    // that tangles with sessions, isn't added to it
+    next.head.freeze()
+    frames0() = next
     out
   }
 

--- a/amm/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -104,6 +104,7 @@ class Repl(input: InputStream,
     colors,
     verboseOutput = true,
     getFrame = () => frames().head,
+    createFrame = () => { val f = sess0.childFrame(frames().head); frames() = f :: frames(); f },
     replCodeWrapper = replCodeWrapper,
     scriptCodeWrapper = scriptCodeWrapper
   )
@@ -202,7 +203,10 @@ object Repl{
     res match{
       case Res.Skip => // do nothing
       case Res.Exit(value) => interp.compilerManager.shutdownPressy()
-      case Res.Success(ev) => interp.handleImports(ev.imports)
+      case Res.Success(ev) =>
+        interp.handleImports(ev.imports)
+        if (interp.headFrame.frozen)
+          interp.createFrame()
       case _ => ()
     }
   }

--- a/amm/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -130,6 +130,7 @@ class Repl(input: InputStream,
 
 
   sess0.save()
+  interp.createFrame()
 
   val reader = new InputStreamReader(input)
 

--- a/amm/repl/src/test/scala/ammonite/TestRepl.scala
+++ b/amm/repl/src/test/scala/ammonite/TestRepl.scala
@@ -105,6 +105,7 @@ class TestRepl {
       )),
       colors = Ref(Colors.BlackWhite),
       getFrame = () => frames().head,
+      createFrame = () => { val f = sess0.childFrame(frames().head); frames() = f :: frames(); f },
       replCodeWrapper = Preprocessor.CodeWrapper,
       scriptCodeWrapper = Preprocessor.CodeWrapper
     )
@@ -176,8 +177,6 @@ class TestRepl {
         run(commandText.mkString(Util.newLine), currentLine)
 
       val allOut = out + res
-
-      Repl.handleOutput(interp, processed)
 
       if (expected.startsWith("error: ")) {
         val strippedExpected = expected.stripPrefix("error: ")

--- a/amm/repl/src/test/scala/ammonite/TestUtils.scala
+++ b/amm/repl/src/test/scala/ammonite/TestUtils.scala
@@ -29,6 +29,7 @@ object TestUtils {
       extraBridges = Seq(),
       colors = Ref(Colors.BlackWhite),
       getFrame = () => startFrame,
+      createFrame = () => throw new Exception("unsupported"),
       replCodeWrapper = Preprocessor.CodeWrapper,
       scriptCodeWrapper = Preprocessor.CodeWrapper
     )

--- a/amm/repl/src/test/scala/ammonite/session/BuiltinTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/BuiltinTests.scala
@@ -226,5 +226,27 @@ object BuiltinTests extends TestSuite{
         res11: Int = -1
                     """)
     }
+    'discardLoadCommandResult{
+      * - check.session("""
+        @ repl.sess.save("foo")
+
+        @ val a = repl.sess.load("foo")
+
+        @ a
+        error: not found: value a
+      """)
+
+      * - check.session("""
+        @ val n = 2
+        n: Int = 2
+
+        @ repl.sess.save("foo")
+
+        @ val n = repl.sess.load("foo") // should not mask the previous 'n'
+
+        @ val n0 = n
+        n0: Int = 2
+      """)
+    }
   }
 }

--- a/amm/repl/src/test/scala/ammonite/session/BuiltinTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/BuiltinTests.scala
@@ -7,7 +7,7 @@ import scala.collection.{immutable => imm}
 object BuiltinTests extends TestSuite{
 
   val tests = Tests{
-    println("EvaluatorTests")
+    println("BuiltinTests")
     val check = new TestRepl()
     'basicConfig{
       check.session("""

--- a/amm/repl/src/test/scala/ammonite/session/BuiltinTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/BuiltinTests.scala
@@ -248,5 +248,14 @@ object BuiltinTests extends TestSuite{
         n0: Int = 2
       """)
     }
+    'firstFrameNotFrozen{
+      check.session("""
+        @ 2
+        res0: Int = 2
+
+        @ res0 // we should be able to access the result of the previous command
+        res1: Int = 2
+      """)
+    }
   }
 }

--- a/amm/runtime/src/main/scala/ammonite/runtime/ClassLoaders.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/ClassLoaders.scala
@@ -25,22 +25,38 @@ class Frame(val classloader: SpecialClassLoader,
             val pluginClassloader: SpecialClassLoader,
             private[this] var imports0: Imports,
             private[this] var classpath0: Seq[java.io.File]){
+  private var frozen0 = false
+  def frozen = frozen0
+  def freeze(): Unit = {
+    /*
+     * Once frozen, a frame won't accept new imports or classpath elements.
+     * This is useful in commands that load / save sessions, whose result
+     * doesn't need to be kept in the frame.
+     */
+    frozen0 = true
+  }
   private[this] var version0: Int = 0
   def version = version0
   def imports = imports0
   def classpath = classpath0
   def addImports(additional: Imports) = {
-    version0 += 1
-    imports0 = imports0 ++ additional
+    if (!frozen0) {
+      version0 += 1
+      imports0 = imports0 ++ additional
+    }
   }
   def addClasspath(additional: Seq[java.io.File]) = {
-    version0 += 1
-    additional.map(_.toURI.toURL).foreach(classloader.add)
-    classpath0 = classpath0 ++ additional
+    if (!frozen0) {
+      version0 += 1
+      additional.map(_.toURI.toURL).foreach(classloader.add)
+      classpath0 = classpath0 ++ additional
+    }
   }
   def addPluginClasspath(additional: Seq[java.io.File]) = {
-    version0 += 1
-    additional.map(_.toURI.toURL).foreach(pluginClassloader.add)
+    if (!frozen0) {
+      version0 += 1
+      additional.map(_.toURI.toURL).foreach(pluginClassloader.add)
+    }
   }
 }
 object Frame{

--- a/amm/src/main/scala/ammonite/Main.scala
+++ b/amm/src/main/scala/ammonite/Main.scala
@@ -154,6 +154,7 @@ case class Main(predefCode: String = "",
         colorsRef,
         verboseOutput,
         () => frame,
+        () => throw new Exception("session loading / saving not possible here"),
         replCodeWrapper,
         scriptCodeWrapper
       )


### PR DESCRIPTION
Rather than failing at runtime with ClassNotFoundException.

This makes the last command in the following fail at compile time, rather than at runtime with a ClassNotFoundException:
```scala
@ repl.sess.save("foo")

@ val a = repl.sess.load("foo")

@ a
```

Although this looks like a detail here, this is required for classwrapping (upcoming PR).

It works by "freezing" the current frame after loading a session, preventing it to accept extra imports. That way, no imports from the command that loaded the session are added, and we can't run into ClassNotFoundException about it.