### PR TITLE
Updated universal script and removed shebang line by default

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -159,7 +159,8 @@ lazy val amm = project
           Seq(
             Seq("#!/usr/bin/env sh")
               .filter(_ => shebang),
-            Seq(":; alias ::=''"),
+            Seq("shopt -s expand_aliases", "alias ::=''")
+              .map(line => s":; $line"),
             (shellCommands :+ "exit")
               .map(line => s":: $line"),
             "@echo off" +: cmdCommands :+ "exit /B",

--- a/build.sbt
+++ b/build.sbt
@@ -153,28 +153,33 @@ lazy val amm = project
 
     assemblyOption in assembly := (assemblyOption in assembly).value.copy(
       prependShellScript = {
-        def universalScript(shellCommands: Seq[String],
-                            cmdCommands: Seq[String],
-                            shebang: Boolean = true): Seq[String] = {
+        def universalScript(shellCommands: String,
+                            cmdCommands: String,
+                            shebang: Boolean = true): String = {
           Seq(
-            Seq("#!/usr/bin/env sh")
-              .filter(_ => shebang),
-            Seq("shopt -s expand_aliases", "alias ::=''")
-              .map(line => s":; $line"),
-            (shellCommands :+ "exit")
-              .map(line => s":: $line"),
-            "@echo off" +: cmdCommands :+ "exit /B",
-            Seq("\r\n")
-          ).flatten
+            if (shebang) "#!/usr/bin/env sh" else "",
+            "@ 2>/dev/null # 2>nul & echo off & goto BOF\r",
+            ":",
+            shellCommands.replaceAll("\r\n|\n", "\n"),
+            "exit",
+            Seq(
+              "",
+              ":BOF",
+              "@echo off",
+              cmdCommands.replaceAll("\r\n|\n", "\r\n"),
+              "exit /B %errorlevel%",
+              ""
+            ).mkString("\r\n")
+          ).filterNot(_.isEmpty).mkString("\n")
         }
 
         def defaultUniversalScript(javaOpts: Seq[String] = Seq.empty, shebang: Boolean = true): Seq[String] = {
           val javaOptsString = javaOpts.map(_ + " ").mkString
-          universalScript(
-            shellCommands = Seq(s"exec java -jar $javaOptsString" + """$JAVA_OPTS "$0" "$@""""),
-            cmdCommands = Seq(s"java -jar $javaOptsString" + """%JAVA_OPTS% "%~dpnx0" %*"""),
+          Seq(universalScript(
+            shellCommands = s"""exec java -jar $javaOptsString$$JAVA_OPTS "$$0" "$$@"""",
+            cmdCommands = s"""java -jar $javaOptsString%JAVA_OPTS% "%~dpnx0" %*""",
             shebang = shebang
-          )
+          ))
         }
 
         // G1 Garbage Collector is awesome https://github.com/lihaoyi/Ammonite/issues/216

--- a/build.sbt
+++ b/build.sbt
@@ -155,7 +155,7 @@ lazy val amm = project
       prependShellScript = {
         def universalScript(shellCommands: String,
                             cmdCommands: String,
-                            shebang: Boolean = true): String = {
+                            shebang: Boolean = false): String = {
           Seq(
             if (shebang) "#!/usr/bin/env sh" else "",
             "@ 2>/dev/null # 2>nul & echo off & goto BOF\r",
@@ -173,7 +173,7 @@ lazy val amm = project
           ).filterNot(_.isEmpty).mkString("\n")
         }
 
-        def defaultUniversalScript(javaOpts: Seq[String] = Seq.empty, shebang: Boolean = true): Seq[String] = {
+        def defaultUniversalScript(javaOpts: Seq[String] = Seq.empty, shebang: Boolean = false): Seq[String] = {
           val javaOptsString = javaOpts.map(_ + " ").mkString
           Seq(universalScript(
             shellCommands = s"""exec java -jar $javaOptsString$$JAVA_OPTS "$$0" "$$@"""",

--- a/build.sbt
+++ b/build.sbt
@@ -152,10 +152,33 @@ lazy val amm = project
 
 
     assemblyOption in assembly := (assemblyOption in assembly).value.copy(
-      prependShellScript = Some(
+      prependShellScript = {
+        def universalScript(shellCommands: Seq[String],
+                            cmdCommands: Seq[String],
+                            shebang: Boolean = true): Seq[String] = {
+          Seq(
+            Seq("#!/usr/bin/env sh")
+              .filter(_ => shebang),
+            Seq(":; alias ::=''"),
+            (shellCommands :+ "exit")
+              .map(line => s":: $line"),
+            "@echo off" +: cmdCommands :+ "exit /B",
+            Seq("\r\n")
+          ).flatten
+        }
+
+        def defaultUniversalScript(javaOpts: Seq[String] = Seq.empty, shebang: Boolean = true): Seq[String] = {
+          val javaOptsString = javaOpts.map(_ + " ").mkString
+          universalScript(
+            shellCommands = Seq(s"exec java -jar $javaOptsString" + """$JAVA_OPTS "$0" "$@""""),
+            cmdCommands = Seq(s"java -jar $javaOptsString" + """%JAVA_OPTS% "%~dpnx0" %*"""),
+            shebang = shebang
+          )
+        }
+
         // G1 Garbage Collector is awesome https://github.com/lihaoyi/Ammonite/issues/216
-        Seq("#!/usr/bin/env sh", """exec java -jar -Xmx500m -XX:+UseG1GC $JAVA_OPTS "$0" "$@"""")
-      )
+        Some(defaultUniversalScript(Seq("-Xmx500m", "-XX:+UseG1GC")))
+      }
     ),
     assemblyJarName in assembly := s"${name.value}-${version.value}-${scalaVersion.value}",
     assembly in Test := {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 
 addSbtPlugin("com.lihaoyi" % "scalatex-sbt-plugin" % "0.3.7")
 

--- a/readme/Footer.scalatex
+++ b/readme/Footer.scalatex
@@ -1434,6 +1434,12 @@
       @readme.Sample.unstableCurl
 
     @p
+      The latest build can also be run on windows. Just save it as amm.bat:
+
+    @p
+      @lnk(ammonite.Constants.unstableCurlUrl)
+
+    @p
       Or usage in an SBT project
 
     @hl.scala

--- a/readme/Sample.scala
+++ b/readme/Sample.scala
@@ -17,8 +17,10 @@ object Sample{
     s"$$ sudo curl -L -o /usr/local/bin/amm " +
     curlUrl +
     " && sudo chmod +x /usr/local/bin/amm && amm"
+  def unstableCurlCommand(curlUrl: String) =
+    s"""$$ sudo sh -c '(echo "#!/usr/bin/env sh" && curl -L $curlUrl) > /usr/local/bin/amm && chmod +x /usr/local/bin/amm' && amm"""
   val replCurl = curlCommand(ammonite.Constants.curlUrl)
-  val unstableCurl = curlCommand(ammonite.Constants.unstableCurlUrl)
+  val unstableCurl = unstableCurlCommand(ammonite.Constants.unstableCurlUrl)
   val filesystemCurl =
     "$ mkdir -p ~/.ammonite && curl -L -o ~/.ammonite/predef.sc https://git.io/vHaKQ"
   val cacheVersion = 6

--- a/readme/Sample.scala
+++ b/readme/Sample.scala
@@ -18,7 +18,9 @@ object Sample{
     curlUrl +
     " && sudo chmod +x /usr/local/bin/amm && amm"
   def unstableCurlCommand(curlUrl: String) =
-    s"""$$ sudo sh -c '(echo "#!/usr/bin/env sh" && curl -L $curlUrl) > /usr/local/bin/amm && chmod +x /usr/local/bin/amm' && amm"""
+    s"""$$ sudo sh -c '(echo "#!/usr/bin/env sh" && curl -L """ +
+    curlUrl +
+    ") > /usr/local/bin/amm && chmod +x /usr/local/bin/amm' && amm"
   val replCurl = curlCommand(ammonite.Constants.curlUrl)
   val unstableCurl = unstableCurlCommand(ammonite.Constants.unstableCurlUrl)
   val filesystemCurl =


### PR DESCRIPTION
This pr changes updates the generated universal script to be on par with lihaoyi/mill#264.
Also the shebang line isn't generated anymore by default so that it doesn't show an error on windows anymore.
The linux download instructions should be updated to add this line afterwards.