### PR TITLE
use oraclejdk8 instead of oraclejdk7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
 
   - stage: build
     env: CI_SCRIPT="mill -i unitTest"
-    jdk: oraclejdk7
+    jdk: oraclejdk8
     scala: 2.11.12
 
   - stage: build
@@ -25,7 +25,7 @@ matrix:
 
   - stage: build
     env: CI_SCRIPT="mill -i integrationTest"
-    jdk: oraclejdk7
+    jdk: oraclejdk8
     scala: 2.11.12
 
   - stage: build


### PR DESCRIPTION
__oraclejdk7 setting has no meaning!__
travis-ci no longer support oraclejdk7. travis-ci still support openjdk7 but openjdk7 build fail

- https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879
- https://github.com/lihaoyi/Ammonite/issues/774
- https://github.com/lihaoyi/Ammonite/pull/740