### PR TITLE
Try not to load duplicated JARs if possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ script:
 - export PATH=~/bin/amm:~/bin/mill:$PATH
 - mkdir -p ~/bin
 # We use 2.11 since we need to run tests on Java 7
-- if [ ! -f ~/bin/mill ]; then sudo sh -c '(echo "#!/usr/bin/env sh" && curl -L https://github.com/lihaoyi/mill/releases/download/0.2.3/0.2.3) > ~/bin/mill && chmod +x ~/bin/mill'; fi
+- if [ ! -f ~/bin/mill-0.2.3 ]; then sudo sh -c '(echo "#!/usr/bin/env sh" && curl -L https://github.com/lihaoyi/mill/releases/download/0.2.3/0.2.3) > ~/bin/mill-0.2.3 && chmod +x ~/bin/mill-0.2.3 && ( cd ~/bin && rm -f mill && ln -s mill-0.2.3 mill)'; fi
 - JAVAOPTS="-Xmx2048m" $CI_SCRIPT
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ script:
 - export PATH=~/bin/amm:~/bin/mill:$PATH
 - mkdir -p ~/bin
 # We use 2.11 since we need to run tests on Java 7
-- if [ ! -f ~/bin/mill ]; then sudo sh -c '(echo "#!/usr/bin/env sh" && curl -L https://github.com/lihaoyi/mill/releases/download/0.2.0/0.2.0-32-14d002) > ~/bin/mill && chmod +x ~/bin/mill'; fi
+- if [ ! -f ~/bin/mill ]; then sudo sh -c '(echo "#!/usr/bin/env sh" && curl -L https://github.com/lihaoyi/mill/releases/download/0.2.3/0.2.3) > ~/bin/mill && chmod +x ~/bin/mill'; fi
 - JAVAOPTS="-Xmx2048m" $CI_SCRIPT
 
 notifications:

--- a/amm/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -23,7 +23,8 @@ class Repl(input: InputStream,
            initialColors: Colors = Colors.Default,
            remoteLogger: Option[RemoteLogger],
            replCodeWrapper: Preprocessor.CodeWrapper,
-           scriptCodeWrapper: Preprocessor.CodeWrapper) { repl =>
+           scriptCodeWrapper: Preprocessor.CodeWrapper,
+           alreadyLoadedDependencies: Seq[coursier.Dependency]) { repl =>
 
   val prompt = Ref("@ ")
 
@@ -114,7 +115,8 @@ class Repl(input: InputStream,
     getFrame = () => frames().head,
     createFrame = () => { val f = sess0.childFrame(frames().head); frames() = f :: frames(); f },
     replCodeWrapper = replCodeWrapper,
-    scriptCodeWrapper = scriptCodeWrapper
+    scriptCodeWrapper = scriptCodeWrapper,
+    alreadyLoadedDependencies = alreadyLoadedDependencies
   )
 
   def initializePredef() = interp.initializePredef()

--- a/amm/repl/src/test/scala/ammonite/TestRepl.scala
+++ b/amm/repl/src/test/scala/ammonite/TestRepl.scala
@@ -3,6 +3,7 @@ package ammonite
 import java.io.PrintStream
 
 import ammonite.interp.{Interpreter, Preprocessor}
+import ammonite.main.Defaults
 import ammonite.ops.{Path, read}
 import ammonite.repl._
 import ammonite.runtime.{Frame, History, Storage}
@@ -109,7 +110,8 @@ class TestRepl {
       getFrame = () => frames().head,
       createFrame = () => { val f = sess0.childFrame(frames().head); frames() = f :: frames(); f },
       replCodeWrapper = codeWrapper,
-      scriptCodeWrapper = codeWrapper
+      scriptCodeWrapper = codeWrapper,
+      alreadyLoadedDependencies = Defaults.alreadyLoadedDependencies("amm-test-dependencies.txt")
     )
 
   }catch{ case e: Throwable =>

--- a/amm/repl/src/test/scala/ammonite/TestUtils.scala
+++ b/amm/repl/src/test/scala/ammonite/TestUtils.scala
@@ -3,6 +3,7 @@ package ammonite
 import java.io.PrintStream
 
 import ammonite.interp.{Interpreter, Preprocessor}
+import ammonite.main.Defaults
 import ammonite.runtime.{Frame, History, Storage}
 import ammonite.util._
 
@@ -31,7 +32,8 @@ object TestUtils {
       getFrame = () => startFrame,
       createFrame = () => throw new Exception("unsupported"),
       replCodeWrapper = Preprocessor.CodeWrapper,
-      scriptCodeWrapper = Preprocessor.CodeWrapper
+      scriptCodeWrapper = Preprocessor.CodeWrapper,
+      alreadyLoadedDependencies = Defaults.alreadyLoadedDependencies("amm-test-dependencies.txt")
     )
     interp.initializePredef()
     interp

--- a/amm/repl/src/test/scala/ammonite/session/FailureTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/FailureTests.scala
@@ -45,7 +45,7 @@ object FailureTests extends TestSuite{
     }
     'ivyFail{
       check.session("""
-        @ import $ivy.`com.lihaoyi::upickle:0.1.12312-DOESNT-EXIST`
+        @ import $ivy.`com.lihaoyi::upickle-doest-exist:0.1.0`
         error: Failed to resolve ivy dependencies
       """)
     }

