### PR TITLE
Class wrapper for Java serialization friendliness

### DIFF
--- a/amm/interp/src/main/scala/ammonite/interp/AmmonitePlugin.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/AmmonitePlugin.scala
@@ -106,10 +106,15 @@ object AmmonitePlugin{
       )
     }
 
-    val uses =
-      if (userCodeNestingLevel <= 1)
+    val usedEarlierDefinitions = userCodeNestingLevel match {
+      case 1 =>
+        /*
+         * We don't try to determine what previous commands are actually used here.
+         * userCodeNestingLevel == 1 likely corresponds to the default object-based
+         * code wrapper, which doesn't rely on the actually used previous commands.
+         */
         Map.empty[String, Seq[String]]
-      else {
+      case 2 =>
         /*
          * For userCodeNestingLevel >= 2, we list the variables from the first wrapper
          * used from the user code.
@@ -150,8 +155,8 @@ object AmmonitePlugin{
           .distinct
 
         Map(wrapperName.encoded -> uses0)
-      }
-    wrapperUses(uses)
+    }
+    wrapperUses(usedEarlierDefinitions)
 
     val symbols = stats.filter(x => !Option(x.symbol).exists(_.isPrivate))
                        .foldLeft(List.empty[(Boolean, String, String, Seq[Name])]){

--- a/amm/interp/src/main/scala/ammonite/interp/AmmonitePlugin.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/AmmonitePlugin.scala
@@ -14,6 +14,7 @@ import scala.reflect.internal.util.{BatchSourceFile, OffsetPosition}
  */
 class AmmonitePlugin(g: scala.tools.nsc.Global,
                      output: Seq[ImportData] => Unit,
+                     treeRepr: String => Unit,
                      topWrapperLen: => Int) extends Plugin{
   val name: String = "AmmonitePlugin"
   val global: Global = g
@@ -30,7 +31,7 @@ class AmmonitePlugin(g: scala.tools.nsc.Global,
         def name = phaseName
         def apply(unit: g.CompilationUnit): Unit = {
           val things = global.currentRun.units.map(_.source.path).toList
-          AmmonitePlugin(g)(unit, output, topWrapperLen)
+          AmmonitePlugin(g)(unit, output, treeRepr, topWrapperLen)
         }
       }
     },
@@ -60,6 +61,7 @@ object AmmonitePlugin{
   def apply(g: Global)
            (unit: g.CompilationUnit,
             output: Seq[ImportData] => Unit,
+            treeRepr: String => Unit,
             topWrapperLen: => Int) = {
 
 
@@ -96,6 +98,7 @@ object AmmonitePlugin{
 
     val stats = unit.body.children.last.children.last.asInstanceOf[g.ImplDef]
       .impl.body.last.asInstanceOf[g.ImplDef].impl.body
+    treeRepr(stats.toString())
     val symbols = stats.filter(x => !Option(x.symbol).exists(_.isPrivate))
                        .foldLeft(List.empty[(Boolean, String, String, Seq[Name])]){
       // These are all the ways we want to import names from previous

--- a/amm/interp/src/main/scala/ammonite/interp/AmmonitePlugin.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/AmmonitePlugin.scala
@@ -94,7 +94,8 @@ object AmmonitePlugin{
       !ignoredNames(sym.name.decoded)
     }
 
-    val stats = unit.body.children.last.children.last.asInstanceOf[g.ImplDef].impl.body
+    val stats = unit.body.children.last.children.last.asInstanceOf[g.ImplDef]
+      .impl.body.last.asInstanceOf[g.ImplDef].impl.body
     val symbols = stats.filter(x => !Option(x.symbol).exists(_.isPrivate))
                        .foldLeft(List.empty[(Boolean, String, String, Seq[Name])]){
       // These are all the ways we want to import names from previous

--- a/amm/interp/src/main/scala/ammonite/interp/AmmonitePlugin.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/AmmonitePlugin.scala
@@ -109,7 +109,7 @@ object AmmonitePlugin{
 
         def rec(expr: g.Tree): List[(g.Name, g.Symbol)] = {
           expr match {
-            case s @ g.Select(lhs, name) => (name -> s.symbol) :: rec(lhs)
+            case s @ g.Select(lhs, _) => (s.symbol.name -> s.symbol) :: rec(lhs)
             case i @ g.Ident(name) => List(name -> i.symbol)
             case t @ g.This(pkg) => List(pkg -> t.symbol)
           }

--- a/amm/interp/src/main/scala/ammonite/interp/AmmonitePlugin.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/AmmonitePlugin.scala
@@ -139,22 +139,18 @@ object AmmonitePlugin{
          * this would process the tree of `val n0 = n + 1`, find `n` as a tree like
          * `cmd2.this.cmd0.n`, and put `cmd0` in `uses`.
          */
-        val wrapperName = unit.body.children.last.children
-          .last.asInstanceOf[g.ImplDef].symbol.name
-        val rawWrapperName = wrapperName match {
-          case g.TermName(n) => n
-          case g.TypeName(n) => n
-        }
+        val wrapperSym = unit.body.children.last.children
+          .last.asInstanceOf[g.ImplDef].symbol
         val uses0 = stats
           .flatMap(t =>
             t.collect {
-              case g.Select(g.This(g.TypeName(`rawWrapperName`)), g.TermName(name)) =>
+              case g.Select(node, g.TermName(name)) if node.symbol == wrapperSym =>
                 name
             }
           )
           .distinct
 
-        Map(wrapperName.encoded -> uses0)
+        Map(wrapperSym.encodedName -> uses0)
     }
     wrapperUses(usedEarlierDefinitions)
 

--- a/amm/interp/src/main/scala/ammonite/interp/Compiler.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Compiler.scala
@@ -2,6 +2,7 @@ package ammonite.interp
 
 
 import java.io.OutputStream
+import java.nio.charset.StandardCharsets
 
 import ammonite.runtime.{Classpath, Evaluator}
 import ammonite.util.{ImportData, Imports, Name, Printer}
@@ -201,7 +202,7 @@ object Compiler{
     var infoLogger: String => Unit = s => ()
 
     var lastImports = Seq.empty[ImportData]
-    var treeRepr = ""
+    var wrapperUses = Seq.empty[String]
 
     val (vd, reporter, compiler) = {
 
@@ -233,7 +234,7 @@ object Compiler{
         createPlugins = g => {
           List(
             new ammonite.interp.AmmonitePlugin(
-              g, lastImports = _, treeRepr = _, userCodeNestingLevel, importsLen
+              g, lastImports = _, wrapperUses = _, userCodeNestingLevel, importsLen
             )
           ) ++ {
             for {
@@ -353,7 +354,9 @@ object Compiler{
          * and can easily be grepped to find that kind of dependency between commands.
          */
         val extraFiles = Seq(
-          s"${indexedWrapperName.encoded}-tree.txt" -> treeRepr.getBytes("UTF-8")
+          s"${indexedWrapperName.encoded}-uses.txt" -> wrapperUses
+            .mkString("\n")
+            .getBytes(StandardCharsets.UTF_8)
         )
 
         val imports = lastImports.toList

--- a/amm/interp/src/main/scala/ammonite/interp/Compiler.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Compiler.scala
@@ -37,7 +37,7 @@ trait Compiler{
               printer: Printer,
               importsLen0: Int,
               userCodeNestingLevel: Int,
-              fileName: String): Compiler.Output
+              fileName: String): Option[Compiler.Output]
 
   def search(name: scala.reflect.runtime.universe.Type): Option[String]
   /**
@@ -80,7 +80,7 @@ object Compiler{
    * If the Option is None, it means compilation failed
    * Otherwise it's a Traversable of (filename, bytes) tuples
    */
-  type Output = Option[(Vector[(String, Array[Byte])], Imports)]
+  case class Output(classFiles: Vector[(String, Array[Byte])], imports: Imports)
 
   /**
     * Converts a bunch of bytes into Scalac's weird VirtualFile class
@@ -306,7 +306,7 @@ object Compiler{
                 printer: Printer,
                 importsLen0: Int,
                 userCodeNestingLevel: Int,
-                fileName: String): Output = {
+                fileName: String): Option[Output] = {
 
       def enumerateVdFiles(d: VirtualDirectory): Iterator[AbstractFile] = {
         val (subs, files) = d.iterator.partition(_.isDirectory)
@@ -358,7 +358,7 @@ object Compiler{
               .getBytes(StandardCharsets.UTF_8)
 
         val imports = lastImports.toList
-        Some( (files ++ extraFiles, Imports(imports)) )
+        Some(Output(files ++ extraFiles, Imports(imports)))
 
       }
     }

--- a/amm/interp/src/main/scala/ammonite/interp/Compiler.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Compiler.scala
@@ -36,6 +36,7 @@ trait Compiler{
               printer: Printer,
               importsLen0: Int,
               indexedWrapperName: Name,
+              userCodeNestingLevel: Int,
               fileName: String): Compiler.Output
 
   def search(name: scala.reflect.runtime.universe.Type): Option[String]
@@ -44,6 +45,7 @@ trait Compiler{
    */
   def parse(fileName: String, line: String): Either[String, Seq[Global#Tree]]
   var importsLen = 0
+  var userCodeNestingLevel = -1
 
 }
 object Compiler{
@@ -230,7 +232,9 @@ object Compiler{
         evalClassloader,
         createPlugins = g => {
           List(
-            new ammonite.interp.AmmonitePlugin(g, lastImports = _, treeRepr = _, importsLen)
+            new ammonite.interp.AmmonitePlugin(
+              g, lastImports = _, treeRepr = _, userCodeNestingLevel, importsLen
+            )
           ) ++ {
             for {
               (name, cls) <- plugins0
@@ -302,6 +306,7 @@ object Compiler{
                 printer: Printer,
                 importsLen0: Int,
                 indexedWrapperName: Name,
+                userCodeNestingLevel: Int,
                 fileName: String): Output = {
 
       def enumerateVdFiles(d: VirtualDirectory): Iterator[AbstractFile] = {
@@ -317,6 +322,7 @@ object Compiler{
       this.infoLogger = printer.info
       val singleFile = makeFile(src, fileName)
       this.importsLen = importsLen0
+      this.userCodeNestingLevel = userCodeNestingLevel
       val run = new compiler.Run()
       vd.clear()
 

--- a/amm/interp/src/main/scala/ammonite/interp/CompilerLifecycleManager.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/CompilerLifecycleManager.scala
@@ -131,6 +131,7 @@ class CompilerLifecycleManager(headFrame: => Frame){
           printer,
           processed.prefixCharLength,
           indexedWrapperName,
+          processed.userCodeNestingLevel,
           fileName
         )
       }

--- a/amm/interp/src/main/scala/ammonite/interp/CompilerLifecycleManager.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/CompilerLifecycleManager.scala
@@ -71,6 +71,7 @@ class CompilerLifecycleManager(headFrame: => Frame){
       // Otherwise activating autocomplete makes the presentation compiler mangle
       // the shared settings and makes the main compiler sad
       val settings = Option(compiler).fold(new Settings)(_.compiler.settings.copy)
+      settings.Ydelambdafy.value = "inline" // seems to be required in 2.12 for serializing lambdas
       Internal.compiler = Compiler(
         Classpath.classpath ++ headFrame.classpath,
         dynamicClasspath,

--- a/amm/interp/src/main/scala/ammonite/interp/CompilerLifecycleManager.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/CompilerLifecycleManager.scala
@@ -115,8 +115,7 @@ class CompilerLifecycleManager(headFrame: => Frame){
 
   def compileClass(processed: Preprocessor.Output,
                    printer: Printer,
-                   fileName: String,
-                   indexedWrapperName: Name): Res[(Util.ClassFiles, Imports)] = synchronized{
+                   fileName: String): Res[(Util.ClassFiles, Imports)] = synchronized{
     // Enforce the invariant that every piece of code Ammonite ever compiles,
     // gets run within the `ammonite` package. It's further namespaced into
     // things like `ammonite.$file` or `ammonite.$sess`, but it has to be
@@ -130,7 +129,6 @@ class CompilerLifecycleManager(headFrame: => Frame){
           processed.code.getBytes,
           printer,
           processed.prefixCharLength,
-          indexedWrapperName,
           processed.userCodeNestingLevel,
           fileName
         )

--- a/amm/interp/src/main/scala/ammonite/interp/CompilerLifecycleManager.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/CompilerLifecycleManager.scala
@@ -71,7 +71,6 @@ class CompilerLifecycleManager(headFrame: => Frame){
       // Otherwise activating autocomplete makes the presentation compiler mangle
       // the shared settings and makes the main compiler sad
       val settings = Option(compiler).fold(new Settings)(_.compiler.settings.copy)
-      settings.Ydelambdafy.value = "inline" // seems to be required in 2.12 for serializing lambdas
       Internal.compiler = Compiler(
         Classpath.classpath ++ headFrame.classpath,
         dynamicClasspath,

--- a/amm/interp/src/main/scala/ammonite/interp/CompilerLifecycleManager.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/CompilerLifecycleManager.scala
@@ -115,7 +115,8 @@ class CompilerLifecycleManager(headFrame: => Frame){
 
   def compileClass(processed: Preprocessor.Output,
                    printer: Printer,
-                   fileName: String): Res[(Util.ClassFiles, Imports)] = synchronized{
+                   fileName: String,
+                   indexedWrapperName: Name): Res[(Util.ClassFiles, Imports)] = synchronized{
     // Enforce the invariant that every piece of code Ammonite ever compiles,
     // gets run within the `ammonite` package. It's further namespaced into
     // things like `ammonite.$file` or `ammonite.$sess`, but it has to be
@@ -125,7 +126,13 @@ class CompilerLifecycleManager(headFrame: => Frame){
     init()
     for {
       compiled <- Res.Success{
-        compiler.compile(processed.code.getBytes, printer, processed.prefixCharLength, fileName)
+        compiler.compile(
+          processed.code.getBytes,
+          printer,
+          processed.prefixCharLength,
+          indexedWrapperName,
+          fileName
+        )
       }
       _ = Internal.compilationCount += 1
       (classfiles, imports) <- Res[(Util.ClassFiles, Imports)](compiled, "Compilation Failed")

--- a/amm/interp/src/main/scala/ammonite/interp/CompilerLifecycleManager.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/CompilerLifecycleManager.scala
@@ -115,7 +115,7 @@ class CompilerLifecycleManager(headFrame: => Frame){
 
   def compileClass(processed: Preprocessor.Output,
                    printer: Printer,
-                   fileName: String): Res[(Util.ClassFiles, Imports)] = synchronized{
+                   fileName: String): Res[Compiler.Output] = synchronized{
     // Enforce the invariant that every piece of code Ammonite ever compiles,
     // gets run within the `ammonite` package. It's further namespaced into
     // things like `ammonite.$file` or `ammonite.$sess`, but it has to be
@@ -134,8 +134,8 @@ class CompilerLifecycleManager(headFrame: => Frame){
         )
       }
       _ = Internal.compilationCount += 1
-      (classfiles, imports) <- Res[(Util.ClassFiles, Imports)](compiled, "Compilation Failed")
-    } yield (classfiles, imports)
+      output <- Res(compiled, "Compilation Failed")
+    } yield output
 
   }
 

--- a/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
@@ -52,6 +52,7 @@ class Interpreter(val printer: Printer,
   def pluginClassloader = headFrame.pluginClassloader
   def handleImports(i: Imports) = headFrame.addImports(i)
   def frameImports = headFrame.imports
+  def frameUsedEarlierDefinitions = headFrame.usedEarlierDefinitions
 
   val compilerManager = new CompilerLifecycleManager(headFrame)
 
@@ -266,6 +267,7 @@ class Interpreter(val printer: Printer,
       res <- eval.processLine(
         output.classFiles,
         output.imports,
+        output.usedEarlierDefinitions.getOrElse(Nil),
         printer,
         indexedWrapperName,
         replCodeWrapper.wrapperPath,
@@ -299,6 +301,7 @@ class Interpreter(val printer: Printer,
       res <- eval.processScriptBlock(
         cls,
         output.imports,
+        output.usedEarlierDefinitions.getOrElse(Nil),
         codeSource.wrapperName,
         scriptCodeWrapper.wrapperPath,
         codeSource.pkgName,

--- a/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
@@ -249,7 +249,8 @@ class Interpreter(val printer: Printer,
       (classFiles, newImports) <- compilerManager.compileClass(
         processed,
         printer,
-        fileName
+        fileName,
+        indexedWrapperName
       )
       _ = incrementLine()
       res <- eval.processLine(
@@ -280,7 +281,7 @@ class Interpreter(val printer: Printer,
     for {
       _ <- Catching{case e: Throwable => e.printStackTrace(); throw e}
       (classFiles, newImports) <- compilerManager.compileClass(
-        processed, printer, codeSource.fileName
+        processed, printer, codeSource.fileName, indexedWrapperName
       )
       cls <- eval.loadClass(fullyQualifiedName, classFiles)
 

--- a/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
@@ -260,8 +260,7 @@ class Interpreter(val printer: Printer,
       (classFiles, newImports) <- compilerManager.compileClass(
         processed,
         printer,
-        fileName,
-        indexedWrapperName
+        fileName
       )
       _ = incrementLine()
       res <- eval.processLine(
@@ -293,7 +292,7 @@ class Interpreter(val printer: Printer,
     for {
       _ <- Catching{case e: Throwable => e.printStackTrace(); throw e}
       (classFiles, newImports) <- compilerManager.compileClass(
-        processed, printer, codeSource.fileName, indexedWrapperName
+        processed, printer, codeSource.fileName
       )
       cls <- eval.loadClass(fullyQualifiedName, classFiles)
 

--- a/amm/interp/src/main/scala/ammonite/interp/Parsers.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Parsers.scala
@@ -60,6 +60,8 @@ object Parsers {
   val Splitter0 = P( StatementBlock(Fail) )
   val Splitter = P( ("{" ~ Splitter0 ~ "}" | Splitter0) ~ End )
 
+  val ObjParser = P( ObjDef )
+
   /**
    * Attempts to break a code blob into multiple statements. Returns `None` if
    * it thinks the code blob is "incomplete" and requires more input
@@ -77,6 +79,11 @@ object Parsers {
       case Parsed.Failure(_, index, extra) if furthest == code.length => None
       case x => Some(x)
     }
+  }
+
+  def isObjDef(code: String): Boolean = {
+    ObjParser.parse(code)
+      .fold((_, _, _) => false, (_, _) => true)
   }
 
   val Separator = P( WL ~ "@" ~~ CharIn(" " + System.lineSeparator).rep(1) )

--- a/amm/interp/src/main/scala/ammonite/interp/Preprocessor.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Preprocessor.scala
@@ -364,6 +364,7 @@ object ${indexedWrapperName.backticked}{\n"""
      */
     private val userCodeNestingLevel = 2
     private val q = "\""
+    private val tq = "\"\"\""
     override val wrapperPath: Seq[Name] = Seq(Name("instance"))
     def apply(
       code: String,
@@ -433,7 +434,7 @@ object ${indexedWrapperName.backticked}{
                */
               val encoded = Util.encodeScalaSourcePath(path)
               s"final val ${key.backticked}: $encoded.type = " +
-                s"if (__amm_usedThings($q$q$q${key.raw}$q$q$q)) $encoded else null$newLine"
+                s"if (__amm_usedThings($tq${key.raw}$tq)) $encoded else null$newLine"
             case (key, values) =>
               throw new Exception(
                 "Should not happen - several required values with the same name " +
@@ -457,7 +458,7 @@ final class ${indexedWrapperName.backticked} extends java.io.Serializable {
   @_root_.scala.transient private val __amm_usedThings =
     new _root_.ammonite.interp.Preprocessor.CodeClassWrapper.UsedThings(this)
 
-  override def toString = $q$q$q${indexedWrapperName.encoded}$q$q$q
+  override def toString = $q${indexedWrapperName.encoded}$q
 $requiredVals
 $reworkedImports
 

--- a/amm/interp/src/main/scala/ammonite/interp/Preprocessor.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Preprocessor.scala
@@ -443,6 +443,13 @@ object ${indexedWrapperName.backticked}{
           }
           .mkString
 
+        val usedThingsSet =
+          if (reqVals.isEmpty) ""
+          else
+            s"""
+  @_root_.scala.transient private val __amm_usedThings =
+    _root_.ammonite.repl.ReplBridge.value.usedEarlierDefinitions.toSet"""
+
         val top = normalizeNewlines(s"""
 package ${pkgName.head.encoded}
 package ${Util.encodeScalaSourcePath(pkgName.tail)}
@@ -455,8 +462,7 @@ object ${indexedWrapperName.backticked}{
 
 final class ${indexedWrapperName.backticked} extends java.io.Serializable {
 
-  @_root_.scala.transient private val __amm_usedThings =
-    new _root_.ammonite.interp.Preprocessor.CodeClassWrapper.UsedThings(this)
+$usedThingsSet
 
   override def toString = $q${indexedWrapperName.encoded}$q
 $requiredVals
@@ -473,33 +479,6 @@ final class Helper extends java.io.Serializable{\n"""
 
         (top, bottom, userCodeNestingLevel)
       }
-    }
-
-    final class UsedThings(obj: AnyRef) {
-
-      lazy val usedThings: Set[String] = {
-        var is: java.io.InputStream = null
-        try {
-          is = Thread.currentThread
-            .getContextClassLoader
-            .getResource(obj.toString + "-uses.txt")
-            .openStream()
-          if (is == null)
-            Set.empty[String]
-          else
-            Source.fromInputStream(is)(Codec.UTF8)
-              .mkString
-              .split('\n')
-              .toSet
-        } finally {
-          if (is != null)
-            is.close()
-        }
-      }
-
-      def apply(name: String): Boolean =
-        usedThings(name)
-
     }
   }
 }

--- a/amm/interp/src/main/scala/ammonite/interp/Preprocessor.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Preprocessor.scala
@@ -306,6 +306,7 @@ object Preprocessor{
 
 
   trait CodeWrapper{
+    def wrapperPath: Seq[Name] = Nil
     def apply(
       code: String,
       pkgName: Seq[Name],
@@ -334,6 +335,7 @@ object Preprocessor{
      * macros).
      */
     private val q = "\""
+    override val wrapperPath: Seq[Name] = Seq(Name("instance"))
     def apply(
       code: String,
       pkgName: Seq[Name],
@@ -375,8 +377,8 @@ object ${indexedWrapperName.backticked}{
             .value
             .map { data =>
               val prefix = Seq(Name("_root_"), Name("ammonite"), Name("$sess"))
-              if (data.prefix.startsWith(prefix) && data.prefix.endsWith(Seq(Name("instance")))) {
-                val name = data.prefix.drop(prefix.length).dropRight(1).last
+              if (data.prefix.startsWith(prefix) && data.prefix.endsWith(wrapperPath)) {
+                val name = data.prefix.drop(prefix.length).dropRight(wrapperPath.length).last
                 (data.copy(prefix = Seq(name)), Seq(name -> data.prefix))
               } else
                 (data, Nil)

--- a/amm/repl/src/main/scala/ammonite/repl/ApiImpls.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/ApiImpls.scala
@@ -21,7 +21,8 @@ class SessionApiImpl(frames0: => StableRef[List[Frame]]) extends Session{
       parent.pluginClassloader.classpathSignature
     ),
     parent.imports,
-    parent.classpath
+    parent.classpath,
+    parent.usedEarlierDefinitions
   )
 
   def save(name: String = "") = {

--- a/amm/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -57,6 +57,8 @@ class Repl(input: InputStream,
   def imports = frames().head.imports
   def fullImports = interp.predefImports ++ imports
 
+  def usedEarlierDefinitions = frames().head.usedEarlierDefinitions
+
   val interp: Interpreter = new Interpreter(
     printer,
     storage,
@@ -80,6 +82,7 @@ class Repl(input: InputStream,
         def compiler = interp.compilerManager.compiler.compiler
         def fullImports = repl.fullImports
         def imports = repl.imports
+        def usedEarlierDefinitions = repl.usedEarlierDefinitions
         def width = frontEnd().width
         def height = frontEnd().height
 

--- a/amm/repl/src/main/scala/ammonite/repl/ReplAPI.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/ReplAPI.scala
@@ -83,6 +83,29 @@ trait ReplAPI {
    * *excludes* imports from the built-in predef and user predef files
    */
   def imports: Imports
+
+  /**
+    * If class wrapping is enabled, this lists the names of the previous commands
+    * that the current commands actually references (as told by the scalac).
+    *
+    * E.g. in a session like
+    * ```
+    * @ val n = 2
+    * n: Int = 2
+    *
+    * @ val p = 1
+    * p: Int = 1
+    *
+    * @ n + p
+    * res2: Int = 3
+    * ```
+    * this would have returned an empty list if called from the same line as `val n = 2`
+    * or `val p = 1`. This would have returned `Seq("cmd0", "cmd1")` if called
+    * from the same line as `n + p`, as both `cmd0`, that defines `n`, and `cmd1`, that
+    * defines `p`, are referenced from this line.
+    */
+  def usedEarlierDefinitions: Seq[String]
+
   /**
    * Controls how things are pretty-printed in the REPL. Feel free
    * to shadow this with your own definition to change how things look

--- a/amm/repl/src/test/scala/ammonite/DualTestRepl.scala
+++ b/amm/repl/src/test/scala/ammonite/DualTestRepl.scala
@@ -1,0 +1,32 @@
+package ammonite
+
+import ammonite.interp.Preprocessor
+import ammonite.util.{Evaluated, Res}
+
+/**
+  * Wraps several [[TestRepl]], and runs its tests against all of them.
+  */
+class DualTestRepl { dual =>
+
+  def predef: (String, Option[ammonite.ops.Path]) = ("", None)
+
+  val repls = Seq(
+    new TestRepl {
+      override def predef = dual.predef
+    },
+    new TestRepl {
+      override def predef = dual.predef
+      override def codeWrapper = Preprocessor.CodeClassWrapper
+    }
+  )
+
+  def interps = repls.map(_.interp)
+
+  def session(sess: String): Unit =
+    repls.foreach(_.session(sess))
+  def result(input: String, expected: Res[Evaluated]): Unit =
+    repls.foreach(_.result(input, expected))
+  def fail(input: String,
+           failureCheck: String => Boolean = _ => true): Unit =
+    repls.foreach(_.fail(input, failureCheck))
+}

--- a/amm/repl/src/test/scala/ammonite/TestRepl.scala
+++ b/amm/repl/src/test/scala/ammonite/TestRepl.scala
@@ -19,6 +19,7 @@ import scala.collection.mutable
 class TestRepl {
   var allOutput = ""
   def predef: (String, Option[ammonite.ops.Path]) = ("", None)
+  def codeWrapper: Preprocessor.CodeWrapper = Preprocessor.CodeWrapper
 
   val tempDir = ammonite.ops.Path(
     java.nio.file.Files.createTempDirectory("ammonite-tester")
@@ -106,8 +107,8 @@ class TestRepl {
       colors = Ref(Colors.BlackWhite),
       getFrame = () => frames().head,
       createFrame = () => { val f = sess0.childFrame(frames().head); frames() = f :: frames(); f },
-      replCodeWrapper = Preprocessor.CodeWrapper,
-      scriptCodeWrapper = Preprocessor.CodeWrapper
+      replCodeWrapper = codeWrapper,
+      scriptCodeWrapper = codeWrapper
     )
 
   }catch{ case e: Throwable =>

--- a/amm/repl/src/test/scala/ammonite/TestRepl.scala
+++ b/amm/repl/src/test/scala/ammonite/TestRepl.scala
@@ -84,6 +84,7 @@ class TestRepl {
           def compiler = interp.compilerManager.compiler.compiler
           def fullImports = interp.predefImports ++ imports
           def imports = interp.frameImports
+          def usedEarlierDefinitions = interp.frameUsedEarlierDefinitions
           def width = 80
           def height = 80
 

--- a/amm/repl/src/test/scala/ammonite/interp/PrintTests.scala
+++ b/amm/repl/src/test/scala/ammonite/interp/PrintTests.scala
@@ -1,40 +1,46 @@
 package ammonite.interp
 
-import ammonite.TestRepl
+import ammonite.DualTestRepl
 import ammonite.util.Util.newLine
 import utest._
 
 object PrintTests extends TestSuite{
   val tests = Tests{
     println("PrintTests")
-    val check = new TestRepl()
+    val check = new DualTestRepl()
 
     'simple - {
-      val t @ (ev, out, res, warn, err, inf) = check.run("val n = 2", 0)
-      val expectedRes = "n: Int = 2"
+      for (repl <- check.repls) {
+        val t @ (ev, out, res, warn, err, inf) = repl.run("val n = 2", 0)
+        val expectedRes = "n: Int = 2"
 
-      assert({ identity(t); ev.isSuccess })
-      assert({ identity(t); out.isEmpty })
-      assert({ identity(t); res == expectedRes })
+        assert({ identity(t); ev.isSuccess })
+        assert({ identity(t); out.isEmpty })
+        assert({ identity(t); res == expectedRes })
+      }
     }
 
     'out - {
-      val t @ (ev, out, res, warn, err, inf) = check.run("show(List(1, 2, 3))", 0)
-      val expectedOut = "List(1, 2, 3)" + newLine
+      for (repl <- check.repls) {
+        val t @ (ev, out, res, warn, err, inf) = repl.run("show(List(1, 2, 3))", 0)
+        val expectedOut = "List(1, 2, 3)" + newLine
 
-      assert({ identity(t); ev.isSuccess })
-      assert({ identity(t); out == expectedOut })
-      assert({ identity(t); res.isEmpty })
+        assert({ identity(t); ev.isSuccess })
+        assert({ identity(t); out == expectedOut })
+        assert({ identity(t); res.isEmpty })
+      }
     }
 
     'both - {
-      val t @ (ev, out, res, warn, err, inf) = check.run("show(List(1, 2, 3)); val n = 3", 0)
-      val expectedOut = "List(1, 2, 3)" + newLine
-      val expectedRes = "n: Int = 3"
+      for (repl <- check.repls) {
+        val t @ (ev, out, res, warn, err, inf) = repl.run("show(List(1, 2, 3)); val n = 3", 0)
+        val expectedOut = "List(1, 2, 3)" + newLine
+        val expectedRes = "n: Int = 3"
 
-      assert({ identity(t); ev.isSuccess })
-      assert({ identity(t); out == expectedOut })
-      assert({ identity(t); res == expectedRes })
+        assert({ identity(t); ev.isSuccess })
+        assert({ identity(t); out == expectedOut })
+        assert({ identity(t); res == expectedRes })
+      }
     }
   }
 }

--- a/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
@@ -373,10 +373,9 @@ object AdvancedTests extends TestSuite{
         @ val cls = classOf[Child]
 
         @ val resName = cls.getName.replace('.', '/') + ".class"
-        resName: String = "ammonite/$sess/cmd0$Child.class"
 
-        @ cls.getClassLoader.getResource(resName)
-        res3: java.net.URL = memory:ammonite/$sess/cmd0$Child.class
+        @ cls.getClassLoader.getResource(resName) != null
+        res3: Boolean = true
 
         @ cls.getClassLoader.getResourceAsStream(resName) != null
         res4: Boolean = true

--- a/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
@@ -1,7 +1,7 @@
 package ammonite.session
 
 import ammonite.TestUtils._
-import ammonite.TestRepl
+import ammonite.DualTestRepl
 import ammonite.util.{Res, Util}
 import utest._
 
@@ -9,7 +9,7 @@ import utest._
 object AdvancedTests extends TestSuite{
   val tests = Tests{
     println("AdvancedTests")
-    val check = new TestRepl()
+    val check = new DualTestRepl()
     'pprint{
       check.session(s"""
         @ Seq.fill(10)(Seq.fill(3)("Foo"))
@@ -53,7 +53,7 @@ object AdvancedTests extends TestSuite{
     }
 
     'predef{
-      val check2 = new TestRepl{
+      val check2 = new DualTestRepl{
         override def predef = (
           """
           import math.abs
@@ -79,7 +79,7 @@ object AdvancedTests extends TestSuite{
 
     }
     'predefSettings{
-      val check2 = new TestRepl{
+      val check2 = new DualTestRepl{
         override def predef = (
           """
           interp.configureCompiler(_.settings.Xexperimental.value = true)
@@ -294,8 +294,8 @@ object AdvancedTests extends TestSuite{
       // one getting its own `ReplBridge`. This ensures that the various
       // Interpreters are properly encapsulated and don't interfere with each
       // other.
-      val c1 = new TestRepl()
-      val c2 = new TestRepl()
+      val c1 = new DualTestRepl()
+      val c2 = new DualTestRepl()
       c1.session("""
         @ repl.prompt() = "A"
       """)
@@ -311,7 +311,7 @@ object AdvancedTests extends TestSuite{
     }
     'macroParadiseWorks{
       val scalaVersion: String = scala.util.Properties.versionNumberString
-      val c1: TestRepl = new TestRepl()
+      val c1: DualTestRepl = new DualTestRepl()
       c1.session(s"""
         @ interp.load.plugin.ivy("org.scalamacros" % "paradise_${scalaVersion}" % "2.1.0")
       """)
@@ -329,7 +329,7 @@ object AdvancedTests extends TestSuite{
       import ammonite.ops._
       val dir = pwd/'amm/'src/'test/'resources/'scripts/'predefWithLoad
       'loadExec {
-        val c1 = new TestRepl() {
+        val c1 = new DualTestRepl() {
           override def predef = (
             read! dir/"PredefLoadExec.sc",
             Some(dir/"PredefLoadExec.sc")
@@ -341,7 +341,7 @@ object AdvancedTests extends TestSuite{
         """)
       }
       'loadModule{
-        val c2 = new TestRepl(){
+        val c2 = new DualTestRepl(){
           override def predef = (
             read! dir/"PredefLoadModule.sc",
             Some(dir/"PredefLoadModule.sc")
@@ -353,7 +353,7 @@ object AdvancedTests extends TestSuite{
         """)
       }
       'importIvy{
-        val c2 = new TestRepl(){
+        val c2 = new DualTestRepl(){
           override def predef = (
             read! dir/"PredefMagicImport.sc",
             Some(dir/"PredefMagicImport.sc")

--- a/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
@@ -99,13 +99,15 @@ object AdvancedTests extends TestSuite{
 
         @ import reflect.macros.Context
 
-        @ def impl(c: Context): c.Expr[String] = {
-        @  import c.universe._
-        @  c.Expr[String](Literal(Constant("Hello!")))
+        @ object Macro {
+        @   def impl(c: Context): c.Expr[String] = {
+        @    import c.universe._
+        @    c.Expr[String](Literal(Constant("Hello!")))
+        @   }
         @ }
-        defined function impl
+        defined object Macro
 
-        @ def m: String = macro impl
+        @ def m: String = macro Macro.impl
         defined function m
 
         @ m

--- a/amm/repl/src/test/scala/ammonite/session/BuiltinTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/BuiltinTests.scala
@@ -1,6 +1,6 @@
 package ammonite.session
 
-import ammonite.TestRepl
+import ammonite.DualTestRepl
 import utest._
 
 import scala.collection.{immutable => imm}
@@ -8,7 +8,7 @@ object BuiltinTests extends TestSuite{
 
   val tests = Tests{
     println("BuiltinTests")
-    val check = new TestRepl()
+    val check = new DualTestRepl()
     'basicConfig{
       check.session("""
         @ // Set the shell prompt to be something else

--- a/amm/repl/src/test/scala/ammonite/session/EulerTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/EulerTests.scala
@@ -1,11 +1,11 @@
 package ammonite.session
 
-import ammonite.TestRepl
+import ammonite.DualTestRepl
 import utest._
 object EulerTests extends TestSuite{
   val tests = Tests{
     println("EulerTests")
-    val check = new TestRepl()
+    val check = new DualTestRepl()
 
 
     // Taken from https://pavelfatin.com/scala-for-project-euler/

--- a/amm/repl/src/test/scala/ammonite/session/EvaluatorTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/EvaluatorTests.scala
@@ -1,6 +1,6 @@
 package ammonite.session
 
-import ammonite.TestRepl
+import ammonite.DualTestRepl
 import ammonite.TestUtils._
 import utest._
 
@@ -10,7 +10,7 @@ object EvaluatorTests extends TestSuite{
 
   val tests = Tests{
     println("EvaluatorTests")
-    val check = new TestRepl()
+    val check = new DualTestRepl()
     'simpleExpressions{
       check.session("""
         @ 1 + 2

--- a/amm/repl/src/test/scala/ammonite/session/FailureTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/FailureTests.scala
@@ -56,7 +56,7 @@ object FailureTests extends TestSuite{
         x.contains("java.lang.Exception: lol") &&
         x.contains("java.lang.Exception: hoho") &&
         // and none of the stuff we don't want
-        x.lines.length == 6 &&
+        !x.contains("evaluatorRunPrinter") &&
         !x.contains("Something unexpected went wrong =(")
       )
     }

--- a/amm/repl/src/test/scala/ammonite/session/FailureTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/FailureTests.scala
@@ -1,13 +1,13 @@
 package ammonite.session
 
-import ammonite.{TestRepl, TestUtils}
+import ammonite.{DualTestRepl, TestUtils}
 import utest._
 
 import scala.collection.{immutable => imm}
 object FailureTests extends TestSuite{
   val tests = Tests{
     println("FailureTests")
-    val check = new TestRepl()
+    val check = new DualTestRepl()
     'compileFailure {
       check.session("""
         @ doesnt_exist

--- a/amm/repl/src/test/scala/ammonite/session/ImportHookTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/ImportHookTests.scala
@@ -1,6 +1,6 @@
 package ammonite.session
 
-import ammonite.TestRepl
+import ammonite.DualTestRepl
 import ammonite.TestUtils._
 import ammonite.runtime.tools.IvyThing
 import utest._
@@ -13,7 +13,7 @@ object ImportHookTests extends TestSuite{
 
   val tests = Tests{
     println("ImportHookTests")
-    val check = new TestRepl()
+    val check = new DualTestRepl()
     'repl{
       'file{
         'basic - check.session("""

--- a/amm/repl/src/test/scala/ammonite/session/ImportTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/ImportTests.scala
@@ -1,6 +1,6 @@
 package ammonite.session
 
-import ammonite.TestRepl
+import ammonite.DualTestRepl
 import ammonite.TestUtils._
 import utest._
 
@@ -10,7 +10,7 @@ object ImportTests extends TestSuite{
 
   val tests = Tests{
     println("ImportTests")
-    val check = new TestRepl()
+    val check = new DualTestRepl()
 
     'basic {
       'hello{

--- a/amm/repl/src/test/scala/ammonite/session/ProjectTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/ProjectTests.scala
@@ -1,6 +1,6 @@
 package ammonite.session
 
-import ammonite.TestRepl
+import ammonite.DualTestRepl
 import ammonite.TestUtils._
 import utest._
 
@@ -9,7 +9,7 @@ import scala.collection.{immutable => imm}
 object ProjectTests extends TestSuite{
   val tests = Tests{
     println("ProjectTests")
-    val check = new TestRepl()
+    val check = new DualTestRepl()
     'load {
       'ivy {
         'standalone - {

--- a/amm/repl/src/test/scala/ammonite/session/SerializationTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/SerializationTests.scala
@@ -11,84 +11,82 @@ object SerializationTests extends TestSuite{
       override def codeWrapper = Preprocessor.CodeClassWrapper
     }
 
-    'dummy {
-      'foo - {
-        // User values from the REPL shouldn't be recomputed upon
-        // deserialization. The test below checks that the value `a`, whose
-        // computation is side-effecting, is indeed serialized along `closure`,
-        // rather than re-computed.
+    'closure {
+      // User values from the REPL shouldn't be recomputed upon
+      // deserialization. The test below checks that the value `a`, whose
+      // computation is side-effecting, is indeed serialized along `closure`,
+      // rather than re-computed.
 
-        // About the issue of values in singletons not being serialized (and
-        // being recomputed if necessary), see the discussion in
-        // https://groups.google.com/forum/#!topic/scala-internals/h27CFLoJXjE.
+      // About the issue of values in singletons not being serialized (and
+      // being recomputed if necessary), see the discussion in
+      // https://groups.google.com/forum/#!topic/scala-internals/h27CFLoJXjE.
 
-        // This is similar to what happens when mapping a function on an RDD
-        // or using a UDF in Spark: a closure gets serialized this way, and is sent
-        // to a bunch of "executors" that each deserialize it.
+      // This is similar to what happens when mapping a function on an RDD
+      // or using a UDF in Spark: a closure gets serialized this way, and is sent
+      // to a bunch of "executors" that each deserialize it.
 
-        // In the test, `a` acts as the result of the heavy computation. We do not want
-        // the calculation of `a` to re-run when deserializing `closure`.
+      // In the test, `a` acts as the result of the heavy computation. We do not want
+      // the calculation of `a` to re-run when deserializing `closure`.
 
-        // After creating the closure, the test serializes it, then deserializes it
-        // via a classloader that can load the exact same bytecode as the classloader of
-        // the current session. We call the deserialized closure by reflection, and check
-        // that the heavy computation was not run again.
+      // After creating the closure, the test serializes it, then deserializes it
+      // via a classloader that can load the exact same bytecode as the classloader of
+      // the current session. We call the deserialized closure by reflection, and check
+      // that the heavy computation was not run again.
 
-        check.session(
-          s"""
-            @ object costlySideEffect {
-            @   import java.nio.file.{Files, Paths}
-            @   private val path = Paths.get("a")
-            @   def apply()  = Files.write(path, Array[Byte]())
-            @   def clear()  = Files.deleteIfExists(path)
-            @   def exists() = assert(Files.exists(path), "Side-effect didn't run")
-            @   def absent(msg: String = "") =
-            @     assert(!Files.exists(path), s"Side-effect did run $$msg")
-            @ }
+      check.session(
+        s"""
+          @ object costlySideEffect {
+          @   import java.nio.file.{Files, Paths}
+          @   private val path = Paths.get("a")
+          @   def apply()  = Files.write(path, Array[Byte]())
+          @   def clear()  = Files.deleteIfExists(path)
+          @   def exists() = assert(Files.exists(path), "Side-effect didn't run")
+          @   def absent(msg: String = "") =
+          @     assert(!Files.exists(path), s"Side-effect did run $$msg")
+          @ }
 
-            @ class D // not serializable
+          @ class D // not serializable
 
-            @ val d =
-            @   // serialization should succeed in spite of this
-            @   // non-serializable variable being around
-            @   new D
+          @ val d =
+          @   // serialization should succeed in spite of this
+          @   // non-serializable variable being around
+          @   new D
 
-            @ val a = {
-            @   costlySideEffect()
-            @   Option(2)
-            @ }
+          @ val a = {
+          @   costlySideEffect()
+          @   Option(2)
+          @ }
 
-            @ val closure: Int => Option[Int] = { n =>
-            @   a.map(_ + n)
-            @ }
+          @ val closure: Int => Option[Int] = { n =>
+          @   a.map(_ + n)
+          @ }
 
-            @ {{
-            @   costlySideEffect.exists() // "a" side-effect has run
-            @   costlySideEffect.clear()
-            @   costlySideEffect.absent("after cleaning")
-            @ }}
+          @ {{
+          @   costlySideEffect.exists() // "a" side-effect has run
+          @   costlySideEffect.clear()
+          @   costlySideEffect.absent("after cleaning")
+          @ }}
 
-            @ lazy val closureClone = ammonite.session.SerializationTests.Util.deserialize(
-            @   ammonite.session.SerializationTests.Util.serialize(closure),
-            @   Thread.currentThread
-            @     .getContextClassLoader
-            @     .asInstanceOf[ammonite.runtime.SpecialClassLoader]
-            @     .cloneClassLoader()
-            @ )
+          @ lazy val closureClone = ammonite.session.SerializationTests.Util.deserialize(
+          @   ammonite.session.SerializationTests.Util.serialize(closure),
+          @   Thread.currentThread
+          @     .getContextClassLoader
+          @     .asInstanceOf[ammonite.runtime.SpecialClassLoader]
+          @     .cloneClassLoader()
+          @ )
 
-            @ {{
-            @   costlySideEffect.absent("before deserialization")
-            @   closureClone
-            @     .getClass
-            @     .getMethod("apply", classOf[Int])
-            @     .invoke(closureClone, 2: java.lang.Integer)
-            @   // calling apply should not run the side-effect again, the
-            @   // value of 'a' must come from deserialization
-            @   costlySideEffect.absent("after deserialization")
-            @ }}
+          @ {{
+          @   costlySideEffect.absent("before deserialization")
+          @   closureClone
+          @     .getClass
+          @     .getMethod("apply", classOf[Int])
+          @     .invoke(closureClone, 2: java.lang.Integer)
+          @   // calling apply should not run the side-effect again, the
+          @   // value of 'a' must come from deserialization
+          @   costlySideEffect.absent("after deserialization")
+          @ }}
 
-          """)
-      }
+        """)
     }
   }
 

--- a/amm/repl/src/test/scala/ammonite/session/SerializationTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/SerializationTests.scala
@@ -34,7 +34,7 @@ object SerializationTests extends TestSuite{
 
         check.session(
           s"""
-            @ object costlySideEffect extends Serializable {
+            @ object costlySideEffect {
             @   import java.nio.file.{Files, Paths}
             @   private val path = Paths.get("a")
             @   def apply()  = Files.write(path, Array[Byte]())

--- a/amm/repl/src/test/scala/ammonite/session/SerializationTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/SerializationTests.scala
@@ -33,8 +33,12 @@ object SerializationTests extends TestSuite{
       // the current session. We call the deserialized closure by reflection, and check
       // that the heavy computation was not run again.
 
+      // -Ydelambdafy=inline seems to be required in 2.12 for serializing lambdas
+
       check.session(
         s"""
+          @ interp.configureCompiler(_.settings.Ydelambdafy.value = "inline")
+
           @ object costlySideEffect {
           @   import java.nio.file.{Files, Paths}
           @   private val path = Paths.get("a")

--- a/amm/repl/src/test/scala/ammonite/session/SerializationTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/SerializationTests.scala
@@ -7,7 +7,9 @@ import utest._
 object SerializationTests extends TestSuite{
   val tests = Tests{
     println("SerializationTests")
-    val check = new TestRepl
+    val check = new TestRepl {
+      override def codeWrapper = Preprocessor.CodeClassWrapper
+    }
 
     'dummy {
       'foo - {

--- a/amm/repl/src/test/scala/ammonite/session/SerializationTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/SerializationTests.scala
@@ -1,0 +1,133 @@
+package ammonite.session
+
+import ammonite.TestRepl
+import ammonite.interp.Preprocessor
+import utest._
+
+object SerializationTests extends TestSuite{
+  val tests = Tests{
+    println("SerializationTests")
+    val check = new TestRepl
+
+    'dummy {
+      'foo - {
+        // User values from the REPL shouldn't be recomputed upon
+        // deserialization. The test below checks that the value `a`, whose
+        // computation is side-effecting, is indeed serialized along `closure`,
+        // rather than re-computed.
+
+        // About the issue of values in singletons not being serialized (and
+        // being recomputed if necessary), see the discussion in
+        // https://groups.google.com/forum/#!topic/scala-internals/h27CFLoJXjE.
+
+        // This is similar to what happens when mapping a function on an RDD
+        // or using a UDF in Spark: a closure gets serialized this way, and is sent
+        // to a bunch of "executors" that each deserialize it.
+
+        // In the test, `a` acts as the result of the heavy computation. We do not want
+        // the calculation of `a` to re-run when deserializing `closure`.
+
+        // After creating the closure, the test serializes it, then deserializes it
+        // via a classloader that can load the exact same bytecode as the classloader of
+        // the current session. We call the deserialized closure by reflection, and check
+        // that the heavy computation was not run again.
+
+        check.session(
+          s"""
+            @ object costlySideEffect extends Serializable {
+            @   import java.nio.file.{Files, Paths}
+            @   private val path = Paths.get("a")
+            @   def apply()  = Files.write(path, Array[Byte]())
+            @   def clear()  = Files.deleteIfExists(path)
+            @   def exists() = assert(Files.exists(path), "Side-effect didn't run")
+            @   def absent(msg: String = "") =
+            @     assert(!Files.exists(path), s"Side-effect did run $$msg")
+            @ }
+
+            @ class D // not serializable
+
+            @ val d =
+            @   // serialization should succeed in spite of this
+            @   // non-serializable variable being around
+            @   new D
+
+            @ val a = {
+            @   costlySideEffect()
+            @   Option(2)
+            @ }
+
+            @ val closure: Int => Option[Int] = { n =>
+            @   a.map(_ + n)
+            @ }
+
+            @ {{
+            @   costlySideEffect.exists() // "a" side-effect has run
+            @   costlySideEffect.clear()
+            @   costlySideEffect.absent("after cleaning")
+            @ }}
+
+            @ lazy val closureClone = ammonite.session.SerializationTests.Util.deserialize(
+            @   ammonite.session.SerializationTests.Util.serialize(closure),
+            @   Thread.currentThread
+            @     .getContextClassLoader
+            @     .asInstanceOf[ammonite.runtime.SpecialClassLoader]
+            @     .cloneClassLoader()
+            @ )
+
+            @ {{
+            @   costlySideEffect.absent("before deserialization")
+            @   closureClone
+            @     .getClass
+            @     .getMethod("apply", classOf[Int])
+            @     .invoke(closureClone, 2: java.lang.Integer)
+            @   // calling apply should not run the side-effect again, the
+            @   // value of 'a' must come from deserialization
+            @   costlySideEffect.absent("after deserialization")
+            @ }}
+
+          """)
+      }
+    }
+  }
+
+  object Util {
+
+    import java.io._
+
+    def serialize(m: AnyRef): Array[Byte] = {
+      val baos = new ByteArrayOutputStream()
+      val oos = new ObjectOutputStream(baos)
+      try {
+        oos.writeObject(m)
+        baos.toByteArray
+      }
+      finally oos.close()
+    }
+
+    def deserialize(b: Array[Byte], loader: ClassLoader): AnyRef = {
+      val bais = new ByteArrayInputStream(b)
+      val ois = new ClassLoaderObjectInputStream(loader, bais)
+      try ois.readObject()
+      finally ois.close()
+    }
+
+    // from akka.util
+
+    /**
+      * ClassLoaderObjectInputStream tries to utilize the provided ClassLoader
+      * to load Classes and falls back to ObjectInputStreams resolver.
+      *
+      * @param classLoader - the ClassLoader which is to be used primarily
+      * @param is - the InputStream that is wrapped
+      */
+    class ClassLoaderObjectInputStream(
+     classLoader: ClassLoader,
+     is: InputStream
+    ) extends ObjectInputStream(is) {
+      override protected def resolveClass(objectStreamClass: ObjectStreamClass): Class[_] =
+        try Class.forName(objectStreamClass.getName, false, classLoader) catch {
+          case cnfe: ClassNotFoundException ⇒ super.resolveClass(objectStreamClass)
+        }
+    }
+  }
+}

--- a/amm/runtime/src/main/scala/ammonite/runtime/ClassLoaders.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/ClassLoaders.scala
@@ -24,7 +24,8 @@ import scala.collection.mutable
 class Frame(val classloader: SpecialClassLoader,
             val pluginClassloader: SpecialClassLoader,
             private[this] var imports0: Imports,
-            private[this] var classpath0: Seq[java.io.File]){
+            private[this] var classpath0: Seq[java.io.File],
+            private[this] var usedEarlierDefinitions0: Seq[String]){
   private var frozen0 = false
   def frozen = frozen0
   def freeze(): Unit = {
@@ -39,6 +40,7 @@ class Frame(val classloader: SpecialClassLoader,
   def version = version0
   def imports = imports0
   def classpath = classpath0
+  def usedEarlierDefinitions = usedEarlierDefinitions0
   def addImports(additional: Imports) = {
     if (!frozen0) {
       version0 += 1
@@ -58,6 +60,8 @@ class Frame(val classloader: SpecialClassLoader,
       additional.map(_.toURI.toURL).foreach(pluginClassloader.add)
     }
   }
+  def usedEarlierDefinitions_=(usedEarlierDefinitions: Seq[String]): Unit =
+    usedEarlierDefinitions0 = usedEarlierDefinitions
 }
 object Frame{
   def createInitial() = {
@@ -75,7 +79,7 @@ object Frame{
       likelyJdkSourceLocation.toNIO.toUri.toURL
     )
 
-    new Frame(special, special, Imports(), Seq())
+    new Frame(special, special, Imports(), Seq(), Seq())
   }
 }
 

--- a/amm/runtime/src/main/scala/ammonite/runtime/ClassLoaders.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/ClassLoaders.scala
@@ -231,7 +231,7 @@ class SpecialClassLoader(parent: ClassLoader, parentSignature: Seq[(Path, Long)]
     path -> (if (exists(path))path.mtime.toMillis else 0)
   }
 
-  private[this] var classpathSignature0 = parentSignature
+  private var classpathSignature0 = parentSignature
   def classpathSignature = classpathSignature0
   def classpathHash = {
     Util.md5Hash(
@@ -269,6 +269,26 @@ class SpecialClassLoader(parent: ClassLoader, parentSignature: Seq[(Path, Long)]
         }
       })
     }
+  }
+
+  def cloneClassLoader(parent: ClassLoader = null): SpecialClassLoader = {
+
+    // FIXME Not tailrec
+
+     val newParent =
+       if (parent == null)
+         getParent match {
+           case s: SpecialClassLoader => s.cloneClassLoader()
+           case p => p
+         }
+       else
+         parent
+
+     val clone = new SpecialClassLoader(newParent, parentSignature, getURLs.toSeq: _*)
+     clone.newFileDict ++= newFileDict
+     clone.classpathSignature0 = classpathSignature0
+
+     clone
   }
 
 }

--- a/amm/runtime/src/main/scala/ammonite/runtime/Evaluator.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/Evaluator.scala
@@ -140,6 +140,10 @@ object Evaluator{
                 // For some reason, for things not-in-packages you can't access
                 // them off of `_root_`
                 Seq(Name("_root_")) ++ wrapperName ++ Seq(Name("instance"))
+              else if (id.prefix.startsWith(wrapperName))
+                Seq(Name("_root_")) ++ wrapperName.init ++
+                  Seq(id.prefix.apply(wrapperName.length), Name("instance")) ++
+                  id.prefix.drop(wrapperName.length + 1)
               else if (id.prefix.headOption.exists(_.backticked == "_root_"))
                 id.prefix
               else

--- a/amm/runtime/src/main/scala/ammonite/runtime/Evaluator.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/Evaluator.scala
@@ -136,18 +136,16 @@ object Evaluator{
         Imports(
           for(id <- imports.value) yield {
             val filledPrefix =
-              if (id.prefix.isEmpty) {
+              if (id.prefix.isEmpty)
                 // For some reason, for things not-in-packages you can't access
                 // them off of `_root_`
-                wrapperName
-              } else {
+                Seq(Name("_root_")) ++ wrapperName ++ Seq(Name("instance"))
+              else if (id.prefix.headOption.exists(_.backticked == "_root_"))
                 id.prefix
-              }
-            val rootedPrefix: Seq[Name] =
-              if (filledPrefix.headOption.exists(_.backticked == "_root_")) filledPrefix
-              else Seq(Name("_root_")) ++ filledPrefix
+              else
+                Seq(Name("_root_")) ++ id.prefix
 
-            id.copy(prefix = rootedPrefix)
+            id.copy(prefix = filledPrefix)
           }
         )
       )

--- a/amm/runtime/src/main/scala/ammonite/runtime/Evaluator.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/Evaluator.scala
@@ -162,7 +162,19 @@ object Evaluator{
         Imports(
           for(id <- imports.value) yield {
             val filledPrefix =
-              if (id.prefix.isEmpty)
+              if (internalWrapperPath.isEmpty) {
+                val filledPrefix =
+                  if (id.prefix.isEmpty) {
+                    // For some reason, for things not-in-packages you can't access
+                    // them off of `_root_`
+                    wrapperName
+                  } else {
+                    id.prefix
+                  }
+
+                if (filledPrefix.headOption.exists(_.backticked == "_root_")) filledPrefix
+                else Seq(Name("_root_")) ++ filledPrefix
+              } else if (id.prefix.isEmpty)
                 // For some reason, for things not-in-packages you can't access
                 // them off of `_root_`
                 Seq(Name("_root_")) ++ wrapperName ++ internalWrapperPath

--- a/amm/runtime/src/main/scala/ammonite/runtime/Evaluator.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/Evaluator.scala
@@ -22,8 +22,9 @@ trait Evaluator{
   def evalMain(cls: Class[_], contextClassloader: ClassLoader): Any
 
 
-  def processLine(classFiles: ClassFiles,
+  def processLine(output: ClassFiles,
                   newImports: Imports,
+                  usedEarlierDefinitions: Seq[String],
                   printer: Printer,
                   indexedWrapperName: Name,
                   wrapperPath: Seq[Name],
@@ -32,6 +33,7 @@ trait Evaluator{
 
   def processScriptBlock(cls: Class[_],
                          newImports: Imports,
+                         usedEarlierDefinitions: Seq[String],
                          wrapperName: Name,
                          wrapperPath: Seq[Name],
                          pkgName: Seq[Name],
@@ -113,6 +115,7 @@ object Evaluator{
 
     def processLine(classFiles: Util.ClassFiles,
                     newImports: Imports,
+                    usedEarlierDefinitions: Seq[String],
                     printer: Printer,
                     indexedWrapperName: Name,
                     wrapperPath: Seq[Name],
@@ -122,6 +125,8 @@ object Evaluator{
         cls <- loadClass("ammonite.$sess." + indexedWrapperName.backticked, classFiles)
         _ <- Catching{userCodeExceptionHandler}
       } yield {
+        headFrame.usedEarlierDefinitions = usedEarlierDefinitions
+
         // Exhaust the printer iterator now, before exiting the `Catching`
         // block, so any exceptions thrown get properly caught and handled
         val iter = evalMain(cls, contextClassLoader).asInstanceOf[Iterator[String]]
@@ -141,6 +146,7 @@ object Evaluator{
 
     def processScriptBlock(cls: Class[_],
                            newImports: Imports,
+                           usedEarlierDefinitions: Seq[String],
                            wrapperName: Name,
                            wrapperPath: Seq[Name],
                            pkgName: Seq[Name],
@@ -148,6 +154,7 @@ object Evaluator{
       for {
         _ <- Catching{userCodeExceptionHandler}
       } yield {
+        headFrame.usedEarlierDefinitions = usedEarlierDefinitions
         evalMain(cls, contextClassLoader)
         val res = evaluationResult(pkgName :+ wrapperName, wrapperPath, newImports)
         res

--- a/amm/runtime/src/main/scala/ammonite/runtime/ImportHook.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/ImportHook.scala
@@ -112,7 +112,7 @@ object ImportHook{
                   source.flexiblePkgName, filePath relativeTo currentScriptPath/up
                 )
 
-                val fullPrefix = source.pkgRoot ++ flexiblePkg ++ Seq(wrapper)
+                val fullPrefix = source.pkgRoot ++ flexiblePkg ++ Seq(wrapper, Name("instance"))
 
                 val importData = Seq(ImportData(
                   fullPrefix.last, Name(rename.getOrElse(relativeModule.last)),
@@ -252,7 +252,7 @@ object ImportHook{
                 None
               )
 
-              val fullPrefix = source.pkgRoot :+ Name(uri.toString)
+              val fullPrefix = source.pkgRoot ++ Seq(Name(uri.toString), Name("instance"))
               val importData = Seq(ImportData(
                 fullPrefix.last, Name(rename),
                 fullPrefix.dropRight(1), ImportData.TermType

--- a/amm/runtime/src/main/scala/ammonite/runtime/ImportHook.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/ImportHook.scala
@@ -28,7 +28,8 @@ trait ImportHook{
     */
   def handle(source: CodeSource,
              tree: ImportTree,
-             interp: ImportHook.InterpreterInterface)
+             interp: ImportHook.InterpreterInterface,
+             wrapperPath: Seq[Name])
             : Either[String, Seq[ImportHook.Result]]
 }
 
@@ -90,7 +91,8 @@ object ImportHook{
     // import $file.foo.Bar, to import the file `foo/Bar.sc`
     def handle(source: CodeSource,
                tree: ImportTree,
-               interp: InterpreterInterface) = {
+               interp: InterpreterInterface,
+               wrapperPath: Seq[Name]) = {
 
       source.path match{
         case None => Left("Cannot resolve $file import in code without source")
@@ -112,7 +114,7 @@ object ImportHook{
                   source.flexiblePkgName, filePath relativeTo currentScriptPath/up
                 )
 
-                val fullPrefix = source.pkgRoot ++ flexiblePkg ++ Seq(wrapper, Name("instance"))
+                val fullPrefix = source.pkgRoot ++ flexiblePkg ++ Seq(wrapper) ++ wrapperPath
 
                 val importData = Seq(ImportData(
                   fullPrefix.last, Name(rename.getOrElse(relativeModule.last)),
@@ -180,7 +182,8 @@ object ImportHook{
 
     def handle(source: CodeSource,
                tree: ImportTree,
-               interp: InterpreterInterface) = for{
+               interp: InterpreterInterface,
+               wrapperPath: Seq[Name]) = for{
       signatures <- splitImportTree(tree).right
       resolved <- resolve(interp, signatures).right
     } yield resolved.map(Path(_)).map(Result.ClassPath(_, plugin)).toSeq
@@ -190,7 +193,8 @@ object ImportHook{
   class BaseClasspath(plugin: Boolean) extends ImportHook{
     def handle(source: CodeSource,
                tree: ImportTree,
-               interp: InterpreterInterface) = {
+               interp: InterpreterInterface,
+               wrapperPath: Seq[Name]) = {
       source.path match{
         case None => Left("Cannot resolve $cp import in code without source")
         case Some(currentScriptPath) =>
@@ -231,7 +235,8 @@ object ImportHook{
 
     override def handle(source: CodeSource,
                         tree: ImportTree,
-                        interp: InterpreterInterface): Either[String, Seq[Result]] = {
+                        interp: InterpreterInterface,
+                        wrapperPath: Seq[Name]): Either[String, Seq[Result]] = {
       Try(resolveURLs(tree)) match {
         case Failure(e) =>
           Left(e.getMessage)
@@ -252,7 +257,7 @@ object ImportHook{
                 None
               )
 
-              val fullPrefix = source.pkgRoot ++ Seq(Name(uri.toString), Name("instance"))
+              val fullPrefix = source.pkgRoot ++ Seq(Name(uri.toString)) ++ wrapperPath
               val importData = Seq(ImportData(
                 fullPrefix.last, Name(rename),
                 fullPrefix.dropRight(1), ImportData.TermType


### PR DESCRIPTION
The goal of this PR is to make Ammonite behave well wrt Java serialization. This is a quite big PR, hard to split in smaller ones, that roughly adds a failing test (`SerializationTests`), then makes it pass.

Its goal, in sessions like this one
```
@ val n = 2
n: Int = 2

@ val f: Int => Int = { p =>
    p + n
  }
f: Int => Int = <function1>
```
is to be able to serialize `f` with [Java serialization](https://docs.oracle.com/javase/7/docs/api/java/io/ObjectInputStream.html), without its deserialization to re-trigger the calculation of the values `f` depends on (`n`) - these should be serialized / deserialized along with `f`.

Currently, the user code is wrapped in a singleton. Singletons don't serialize their fields, and re-compute them if needed upon deserialization. So here, `n` would be re-computed when deserializing `f`.

To address that, this PR adds a class-based code wrapper, that wraps the user code in classes, and that references the previous commands via instances of these classes (no singleton involved). That way, only class instances are involved during serialization, and the scenario above works fine.

This kind of scenario (serializing closures with Java serialization) is used in Spark (e.g. when [mapping](https://spark.apache.org/docs/2.2.0/api/scala/index.html#org.apache.spark.rdd.RDD@map%5BU%5D(f:T=%3EU)(implicitevidence%243:scala.reflect.ClassTag%5BU%5D):org.apache.spark.rdd.RDD%5BU%5D) a method on RDDs, when creating [UDFs](https://spark.apache.org/docs/2.2.0/api/scala/index.html#org.apache.spark.sql.expressions.UserDefinedFunction), … - where a method is serialized on one machine, then sent to a bunch of machines that deserialize it), but the same kind of thing also happens with other big data frameworks like [flink](https://flink.apache.org/) or [scio](https://github.com/spotify/scio), … Being able to use these frameworks from Ammonite makes it worth the effort IMO.

In more detail, this PR successively:
- makes some minor adjustments to the tests or Ammonite itself (first two commits, also sent as separate PRs in https://github.com/lihaoyi/Ammonite/pull/734 and https://github.com/lihaoyi/Ammonite/pull/735),
- adds a Java serialization test - that fails in a first time (https://github.com/alexarchambault/Ammonite/commit/6988591f38fddf66b7bba78c8b38a9f17e774501),
- changes the code wrapper so that the Java serialization test passes - but this breaks other tests then (https://github.com/alexarchambault/Ammonite/commit/71b506fd31ab1031315400de3111e677221b6b03, https://github.com/alexarchambault/Ammonite/commit/1f857b5cf3d9f78f7ce0ef83f343bd0d7de7e02c, https://github.com/alexarchambault/Ammonite/commit/eec0daa2d7d774630c151f4126a9d7638441c7ad),
- fixes the other tests that were broken (https://github.com/alexarchambault/Ammonite/commit/06ed699419b3319260ec6e44388e9d6cf2610e46 to https://github.com/alexarchambault/Ammonite/commit/a61fde34c4ac753b926c0d07e90bc78ced66d33b),
- factor a few code-wrapper-specific parameters (https://github.com/alexarchambault/Ammonite/commit/f220f37a9b2ee5f56bb7cb2d3a09e2ca0c384118, https://github.com/alexarchambault/Ammonite/commit/632fb56eaef7d880e99679a38503d7a0d128818e),
- adds back the original object code wrapper (the one in the current master of Ammonite, https://github.com/alexarchambault/Ammonite/commit/36d9d04c5ae7bf1f09d444ac188eaa131345e9bf),
- and lastly runs most tests with both the original and the new, class-based, code wrappers (https://github.com/alexarchambault/Ammonite/commit/2bc4bd589a18aa87f268cd5343670b8776726578, https://github.com/alexarchambault/Ammonite/commit/cbd8efffa17aeadd1f6bb7adaba7d0c92807f14d).

The first two commits were also sent in separate PRs (https://github.com/lihaoyi/Ammonite/pull/734, https://github.com/lihaoyi/Ammonite/pull/735). The last commit makes the tests run for both the object and class based code wrappers, so *could* be discarded (less things would be tested). Apart from that, it's quite hard to split it in more atomic PRs…