### PR TITLE
Bump from 2.11.11 to 2.11.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
   - stage: build
     env: CI_SCRIPT="ci/build.sc test published/test"
     jdk: oraclejdk7
-    scala: 2.11.11
+    scala: 2.11.12
 
   - stage: build
     env: CI_SCRIPT="ci/build.sc test integration/test"
@@ -32,25 +32,25 @@ matrix:
   - stage: build
     env: CI_SCRIPT="ci/build.sc test integration/test"
     jdk: oraclejdk7
-    scala: 2.11.11
+    scala: 2.11.12
 
   # Publish everything to sonatype in conjunction with running tests
   - stage: build
     env: CI_SCRIPT="ci/build.sc artifacts 2.11.3 2.11.4 2.11.5 2.11.6 "
     jdk: oraclejdk8
-    scala: 2.11.11
+    scala: 2.11.12
 
   - stage: build
     # 2.11.9 and 2.11.10 were borked releases
-    env: CI_SCRIPT="ci/build.sc artifacts 2.11.7 2.11.8 2.11.11"
+    env: CI_SCRIPT="ci/build.sc artifacts 2.11.7 2.11.8 2.11.12"
     jdk: oraclejdk8
-    scala: 2.11.11
+    scala: 2.11.12
 
   - stage: build
     # Leave 2.12 unprefixed so any additional 2.12 versions get included automatically
     env: CI_SCRIPT="ci/build.sc artifacts 2.12"
     jdk: oraclejdk8
-    scala: 2.11.11
+    scala: 2.11.12
 
 
 
@@ -58,17 +58,17 @@ matrix:
   - stage: release
     env: CI_SCRIPT="ci/build.sc sonatypeReleaseAll"
     jdk: oraclejdk8
-    scala: 2.11.11
+    scala: 2.11.12
 
   - stage: release
     env: CI_SCRIPT="ci/build.sc docs"
     jdk: oraclejdk8
-    scala: 2.11.11
+    scala: 2.11.12
 
   - stage: release
     env: CI_SCRIPT="ci/build.sc executable"
     jdk: oraclejdk8
-    scala: 2.11.11
+    scala: 2.11.12
 
 script:
 - unset _JAVA_OPTIONS

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,20 +13,20 @@ install:
   - cmd: SET SBT_OPTS=-XX:MaxPermSize=2g -Xmx4g
 
 build_script:
-  - sbt ++2.11.11 ops/compile
-  - sbt ++2.11.11 amm/compile
-  - sbt ++2.11.11 integration/compile
+  - sbt ++2.11.12 ops/compile
+  - sbt ++2.11.12 amm/compile
+  - sbt ++2.11.12 integration/compile
 
 test_script:
-  - sbt ++2.11.11 ops/test
-  - sbt ++2.11.11 amm/test
-  - sbt ++2.11.11 integration/test
+  - sbt ++2.11.12 ops/test
+  - sbt ++2.11.12 amm/test
+  - sbt ++2.11.12 integration/test
 
 cache:
   - C:\sbt\
   - '%USERPROFILE%\.ivy2\cache'
   - '%USERPROFILE%\.m2'
-  - '%USERPROFILE%\.sbt'    
+  - '%USERPROFILE%\.sbt'
   - '%LOCALAPPDATA%\Coursier\cache'
   - C:\ProgramData\chocolatey\lib -> appveyor.yml
   - C:\ProgramData\chocolatey\bin -> appveyor.yml

--- a/ci/build.sc
+++ b/ci/build.sc
@@ -15,11 +15,11 @@ val commitsSinceTaggedVersion = {
 }
 
 val allVersions = Seq(
-  "2.11.3", "2.11.4", "2.11.5", "2.11.6", "2.11.7", "2.11.8", "2.11.11",
+  "2.11.3", "2.11.4", "2.11.5", "2.11.6", "2.11.7", "2.11.8", "2.11.12",
   "2.12.0", "2.12.1", "2.12.2", "2.12.3", "2.12.4"
 )
 
-val latestMajorVersions = Set("2.11.11", "2.12.4")
+val latestMajorVersions = Set("2.11.12", "2.12.4")
 
 val (buildVersion, unstable) = sys.env.get("TRAVIS_TAG") match{
   case Some(v) if v != "" => (v, false)

--- a/readme/Footer.scalatex
+++ b/readme/Footer.scalatex
@@ -515,7 +515,7 @@
       @sect{0.8.3}
         @ul
           @li
-            Cross-publish for Scala 2.12.2, 2.11.12
+            Cross-publish for Scala 2.12.2, 2.11.11
           @li
             Bump version of apache-sshd (@issue(545)), by
             @lnk("emanresusername", "https://github.com/emanresusername")

--- a/readme/Footer.scalatex
+++ b/readme/Footer.scalatex
@@ -145,7 +145,7 @@
     @sect{1.0.1}
       @ul
         @li
-          Ammonite is now cross-published to support Scala 
+          Ammonite is now cross-published to support Scala
           @lnk("2.12.3", "https://github.com/scala/scala/releases/tag/v2.12.3")
         @li
           Ammonite REPL now prints an additional newline after the output of
@@ -515,7 +515,7 @@
       @sect{0.8.3}
         @ul
           @li
-            Cross-publish for Scala 2.12.2, 2.11.11
+            Cross-publish for Scala 2.12.2, 2.11.12
           @li
             Bump version of apache-sshd (@issue(545)), by
             @lnk("emanresusername", "https://github.com/emanresusername")


### PR DESCRIPTION
The latest 2.11.x, 2.11.12, contains a CVE fix for the compilation daemon as well as a number of other bug fixes.

For more info see [the 2.11.12 release notes](https://github.com/scala/scala/releases/tag/v2.11.12).