### PR TITLE
Upgrade to coursier 1.0.3 to fix maven `{packaging.type}` bug

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -100,8 +100,8 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
   class RuntimeModule(val crossScalaVersion: String) extends AmmModule{
     def moduleDeps = Seq(ops(), amm.util())
     def ivyDeps = Agg(
-      ivy"io.get-coursier::coursier:1.0.0",
-      ivy"io.get-coursier::coursier-cache:1.0.0",
+      ivy"io.get-coursier::coursier:1.1.0-M4",
+      ivy"io.get-coursier::coursier-cache:1.1.0-M4",
       ivy"org.scalaj::scalaj-http:2.3.0"
     )
 
@@ -143,6 +143,10 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
         ReplModule.this.sources() ++
         ReplModule.this.externalSources()
       }
+
+      def ivyDeps = super.ivyDeps() ++ Agg(
+        ivy"org.scalaz::scalaz-core:7.2.23"
+      )
     }
   }
 }


### PR DESCRIPTION
Numerous build systems which rely on ivy for artifact resolution
currently fail to pull artifacts which use the `{packaging.type}`
feature available for use in maven pom files.

Recent builds of Coursier do not suffer from this bug.

This change updates the version of coursier from 1.0.0 -> 1.1.0-M4 to pull
in the fix for this issue. As part of that change, references to
scalaz were removed from the core but left in some of the testing code.

For reference, some tickets related to the ivy issue:

* https://github.com/sbt/sbt/issues/3618
* https://github.com/gradle/gradle/issues/3065
* https://github.com/jax-rs/api/pull/576