### PR TITLE
autocomplete: blacklisted anything that comes from Any

### DIFF
--- a/amm/repl/src/main/scala/ammonite/repl/AmmoniteFrontEnd.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/AmmoniteFrontEnd.scala
@@ -65,7 +65,9 @@ case class AmmoniteFrontEnd(extraFilters: Filter = Filter.empty) extends FrontEn
 
         lazy val common = FrontEndUtils.findPrefix(completions, 0)
 
-        val blacklisted = Seq("!=", "==", "asInstanceOf", "equals", "getClass", "hashCode", "isInstanceOf", "toString", "|>")
+        val blacklisted = Seq(
+          "!=", "==", "asInstanceOf", "equals", "getClass", "hashCode", "isInstanceOf", "toString", "|>")
+
         val completions2 = for(comp <- completions.filterNot(blacklisted.contains)) yield {
 
           val (left, right) = comp.splitAt(common.length)

--- a/amm/repl/src/main/scala/ammonite/repl/AmmoniteFrontEnd.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/AmmoniteFrontEnd.scala
@@ -64,7 +64,9 @@ case class AmmoniteFrontEnd(extraFilters: Filter = Filter.empty) extends FrontEn
         }
 
         lazy val common = FrontEndUtils.findPrefix(completions, 0)
-        val completions2 = for(comp <- completions) yield {
+
+        val blacklisted = Seq("!=", "==", "asInstanceOf", "equals", "getClass", "hashCode", "isInstanceOf", "toString", "|>")
+        val completions2 = for(comp <- completions.filterNot(blacklisted.contains)) yield {
 
           val (left, right) = comp.splitAt(common.length)
           (colors.comment()(left) ++ right).render

--- a/amm/repl/src/main/scala/ammonite/repl/AmmoniteFrontEnd.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/AmmoniteFrontEnd.scala
@@ -66,7 +66,16 @@ case class AmmoniteFrontEnd(extraFilters: Filter = Filter.empty) extends FrontEn
         lazy val common = FrontEndUtils.findPrefix(completions, 0)
 
         val blacklisted = Seq(
-          "!=", "==", "asInstanceOf", "equals", "getClass", "hashCode", "isInstanceOf", "toString", "|>")
+          "!=",
+          "==",
+          "asInstanceOf",
+          "equals",
+          "getClass",
+          "hashCode",
+          "isInstanceOf",
+          "toString",
+          "|>"
+        )
 
         val completions2 = for(comp <- completions.filterNot(blacklisted.contains)) yield {
 


### PR DESCRIPTION
We decide to filter out all methods that comes with Any.

There was two options. One to edit Pressy.scala:57:
```scala
      blacklist(s.fullNameAsName('.').decoded) ||
      s.fullNameAsName('.').decode.startsWith("scala.Any.") || //this line
      s.isImplicit ||
```
but then when people'll press tab then it'll never complete into full name (eg ".toString") even if it is the only option.

And changes mede here.
They'll be completed when it is the only option and show also definitions after second `Tab`.