--- a/amm/repl/src/test/scala/ammonite/session/ProjectTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/ProjectTests.scala
@@ -306,6 +306,40 @@ object ProjectTests extends TestSuite{
       )
     }
 
+    "no duplicate Ammonite JARs" - {
+      check.session(
+        """
+        @ def scalaLibJarCount() = {
+        @   import scala.collection.JavaConverters._
+        @   Thread.currentThread
+        @     .getContextClassLoader
+        @     .getResources("library.properties")
+        @     .asScala
+        @     .length
+        @ }
+        defined function scalaLibJarCount
+
+        @ val initCount = scalaLibJarCount()
+
+        @ // should only add the shapeless-specific JARs
+
+        @ import $ivy.`com.chuusai::shapeless:2.3.2`
+        import $ivy.$
+
+        @ val addedAfterShapeless = scalaLibJarCount() - initCount
+        addedAfterShapeless: Int = 0
+
+        @ // shouldn't add any JAR (scala-library already pulled by Ammonite)
+
+        @ import $ivy.`org.scala-lang:scala-library:2.11.12`
+        import $ivy.$
+
+        @ val addedAfterScalaLib = scalaLibJarCount() - initCount
+        addedAfterScalaLib: Int = 0
+        """
+      )
+    }
+
   }
 }
 

