### PR TITLE
Always create Java 9 rt cache dir

### DIFF
--- a/amm/runtime/src/main/scala/ammonite/runtime/Classpath.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/Classpath.scala
@@ -3,7 +3,7 @@ package ammonite.runtime
 import java.io.File
 import java.util.zip.ZipFile
 
-import ammonite.ops.Path
+import ammonite.ops._
 import io.github.retronym.java9rtexport.Export
 
 import scala.util.control.NonFatal
@@ -72,10 +72,12 @@ object Classpath {
             val tmpRt = Export.export()
             rtCacheDir(storage) match {
               case Some(path) =>
-                val rt = (path / rtJarName).toIO
-                if (!rt.exists)
-                  java.nio.file.Files.copy(tmpRt.toPath, rt.toPath)
-                files.append(rt)
+                val rt = path / rtJarName
+                if (!exists(rt)) {
+                  mkdir! path
+                  cp(Path(tmpRt), rt)
+                }
+                files.append(rt.toIO)
               case _ => files.append(tmpRt)
             }
         }


### PR DESCRIPTION
This PR adds creation of Java 9 rt cache dir for robustness.
While Ammonite creates its home directory used for caching rt.jar before `Classpath.classpath` is called, mill, however, does not. It is safer to fix the issue here by removing any assumption on the existence of rt cache directory.