### PR TITLE
Removes dependency on scalaz (#644)

### DIFF
--- a/amm/repl/src/test/scala/ammonite/unit/SourceTests.scala
+++ b/amm/repl/src/test/scala/ammonite/unit/SourceTests.scala
@@ -223,33 +223,6 @@ object SourceTests extends TestSuite{
           "def productIterator"
         )
       }
-      'scalaz{
-
-        'base - check212(load(scalaz.==>>), "Map.scala", "object ==>>")
-        // Some aliases the make our code shorter
-        import scalaz.==>>
-        implicit val scalazOrder: scalaz.Order[Int] = scalaz.Order.fromScalaOrdering(Ordering[Int])
-        implicit val scalazShow: scalaz.Show[Int] = scalaz.Show.show[Int](_.toString)
-        type I = Int
-        'empty     - check212(load(==>>.empty[I, I] _), "Map.scala", "final def empty")
-        'singleton - check212(load(==>>.singleton[I, I] _), "Map.scala", "final def singleton")
-        'unions    - check212(load(==>>.unions[I, I] _), "Map.scala", "final def unions")
-        // inherited
-        'mapShow   - check212(load(==>>.mapShow[I, I]), "Map.scala", "implicit def mapShow")
-        'mapOrder  - check212(load(==>>.mapOrder[I, I]), "Map.scala", "implicit def mapOrder")
-        'mapBifoldable - check212(
-          load(==>>.mapBifoldable),
-          "Map.scala",
-          "implicit val mapBifoldable"
-        )
-
-        val instance = ==>>.empty[I, I]
-        'instance  - check212(load(instance), "Map.scala", "case object Tip")
-        'adjust    - check212(load(instance.adjust _), "Map.scala", "def adjust")
-        'values    - check212(load(instance.values _), "Map.scala", "def values")
-        'mapAccumL - check212(load(instance.mapAccumL _), "Map.scala", "def mapAccumL")
-        'split     - check212(load(instance.split _), "Map.scala", "def split")
-      }
       'fastparse{
         import fastparse.all._
         'all - check212(load(fastparse.all), "StringApi.scala", "object all extends StringApi")

--- a/amm/repl/src/test/scala/ammonite/unit/SourceTests.scala
+++ b/amm/repl/src/test/scala/ammonite/unit/SourceTests.scala
@@ -223,6 +223,33 @@ object SourceTests extends TestSuite{
           "def productIterator"
         )
       }
+      'scalaz{
+
+        'base - check212(load(scalaz.==>>), "Map.scala", "object ==>>")
+        // Some aliases the make our code shorter
+        import scalaz.==>>
+        implicit val scalazOrder: scalaz.Order[Int] = scalaz.Order.fromScalaOrdering(Ordering[Int])
+        implicit val scalazShow: scalaz.Show[Int] = scalaz.Show.show[Int](_.toString)
+        type I = Int
+        'empty     - check212(load(==>>.empty[I, I] _), "Map.scala", "final def empty")
+        'singleton - check212(load(==>>.singleton[I, I] _), "Map.scala", "final def singleton")
+        'unions    - check212(load(==>>.unions[I, I] _), "Map.scala", "final def unions")
+        // inherited
+        'mapShow   - check212(load(==>>.mapShow[I, I]), "Map.scala", "implicit def mapShow")
+        'mapOrder  - check212(load(==>>.mapOrder[I, I]), "Map.scala", "implicit def mapOrder")
+        'mapBifoldable - check212(
+          load(==>>.mapBifoldable),
+          "Map.scala",
+          "implicit val mapBifoldable"
+        )
+
+        val instance = ==>>.empty[I, I]
+        'instance  - check212(load(instance), "Map.scala", "case object Tip")
+        'adjust    - check212(load(instance.adjust _), "Map.scala", "def adjust")
+        'values    - check212(load(instance.values _), "Map.scala", "def values")
+        'mapAccumL - check212(load(instance.mapAccumL _), "Map.scala", "def mapAccumL")
+        'split     - check212(load(instance.split _), "Map.scala", "def split")
+      }
       'fastparse{
         import fastparse.all._
         'all - check212(load(fastparse.all), "StringApi.scala", "object all extends StringApi")

--- a/build.sc
+++ b/build.sc
@@ -143,6 +143,9 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
         ReplModule.this.sources() ++
         ReplModule.this.externalSources()
       }
+      def ivyDeps = super.ivyDeps() ++ Agg(
+        ivy"org.scalaz::scalaz-core:7.2.24"
+      )
     }
   }
 }

--- a/build.sc
+++ b/build.sc
@@ -100,8 +100,8 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
   class RuntimeModule(val crossScalaVersion: String) extends AmmModule{
     def moduleDeps = Seq(ops(), amm.util())
     def ivyDeps = Agg(
-      ivy"io.get-coursier::coursier:1.0.0",
-      ivy"io.get-coursier::coursier-cache:1.0.0",
+      ivy"io.get-coursier::coursier:1.1.0-M4",
+      ivy"io.get-coursier::coursier-cache:1.1.0-M4",
       ivy"org.scalaj::scalaj-http:2.3.0"
     )
 

--- a/build.sc
+++ b/build.sc
@@ -141,7 +141,8 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
       def resources = T.sources {
         super.resources() ++
         ReplModule.this.sources() ++
-        ReplModule.this.externalSources()
+        ReplModule.this.externalSources() ++
+        resolveDeps(ivyDeps, sources = true)()
       }
       def ivyDeps = super.ivyDeps() ++ Agg(
         ivy"org.scalaz::scalaz-core:7.2.24"


### PR DESCRIPTION
Coursier no longer depends on scalaz as of 1.1.0-M4. Removing scalaz
means smaller bundle size and keeping interpreter classpath more
pristine.