### PR TITLE
Adds preConfigureCompiler to the interpreter

### DIFF
--- a/amm/interp/src/main/scala/ammonite/interp/InterpAPI.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/InterpAPI.scala
@@ -53,6 +53,12 @@ trait InterpAPI {
     * when it ends up being initialized later
     */
   def configureCompiler(c: scala.tools.nsc.Global => Unit): Unit
+
+  /**
+    * Pre-configures the next compiler. Useful for tuning options that are
+    * used during parsing such as -Yrangepos
+    */
+  def preConfigureCompiler(c: scala.tools.nsc.Settings => Unit): Unit
 }
 
 

--- a/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
@@ -640,6 +640,10 @@ class Interpreter(val printer: Printer,
       compilerManager.configureCompiler(callback)
     }
 
+    def preConfigureCompiler(callback: scala.tools.nsc.Settings => Unit) = {
+      compilerManager.preConfigureCompiler(callback)
+    }
+
     val beforeExitHooks = interp.beforeExitHooks
 
     val repositories = interp.repositories
@@ -734,7 +738,7 @@ object Interpreter{
       else index - (newLineLength - 1)
     }
 
-    if (code.startsWith(SheBang)) {  
+    if (code.startsWith(SheBang)) {
       val matcher = SheBangEndPattern matcher code
       val shebangEnd = if (matcher.find) matcher.end else skipMultipleLines()
       val numberOfStrippedLines = newLine.r.findAllMatchIn( code.substring(0, shebangEnd) ).length

--- a/amm/src/test/resources/scriptCompilerSettings/configureCompiler.sc
+++ b/amm/src/test/resources/scriptCompilerSettings/configureCompiler.sc
@@ -1,0 +1,10 @@
+val scalacOptions = List(
+  "-Yrangepos:true"
+)
+interp.configureCompiler(_.settings.processArguments(scalacOptions, true))
+
+// Forcing the re-initialisation of the compiler.
+// compiler.useOffsetPosition should remain true because it's initialised
+// eagerly
+@
+

--- a/amm/src/test/resources/scriptCompilerSettings/preConfigureCompiler.sc
+++ b/amm/src/test/resources/scriptCompilerSettings/preConfigureCompiler.sc
@@ -1,0 +1,10 @@
+val scalacOptions = List(
+  "-Yrangepos:true"
+)
+interp.preConfigureCompiler(_.processArguments(scalacOptions, true))
+
+// Forcing the re-initialisation of the compiler.
+// compiler.useOffsetPosition should now be false because the configuration of
+// the settings will have occurred before the new compiler become instantiated
+@
+

--- a/amm/src/test/scala/ammonite/interp/CompilerSettingsTests.scala
+++ b/amm/src/test/scala/ammonite/interp/CompilerSettingsTests.scala
@@ -1,0 +1,38 @@
+package ammonite.interp
+
+import ammonite.TestUtils._
+import ammonite.ops._
+import ammonite.runtime.Storage
+import ammonite.main.Scripts
+import utest._
+
+object CompilerSettingsTests extends TestSuite {
+  val tests = Tests {
+    println("CompilerSettingsTests")
+
+    val scriptPath = pwd / 'amm / 'src / 'test / 'resources / 'scriptCompilerSettings
+
+    'configureYrangepos {
+      // In this test, the script sets -Yrangepos to true using "configureCompiler",
+      // which is called AFTER the compiler instantiates. As useOffsetPositions
+      // is set eagerly during the compiler instantiation as !Yrangepos, its
+      // value remains "true".
+      val storage = Storage.InMemory()
+      val interp = createTestInterp(storage)
+      Scripts.runScript(pwd, scriptPath / "configureCompiler.sc", interp)
+
+      assert(interp.compilerManager.compiler.compiler.useOffsetPositions)
+    }
+
+    'preConfigureYrangepos {
+      // In this test, the script sets -Yrangepos using "preConfigureCompiler",
+      // which is called BEFORE the compiler instantiates, resulting in
+      // useOffsetPositions initializing as false, as expected
+      val storage = Storage.InMemory()
+      val interp = createTestInterp(storage)
+      Scripts.runScript(pwd, scriptPath / "preConfigureCompiler.sc", interp)
+
+      assert(!interp.compilerManager.compiler.compiler.useOffsetPositions)
+    }
+  }
+}


### PR DESCRIPTION
Adds a preConfigureCompiler method to the InterpAPI, allowing to mutate settings in a way that is applied before the interpreter instantiates its next compiler.