### PR TITLE
Added logic to avoid losing range information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target/
 project/.sbtserver
 tags
 nohup.out
+out

--- a/amm/interp/src/main/scala/ammonite/interp/AmmonitePlugin.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/AmmonitePlugin.scala
@@ -291,6 +291,14 @@ object LineNumberModifier {
 
       override def transform(tree: g.Tree) = {
         val transformedTree = super.transform(tree)
+        // The `start` and `end` values in transparent/range positions are left
+        // untouched, because of some aggressive validation in scalac that checks
+        // that trees are not overlapping, and shifting these values here
+        // violates the invariant (which breaks Ammonite, potentially because
+        // of multi-stage).
+        // Moreover, we rely only on the "point" value (for error reporting).
+        // The ticket https://github.com/scala/scala-dev/issues/390 tracks down
+        // relaxing the aggressive validation.
         val newPos = tree.pos match {
           case s : TransparentPosition if s.start > topWrapperLen =>
               new TransparentPosition(trimmedSource, s.start, s.point - topWrapperLen, s.end)

--- a/amm/interp/src/main/scala/ammonite/interp/AmmonitePlugin.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/AmmonitePlugin.scala
@@ -5,7 +5,7 @@ import ammonite.util.{ImportData, Name, Util}
 import scala.reflect.NameTransformer
 import scala.tools.nsc._
 import scala.tools.nsc.plugins.{Plugin, PluginComponent}
-import scala.reflect.internal.util.{BatchSourceFile, OffsetPosition}
+import scala.reflect.internal.util._
 
 /**
  * Used to capture the names in scope after every execution, reporting them
@@ -284,25 +284,30 @@ object LineNumberModifier {
                        topWrapperLen: => Int) = {
 
     object LineNumberCorrector extends g.Transformer {
+      import scala.reflect.internal.util._
+
+      private val trimmedSource = new BatchSourceFile(g.currentSource.file,
+        g.currentSource.content.drop(topWrapperLen))
+
       override def transform(tree: g.Tree) = {
         val transformedTree = super.transform(tree)
-        tree.pos match {
-          case s: scala.reflect.internal.util.OffsetPosition =>
-            if(s.point > topWrapperLen) {
-              val con = new BatchSourceFile(s.source.file,
-                s.source.content.drop(topWrapperLen))
-              val p = new OffsetPosition(con, s.point - topWrapperLen)
-              transformedTree.pos = p
-            }
-          case _ =>    //for position  = NoPosition
+        val newPos = tree.pos match {
+          case s : TransparentPosition if s.start > topWrapperLen =>
+              new TransparentPosition(trimmedSource, s.start, s.point - topWrapperLen, s.end)
+          case s: RangePosition if s.start > topWrapperLen =>
+              new RangePosition(trimmedSource, s.start, s.point - topWrapperLen, s.end)
+          case s: OffsetPosition if s.start > topWrapperLen =>
+              new OffsetPosition(trimmedSource, s.point - topWrapperLen)
+          case s => s
+
         }
+        transformedTree.pos = newPos
         transformedTree
       }
 
       def apply(unit: g.CompilationUnit) = transform(unit.body)
     }
 
-    val t = LineNumberCorrector(unit)
-    unit.body = t
+    unit.body = LineNumberCorrector(unit)
   }
 }

--- a/amm/src/test/resources/scriptCompilerSettings/yRangepos.sc
+++ b/amm/src/test/resources/scriptCompilerSettings/yRangepos.sc
@@ -1,0 +1,10 @@
+val scalacOptions = List(
+  "-Yrangepos:true"
+)
+interp.preConfigureCompiler(_.processArguments(scalacOptions, true))
+
+@
+
+case class ABC(a : Int, b : String)
+println(ABC(1, "2"))
+

--- a/amm/src/test/resources/scriptCompilerSettings/yRangeposError.sc
+++ b/amm/src/test/resources/scriptCompilerSettings/yRangeposError.sc
@@ -1,0 +1,10 @@
+val scalacOptions = List(
+  "-Yrangepos:true"
+)
+interp.preConfigureCompiler(_.processArguments(scalacOptions, true))
+
+@
+
+case class ABC(a : Int, b : String)
+val a = ABC(1, 1) // compiler error, the test checks the line at which it throws
+

--- a/amm/src/test/scala/ammonite/interp/YRangeposTests.scala
+++ b/amm/src/test/scala/ammonite/interp/YRangeposTests.scala
@@ -1,0 +1,42 @@
+package ammonite.interp
+
+import ammonite.TestUtils._
+import ammonite.ops._
+import ammonite.runtime.Storage
+import ammonite.main._
+import utest._
+
+import scala.tools.nsc.Global
+
+object YRangeposTests extends TestSuite {
+  val tests = Tests {
+    println("YRangeposTests")
+
+    def checkErrorMessage(file: RelPath, expected: String): Unit = {
+      val e = new InProcessMainMethodRunner(file, Nil, Nil)
+
+      assert(e.err.contains(expected))
+    }
+
+    val scriptFolderPath =
+      pwd / 'amm / 'src / 'test / 'resources / 'scriptCompilerSettings
+
+    'Yrangepos {
+      // This tests shows that enabling Yrangepos does not mess with ammonite's
+      // behaviour. The compiler not crashing is the test itself.
+      val storage = Storage.InMemory()
+      val interp = createTestInterp(storage)
+      val res = Scripts.runScript(pwd, scriptFolderPath / "yRangepos.sc", interp)
+      assert(res.isSuccess)
+    }
+
+    'YrangeposError {
+      // This tests shows that enabling Yrangepos does not mess with ammonite's
+      // behaviour, by checking that the line at which the error is found matches
+      // the expected one in the file
+      val expectedErrorMessage = "yRangeposError.sc:9: type mismatch;"
+      checkErrorMessage('scriptCompilerSettings / "yRangeposError.sc",
+        expectedErrorMessage)
+    }
+  }
+}


### PR DESCRIPTION
* Adds logic to shift the point in range positions (it does not shift start / end because of some internal validation that crashes the compilation)
* Shares the source file trimming between nodes for optimisation

Rationale : 

When compiling ammonite script with `YrangePos` enabled, the transformation performed in the AmmonitePlugin was discarding the "range" nature of the position. This allows to conserve range information, which improves interoperability with some compiler plugins. 

