### PR TITLE
Allow to activate / deactivate Maven profiles

### DIFF
--- a/amm/interp/src/main/scala/ammonite/interp/InterpAPI.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/InterpAPI.scala
@@ -35,6 +35,11 @@ trait InterpAPI {
   def repositories: Ref[List[coursier.Repository]]
 
   /**
+    * profiles to use when loading jars
+    */
+  def profiles: Ref[List[String]]
+
+  /**
     * Exit the Ammonite REPL. You can also use Ctrl-D to exit
     */
   def exit = throw AmmoniteExit(())

--- a/amm/repl/src/test/scala/ammonite/session/ProjectTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/ProjectTests.scala
@@ -340,6 +340,55 @@ object ProjectTests extends TestSuite{
       )
     }
 
+    'profiles {
+      val testCore =
+        """
+        @ import $ivy.`org.apache.spark::spark-sql:1.6.2`
+
+        @ import scala.collection.JavaConverters._
+
+        @ val p = new java.util.Properties
+        p: java.util.Properties = {}
+
+        @ p.load(
+        @   Thread.currentThread()
+        @     .getContextClassLoader
+        @     .getResources("common-version-info.properties")
+        @     .asScala
+        @     .toVector
+        @     .find(!_.toString.contains("-sources.jar"))
+        @     .getOrElse(sys.error("common-version-info.properties not found in classpath"))
+        @     .openStream()
+        @ )
+        """
+      'default {
+        // should load hadoop 2.2 stuff by default
+        if (scala2_11)
+          check.session(
+            s"""
+            $testCore
+
+            @ val hadoopVersion = p.getProperty("version")
+            hadoopVersion: String = "2.2.0"
+            """
+          )
+      }
+      'withProfile {
+        // with the right profile, should load hadoop 2.6 stuff
+        if (scala2_11)
+          check.session(
+            s"""
+            @ interp.profiles() = interp.profiles() :+ "hadoop-2.6"
+
+            $testCore
+
+            @ val hadoopVersion = p.getProperty("version")
+            hadoopVersion: String = "2.6.0"
+            """
+          )
+      }
+    }
+
   }
 }
 

--- a/amm/runtime/src/main/scala/ammonite/runtime/Storage.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/Storage.scala
@@ -41,7 +41,7 @@ trait Storage{
 
 object Storage{
   case class CompileCache(classFiles: Vector[(String, Array[Byte])], imports: Imports)
-  type IvyMap = Map[(String, Seq[coursier.Dependency]), Set[String]]
+  type IvyMap = Map[(String, Seq[String], Seq[coursier.Dependency]), Set[String]]
   implicit def depRW: upickle.default.ReadWriter[coursier.Dependency] = upickle.default.macroRW
   implicit def modRW: upickle.default.ReadWriter[coursier.Module] = upickle.default.macroRW
   implicit def attrRW: upickle.default.ReadWriter[coursier.Attributes] = upickle.default.macroRW

--- a/amm/runtime/src/main/scala/ammonite/runtime/tools/IvyThing.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/tools/IvyThing.scala
@@ -23,6 +23,7 @@ trait IvyConstructor{
 object IvyThing{
   def resolveArtifact(repositories: Seq[coursier.Repository],
                       dependencies: Seq[coursier.Dependency],
+                      profiles: Seq[String],
                       verbose: Boolean,
                       output: PrintStream) = synchronized {
     val writer = new PrintWriter(output)
@@ -36,7 +37,14 @@ object IvyThing{
       Some(logger)
     }
 
-    val start = coursier.Resolution(dependencies.toSet)
+    val start = coursier.Resolution(
+      dependencies.toSet,
+      userActivations =
+        if (profiles.isEmpty)
+          None
+        else
+          Some(profiles.map(p => if (p.startsWith("!")) p.drop(1) -> false else p -> true).toMap)
+    )
 
     val fetch = coursier.Fetch.from(repositories, coursier.Cache.fetch[Task](logger = logger))
 


### PR DESCRIPTION
These are useful when loading old spark stuff. E.g. when loading `org.apache.spark:spark-sql:1.6.2`, enabling the `hadoop-2.6` profile like
```scala
@ interp.profiles() = interp.profiles() :+ "hadoop-2.6"

@ import $ivy.`org.apache.spark::spark-sql:1.6.2`
```
 allows hadoop 2.6 stuff to be pulled rather hadoop 2.2 ones.