### PR TITLE
Run amm as shell and cmd script

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -152,10 +152,33 @@ lazy val amm = project
 
 
     assemblyOption in assembly := (assemblyOption in assembly).value.copy(
-      prependShellScript = Some(
+      prependShellScript = {
+        def universalScript(shellCommands: Seq[String],
+                            cmdCommands: Seq[String],
+                            shebang: Boolean = true): Seq[String] = {
+          Seq(
+            Seq("#!/usr/bin/env sh")
+              .filter(_ => shebang),
+            Seq(":; alias ::=''"),
+            (shellCommands :+ "exit")
+              .map(line => s":: $line"),
+            "@echo off" +: cmdCommands :+ "exit /B",
+            Seq("\r\n")
+          ).flatten
+        }
+
+        def defaultUniversalScript(javaOpts: Seq[String] = Seq.empty, shebang: Boolean = true): Seq[String] = {
+          val javaOptsString = javaOpts.map(_ + " ").mkString
+          universalScript(
+            shellCommands = Seq(s"exec java -jar $javaOptsString" + """$JAVA_OPTS "$0" "$@""""),
+            cmdCommands = Seq(s"java -jar $javaOptsString" + """%JAVA_OPTS% "%~dpnx0" %*"""),
+            shebang = shebang
+          )
+        }
+
         // G1 Garbage Collector is awesome https://github.com/lihaoyi/Ammonite/issues/216
-        Seq("#!/usr/bin/env sh", """exec java -jar -Xmx500m -XX:+UseG1GC $JAVA_OPTS "$0" "$@"""")
-      )
+        Some(defaultUniversalScript(Seq("-Xmx500m", "-XX:+UseG1GC")))
+      }
     ),
     assemblyJarName in assembly := s"${name.value}-${version.value}-${scalaVersion.value}",
     assembly in Test := {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 
 addSbtPlugin("com.lihaoyi" % "scalatex-sbt-plugin" % "0.3.7")
 


### PR DESCRIPTION
As of v1.1.0 ammonite can run on windows.
This pr adds the ability to run the ammonite shell directly as a cmd script while it remains being a proper shell script.
With the .cmd or .bat extension it can be run by double clicking making it very easy for newcomers to launch the ammonite shell.
Feedback is very welcome :)