### PR TITLE
Java 9 rt.jar caching redux

### DIFF
--- a/amm/interp/src/main/scala/ammonite/interp/CompilerLifecycleManager.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/CompilerLifecycleManager.scala
@@ -20,7 +20,7 @@ import scala.tools.nsc.Settings
   * compiler objects are initialized, or worry about initializing them more
   * than necessary
   */
-class CompilerLifecycleManager(headFrame: => Frame){
+class CompilerLifecycleManager(storage: Storage, headFrame: => Frame){
 
 
 
@@ -76,7 +76,7 @@ class CompilerLifecycleManager(headFrame: => Frame){
       val settings = Option(compiler).fold(new Settings)(_.compiler.settings.copy)
       onSettingsInit.foreach(_(settings))
       Internal.compiler = Compiler(
-        Classpath.classpath ++ headFrame.classpath,
+        Classpath.classpath(storage) ++ headFrame.classpath,
         dynamicClasspath,
         headFrame.classloader,
         headFrame.pluginClassloader,
@@ -89,7 +89,7 @@ class CompilerLifecycleManager(headFrame: => Frame){
       // Pressy is lazy, so the actual presentation compiler won't get instantiated
       // & initialized until one of the methods on it is actually used
       Internal.pressy = Pressy(
-        Classpath.classpath ++ headFrame.classpath,
+        Classpath.classpath(storage) ++ headFrame.classpath,
         dynamicClasspath,
         headFrame.classloader,
 

--- a/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
@@ -54,7 +54,7 @@ class Interpreter(val printer: Printer,
   def frameImports = headFrame.imports
   def frameUsedEarlierDefinitions = headFrame.usedEarlierDefinitions
 
-  val compilerManager = new CompilerLifecycleManager(headFrame)
+  val compilerManager = new CompilerLifecycleManager(storage, headFrame)
 
   val eval = Evaluator(headFrame)
 

--- a/amm/runtime/src/main/scala/ammonite/runtime/Classpath.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/Classpath.scala
@@ -31,8 +31,8 @@ object Classpath {
     if (cache != null) return cache
     def rtCacheDir(storage: Storage): Option[Path] = storage match {
       case storage: Storage.Folder =>
-        // no need to cache if the storage is in tmpdir because
-        // Export.export creates the rt.jar in tmpdir
+        // no need to cache if the storage is in tmpdir
+        // because it is temporary
         if (storage.dir.toNIO.startsWith(
           java.nio.file.Paths.get(System.getProperty("java.io.tmpdir"))))
           None

--- a/amm/runtime/src/main/scala/ammonite/runtime/Classpath.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/Classpath.scala
@@ -28,7 +28,7 @@ object Classpath {
    */
   def classpath(storage: Storage): Vector[File] = {
     val cache = storage.classpathCache()
-    if (cache != null) return cache
+    if (cache.isDefined) return cache.get
     def rtCacheDir(storage: Storage): Option[Path] = storage match {
       case storage: Storage.Folder =>
         // no need to cache if the storage is in tmpdir
@@ -82,7 +82,7 @@ object Classpath {
       }
     }
     val r = files.toVector.filter(_.exists)
-    storage.classpathCache.update(r)
+    storage.classpathCache.update(Some(r))
     r
   }
 

--- a/amm/runtime/src/main/scala/ammonite/runtime/Classpath.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/Classpath.scala
@@ -3,6 +3,7 @@ package ammonite.runtime
 import java.io.File
 import java.util.zip.ZipFile
 
+import ammonite.ops.Path
 import io.github.retronym.java9rtexport.Export
 
 import scala.util.control.NonFatal
@@ -18,46 +19,72 @@ object Classpath {
        .get("ammonite.trace-classpath")
        .exists(_.toLowerCase == "true")
 
+  def rtJarName = s"rt-${System.getProperty("java.version")}.jar"
+
   /**
    * In memory cache of all the jars used in the compiler. This takes up some
    * memory but is better than reaching all over the filesystem every time we
    * want to do something.
    */
-  var current = Thread.currentThread().getContextClassLoader
-  val files = collection.mutable.Buffer.empty[java.io.File]
-  while(current != null){
-    current match{
-      case t: java.net.URLClassLoader =>
-        files.appendAll(t.getURLs.map(u => new java.io.File(u.toURI)))
-      case _ =>
+  def classpath(storage: Storage): Vector[File] = {
+    val cache = storage.classpathCache()
+    if (cache != null) return cache
+    def rtCacheDir(storage: Storage): Option[Path] = storage match {
+      case storage: Storage.Folder =>
+        // no need to cache if the storage is in tmpdir because
+        // Export.export creates the rt.jar in tmpdir
+        if (storage.dir.toNIO.startsWith(
+          java.nio.file.Paths.get(System.getProperty("java.io.tmpdir"))))
+          None
+        else Some(storage.dir)
+      case _ => None
     }
-    current = current.getParent
-  }
 
-  {
-    val sunBoot = System.getProperty("sun.boot.class.path")
-    if (sunBoot != null) {
-      files.appendAll(
-        sunBoot
-          .split(java.io.File.pathSeparator)
-          .map(new java.io.File(_))
-      )
-    } else {
-      for (p <- System.getProperty("java.class.path")
-        .split(File.pathSeparatorChar) if !p.endsWith("sbt-launch.jar")) {
-        files.append(new File(p))
+    var current = Thread.currentThread().getContextClassLoader
+    val files = collection.mutable.Buffer.empty[java.io.File]
+    while(current != null){
+      current match{
+        case t: java.net.URLClassLoader =>
+          files.appendAll(t.getURLs.map(u => new java.io.File(u.toURI)))
+        case _ =>
       }
-      try {
-        new java.net.URLClassLoader(files.map(_.toURI.toURL).toArray, null)
-          .loadClass("javax.script.ScriptEngineManager")
-      } catch {
-        case _: ClassNotFoundException =>
-          files.append(Export.export())
+      current = current.getParent
+    }
+
+    {
+      val sunBoot = System.getProperty("sun.boot.class.path")
+      if (sunBoot != null) {
+        files.appendAll(
+          sunBoot
+            .split(java.io.File.pathSeparator)
+            .map(new java.io.File(_))
+        )
+      } else {
+        for (p <- System.getProperty("java.class.path")
+          .split(File.pathSeparatorChar) if !p.endsWith("sbt-launch.jar")) {
+          files.append(new File(p))
+        }
+        try {
+          new java.net.URLClassLoader(files.map(_.toURI.toURL).toArray, null)
+            .loadClass("javax.script.ScriptEngineManager")
+        } catch {
+          case _: ClassNotFoundException =>
+            val tmpRt = Export.export()
+            rtCacheDir(storage) match {
+              case Some(path) =>
+                val rt = (path / rtJarName).toIO
+                if (!rt.exists)
+                  java.nio.file.Files.copy(tmpRt.toPath, rt.toPath)
+                files.append(rt)
+              case _ => files.append(tmpRt)
+            }
+        }
       }
     }
+    val r = files.toVector.filter(_.exists)
+    storage.classpathCache.update(r)
+    r
   }
-
-  val classpath = files.toVector.filter(_.exists)
 
   def canBeOpenedAsJar(file: File): Boolean =
     try {

--- a/amm/runtime/src/main/scala/ammonite/runtime/Storage.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/Storage.scala
@@ -22,6 +22,7 @@ trait Storage{
   def loadPredef: Option[(String, Path)]
   val fullHistory: StableRef[History]
   val ivyCache: StableRef[Storage.IvyMap]
+
   def compileCacheSave(path: String, tag: Tag, data: Storage.CompileCache): Unit
   def compileCacheLoad(path: String, tag: Tag): Option[Storage.CompileCache]
   def classFilesListSave(filePathPrefix: RelPath,
@@ -30,6 +31,12 @@ trait Storage{
   def classFilesListLoad(filePathPrefix: RelPath, tag: Tag): Option[ScriptOutput]
   def getSessionId: Long
 
+  // Store classpathCache in-memory regardless of Storage impl
+  private var _classpathCache: Vector[java.io.File] = _
+  val classpathCache = new StableRef[Vector[java.io.File]]{
+    def apply() = _classpathCache
+    def update(value: Vector[java.io.File]): Unit = _classpathCache = value
+  }
 }
 
 object Storage{

--- a/amm/runtime/src/main/scala/ammonite/runtime/Storage.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/Storage.scala
@@ -32,10 +32,10 @@ trait Storage{
   def getSessionId: Long
 
   // Store classpathCache in-memory regardless of Storage impl
-  private var _classpathCache: Vector[java.io.File] = _
-  val classpathCache = new StableRef[Vector[java.io.File]]{
+  private var _classpathCache: Option[Vector[java.io.File]] = None
+  val classpathCache = new StableRef[Option[Vector[java.io.File]]]{
     def apply() = _classpathCache
-    def update(value: Vector[java.io.File]): Unit = _classpathCache = value
+    def update(value: Option[Vector[java.io.File]]): Unit = _classpathCache = value
   }
 }
 


### PR DESCRIPTION
This PR re-introduces Java 9 rt.jar caching from #761 that I removed due to memory leaks in Ammonite tests.

The main difference is that it now avoids caching rt.jar if the storage backend is in a temp directory, which is detected based on `System.getProperty("java.io.tmpdir")`. This temp directory caching avoidance sidesteps the memory leaks in Ammonite tests, which mostly use temp dir storage backend (and some `Storage.InMemory`). The heuristics for avoiding caching in `rtCacheDir ` can be changed in the future to cover more (or different) cases.

This finally fixes #675.