### PR TITLE
Upgrade to coursier 1.0.3 to fix maven `{packaging.type}` bug

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -100,8 +100,8 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
   class RuntimeModule(val crossScalaVersion: String) extends AmmModule{
     def moduleDeps = Seq(ops(), amm.util())
     def ivyDeps = Agg(
-      ivy"io.get-coursier::coursier:1.0.0",
-      ivy"io.get-coursier::coursier-cache:1.0.0",
+      ivy"io.get-coursier::coursier:1.0.3",
+      ivy"io.get-coursier::coursier-cache:1.0.3",
       ivy"org.scalaj::scalaj-http:2.3.0"
     )
 


### PR DESCRIPTION
Numerous build systems which rely on ivy for artifact resolution
currently fail to pull artifacts which use the `{packaging.type}`
feature available for use in maven pom files.

Recent builds of coursier do not suffer from this bug. This change
updates the version of coursier from 1.0.0 -> 1.0.3 to pull in the fix 
for this issue.

For reference, some tickets related to the ivy issue:

* https://github.com/sbt/sbt/issues/3618
* https://github.com/gradle/gradle/issues/3065
* https://github.com/jax-rs/api/pull/576