### PR TITLE
Issue 747: Switched to startsWith() method to prevent exception

### DIFF
--- a/amm/src/main/scala/ammonite/main/Router.scala
+++ b/amm/src/main/scala/ammonite/main/Router.scala
@@ -91,7 +91,7 @@ object Router{
 
         group match{
           case (value, None) =>
-            if (value(0) == '-' && !varargs){
+            if (value.startsWith("-") && !varargs){
               lookupArgSig.get(stripDashes(value)) match{
                 case None => leftoverArgs.append(value)
                 case Some(sig) => incomplete = Some(sig)

--- a/amm/src/test/resources/mains/ArgList.sc
+++ b/amm/src/test/resources/mains/ArgList.sc
@@ -1,0 +1,4 @@
+@main
+def main(args: String*): Unit = {
+  args.foreach(arg => println(s"Argument: $arg"))
+}

--- a/amm/src/test/scala/ammonite/main/MainTests.scala
+++ b/amm/src/test/scala/ammonite/main/MainTests.scala
@@ -129,6 +129,10 @@ object MainTests extends TestSuite{
           )
           assert(out.contains(expected.trim))
         }
+        'emptyArg {
+          val evaled = exec("ArgList.sc", "")
+          assert(evaled.success)
+        }
       }
     }
 


### PR DESCRIPTION
The issue, #747, is caused by testing the first character (value(0)) for '-', without checking whether it is empty or not.  This fix replaces that check with '.startsWith("-")', which works with an empty string just fine.  There is a unit test for the fix which, without the fix, reproduces the behavior of the issue.