### PR TITLE
Update scalaj-http

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -102,7 +102,7 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
     def ivyDeps = Agg(
       ivy"io.get-coursier::coursier:1.1.0-M4",
       ivy"io.get-coursier::coursier-cache:1.1.0-M4",
-      ivy"org.scalaj::scalaj-http:2.3.0"
+      ivy"org.scalaj::scalaj-http:2.4.0"
     )
 
     def generatedSources = T{


### PR DESCRIPTION
I was having [binary compatibility problems in github4s using 2.4.0](https://gitter.im/47deg/github4s?at=5b476bc1ba5f154b3b981503), so I would really love it if we could have this merged and maybe released soon. Thanks!