--- a/amm/src/main/scala/ammonite/Main.scala
+++ b/amm/src/main/scala/ammonite/Main.scala
@@ -67,7 +67,9 @@ case class Main(predefCode: String = "",
                 remoteLogging: Boolean = true,
                 colors: Colors = Colors.Default,
                 replCodeWrapper: Preprocessor.CodeWrapper = Preprocessor.CodeWrapper,
-                scriptCodeWrapper: Preprocessor.CodeWrapper = Preprocessor.CodeWrapper){
+                scriptCodeWrapper: Preprocessor.CodeWrapper = Preprocessor.CodeWrapper,
+                alreadyLoadedDependencies: Seq[coursier.Dependency] =
+                  Defaults.alreadyLoadedDependencies()){
 
   def loadedPredefFile = predefFile match{
     case Some(path) =>
@@ -119,7 +121,8 @@ case class Main(predefCode: String = "",
         remoteLogger = remoteLogger,
         initialColors = colors,
         replCodeWrapper = replCodeWrapper,
-        scriptCodeWrapper = scriptCodeWrapper
+        scriptCodeWrapper = scriptCodeWrapper,
+        alreadyLoadedDependencies = alreadyLoadedDependencies
       )
     }
 
@@ -156,7 +159,8 @@ case class Main(predefCode: String = "",
         () => frame,
         () => throw new Exception("session loading / saving not possible here"),
         replCodeWrapper,
-        scriptCodeWrapper
+        scriptCodeWrapper,
+        alreadyLoadedDependencies = alreadyLoadedDependencies
       )
       interp.initializePredef() match{
         case None => Right(interp)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
     TEST_TASKS: amm[2.11.12].test integration[2.12.6].test
 
 install:
-  - SET MILL_URL=https://github.com/lihaoyi/mill/releases/download/0.2.0/0.2.0-32-14d002
+  - SET MILL_URL=https://github.com/lihaoyi/mill/releases/download/0.2.3/0.2.3
 
 build_script:
   - SET "PATH=%JAVA_HOME%\bin;%PATH%"

--- a/build.sc
+++ b/build.sc
@@ -480,11 +480,13 @@ def publishSonatype(publishArtifacts: mill.main.Tasks[PublishModule.PublishData]
         case PublishModule.PublishData(a, s) => (s.map{case (p, f) => (p.path, f)}, a)
       }
     }
+
     new SonatypePublisher(
       "https://oss.sonatype.org/service/local",
       "https://oss.sonatype.org/content/repositories/snapshots",
       sys.env("SONATYPE_DEPLOY_USER") + ":" + sys.env("SONATYPE_DEPLOY_PASSWORD"),
-      sys.env("SONATYPE_PGP_PASSWORD"),
+      Option(sys.env("SONATYPE_PGP_PASSWORD")),
+      true,
       T.ctx().log
     ).publishAll(
       true,

--- a/build.sc
+++ b/build.sc
@@ -59,6 +59,27 @@ trait AmmModule extends AmmInternalModule with PublishModule{
 
 
 }
+trait AmmDependenciesResourceFileModule extends JavaModule{
+  def crossScalaVersion: String
+  def dependencyResourceFileName: String
+  def resources = T.sources {
+
+    val deps0 = T.task{compileIvyDeps() ++ transitiveIvyDeps()}()
+    val (_, res) = mill.modules.Jvm.resolveDependenciesMetadata(
+      repositories,
+      deps0.map(resolveCoursierDependency().apply(_)),
+      deps0.filter(_.force).map(resolveCoursierDependency().apply(_)),
+      mapDependencies = Some(mapDependencies)
+    )
+
+    super.resources() ++
+    Seq(PathRef(generateDependenciesFile(
+      crossScalaVersion,
+      dependencyResourceFileName,
+      res.minDependencies.toSeq
+    )))
+  }
+}
 
 object ops extends Cross[OpsModule](binCrossScalaVersions:_*)
 class OpsModule(val crossScalaVersion: String) extends AmmModule{
@@ -137,7 +158,9 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
       ivy"com.github.scopt::scopt:3.5.0"
     )
 
-    object test extends Tests{
+    object test extends Tests with AmmDependenciesResourceFileModule{
+      def crossScalaVersion = ReplModule.this.crossScalaVersion
+      def dependencyResourceFileName = "amm-test-dependencies.txt"
       def resources = T.sources {
         super.resources() ++
         ReplModule.this.sources() ++
@@ -146,7 +169,7 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
     }
   }
 }
-class MainModule(val crossScalaVersion: String) extends AmmModule{
+class MainModule(val crossScalaVersion: String) extends AmmModule with AmmDependenciesResourceFileModule{
 
   def artifactName = "ammonite"
 
@@ -186,6 +209,7 @@ class MainModule(val crossScalaVersion: String) extends AmmModule{
     )
   }
 
+  def dependencyResourceFileName = "amm-dependencies.txt"
 
   object test extends Tests{
     def moduleDeps = super.moduleDeps ++ Seq(amm.repl().test)
@@ -288,6 +312,31 @@ def generateConstantsFile(version: String = buildVersion,
 
   write(ctx.dest/"Constants.scala", versionTxt)
   ctx.dest/"Constants.scala"
+}
+
+def generateDependenciesFile(scalaVersion: String,
+                             fileName: String,
+                             deps: Seq[coursier.Dependency])
+                            (implicit ctx: mill.util.Ctx.Dest) = {
+
+  val dir = ctx.dest / "extra-resources"
+  val dest = dir / fileName
+
+  val content = deps
+    .map { dep =>
+      (dep.module.organization, dep.module.name, dep.version)
+    }
+    .sorted
+    .map {
+      case (org, name, ver) =>
+        s"$org:$name:$ver"
+    }
+    .mkString("\n")
+
+  println(s"Writing $dest")
+  write(dest, content.getBytes("UTF-8"))
+
+  dir
 }
 
 


### PR DESCRIPTION
This PR adds a few tricks to try not to load several versions of a given dependency.

It doesn't cover all cases (one can always load newer versions of already loaded stuff), and doesn't try to warn users in case something wrong was prevented (if users add a newer version of something already in Ammonite itself, this PR prevents it to be loaded - silently).

In more details, the first commit tries to prevent loading JARs that are already in Ammonite itself. It generates a resource file (`ammonite-deps.txt`), listing all the dependencies of Ammonite as known from sbt. It then excludes these dependencies from resolutions, so that no newer or older versions of those can be loaded again.

Second commit is just some refactoring for the next one.

Third commit tries not to load JARs for previous versions of already loaded dependencies. It keeps the already loaded dependencies in `Frame`, and adds those to the resolution. That way no old version of an already loaded dependency can end up being loaded when adding new dependencies.