### PR TITLE
Fixed launcher so it works with ksh (Linux, Solaris) and cygwin.

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -183,7 +183,7 @@ class MainModule(val crossScalaVersion: String) extends AmmModule{
   def prependShellScript = T{
     mill.modules.Jvm.launcherUniversalScript(
       mainClass().get,
-      Agg("$0"),
+      Agg("""$(type cygpath >/dev/null 2>&1 && cygpath -w "$0" || echo $(cd $(dirname $(which "$0")); pwd)/$(basename $(which "$0")))"""),
       Agg("%~dpnx0"),
       // G1 Garbage Collector is awesome https://github.com/lihaoyi/Ammonite/issues/216
       Seq("-Xmx500m", "-XX:+UseG1GC")

--- a/readme/Footer.scalatex
+++ b/readme/Footer.scalatex
@@ -1445,12 +1445,6 @@
       @readme.Sample.unstableCurl
 
     @p
-      On Cygwin, run the following after the above:
-
-    @hl.sh
-      @readme.Sample.cygwinSed
-
-    @p
       The latest build can also be run as Windows batch; just save the following as amm.bat:
 
     @p

--- a/readme/Sample.scala
+++ b/readme/Sample.scala
@@ -19,7 +19,6 @@ object Sample{
     ") > /usr/local/bin/amm && chmod +x /usr/local/bin/amm' && amm"
   val replCurl = curlCommand(ammonite.Constants.curlUrl)
   val unstableCurl = curlCommand(ammonite.Constants.unstableCurlUrl)
-  val cygwinSed = """$ sed -i '0,/"\$0"/{s/"\$0"/`cygpath -w "\$0"`/}' /usr/local/bin/amm"""
   val filesystemCurl =
     "$ mkdir -p ~/.ammonite && curl -L -o ~/.ammonite/predef.sc https://git.io/vHaKQ"
   val cacheVersion = 6


### PR DESCRIPTION
In the case of korn shell, the path for 'amm' wasn't coming through, and so I added some conditioning to convert the "$0" reference to a full path.  In addition, I added a conditional expression that, if the utility 'cygpath' is available, use it to convert a UNIX path to a Windows path; otherwise, condition the path to an absolute reference.

Since Solaris was one of the possible targets, I could not depend on the existence of the 'readlink' utility.  If I had a couple more lines to write code in, I could have made this a bit less cryptic looking.  Given the constraints, this does the job.

I have tested this with these environments, both with directly specifying the full path and with adding the directory containing amm to the path, without prepending the shebang line ('#!/usr/bin/env sh') to the executable:

Solaris (SunOS) 5.10, sparc:
* /bin/bash, version 3.2.57(1)-release - pass
* /bin/ksh, version M-11/16/88i - pass
* /bin/sh - fail (does not have $() in-line evaluation expression)
* /usr/xpg4/bin/sh - pass

Red Hat Enterprise Linux Server, release 5.5, x86-64
* /bin/bash, version 3.2.25(1)-release - pass
* /bin/csh (tcsh), version 6.14.00 (Astron) 2005-03-25 - pass
* /bin/ksh, version AJM 93t+ 2010-02-02 - pass
* /bin/zsh, version 5.0.0 - pass

Ubuntu 16.04 (Xenial Xerus), x86-64
* /bin/bash, version 4.3.48(1)-release - pass
* /bin/csh, version 20110502-2.1ubuntu - pass
* /bin/ksh (mksh), version MIRBSD KSH R52 2016/04/09 - pass

Ubuntu 18.04 (Bionic Beaver), x86-64
* /bin/bash, version 4.4.19(1)-release - pass
* /bin/ksh (mksh), version AJM 93u+ 2012-08-01 - pass
* /bin/csh, version 20110502-3 - pass

Windows 7, 64-bit
* /bin/bash (Cygwin 64-bit), version 4.4.12(3)-release - pass
* cmd.exe (renamed to amm.bat) - pass