### PR TITLE
Fix custom bridges handling

### DIFF
--- a/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
@@ -47,6 +47,15 @@ class Interpreter(val printer: Printer,
   def headFrame = getFrame()
   val repositories = Ref(ammonite.runtime.tools.IvyThing.defaultRepositories)
 
+  headFrame.classloader.specialLocalClasses ++= Seq(
+    "ammonite.interp.InterpBridge",
+    "ammonite.interp.InterpBridge$"
+  )
+
+  headFrame.classloader.specialLocalClasses ++= extraBridges
+    .map(_._1)
+    .flatMap(c => Seq(c, c + "$"))
+
   val mainThread = Thread.currentThread()
 
   def evalClassloader = headFrame.classloader

--- a/amm/repl/src/main/scala/ammonite/repl/ApiImpls.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/ApiImpls.scala
@@ -14,11 +14,13 @@ class SessionApiImpl(frames0: => StableRef[List[Frame]]) extends Session{
   def childFrame(parent: Frame) = new Frame(
     new SpecialClassLoader(
       parent.classloader,
-      parent.classloader.classpathSignature
+      parent.classloader.classpathSignature,
+      parent.classloader.specialLocalClasses
     ),
     new SpecialClassLoader(
       parent.pluginClassloader,
-      parent.pluginClassloader.classpathSignature
+      parent.pluginClassloader.classpathSignature,
+      parent.pluginClassloader.specialLocalClasses
     ),
     parent.imports,
     parent.classpath,

--- a/amm/repl/src/test/scala/ammonite/TestRepl.scala
+++ b/amm/repl/src/test/scala/ammonite/TestRepl.scala
@@ -67,45 +67,54 @@ class TestRepl {
         PredefInfo(Name("testPredef"), predef._1, false, predef._2)
       ),
       customPredefs = Seq(),
-      extraBridges = Seq((
-        "ammonite.repl.ReplBridge",
-        "repl",
-        new ReplApiImpl {
-          def replArgs0 = Vector.empty[Bind[_]]
-          def printer = printer0
+      extraBridges = Seq(
+        (
+          "ammonite.TestReplBridge",
+          "test",
+          new TestReplApi {
+            def message = "ba"
+          }
+        ),
+        (
+          "ammonite.repl.ReplBridge",
+          "repl",
+          new ReplApiImpl {
+            def replArgs0 = Vector.empty[Bind[_]]
+            def printer = printer0
 
-          def sess = sess0
-          val prompt = Ref("@")
-          val frontEnd = Ref[FrontEnd](null)
-          def lastException: Throwable = null
-          def fullHistory = storage.fullHistory()
-          def history = new History(Vector())
-          val colors = Ref(Colors.BlackWhite)
-          def newCompiler() = interp.compilerManager.init(force = true)
-          def compiler = interp.compilerManager.compiler.compiler
-          def fullImports = interp.predefImports ++ imports
-          def imports = interp.frameImports
-          def usedEarlierDefinitions = interp.frameUsedEarlierDefinitions
-          def width = 80
-          def height = 80
+            def sess = sess0
+            val prompt = Ref("@")
+            val frontEnd = Ref[FrontEnd](null)
+            def lastException: Throwable = null
+            def fullHistory = storage.fullHistory()
+            def history = new History(Vector())
+            val colors = Ref(Colors.BlackWhite)
+            def newCompiler() = interp.compilerManager.init(force = true)
+            def compiler = interp.compilerManager.compiler.compiler
+            def fullImports = interp.predefImports ++ imports
+            def imports = interp.frameImports
+            def usedEarlierDefinitions = interp.frameUsedEarlierDefinitions
+            def width = 80
+            def height = 80
 
-          object load extends ReplLoad with (String => Unit){
+            object load extends ReplLoad with (String => Unit){
 
-            def apply(line: String) = {
-              interp.processExec(line, currentLine, () => currentLine += 1) match{
-                case Res.Failure(s) => throw new CompilationError(s)
-                case Res.Exception(t, s) => throw t
-                case _ =>
+              def apply(line: String) = {
+                interp.processExec(line, currentLine, () => currentLine += 1) match{
+                  case Res.Failure(s) => throw new CompilationError(s)
+                  case Res.Exception(t, s) => throw t
+                  case _ =>
+                }
+              }
+
+              def exec(file: Path): Unit = {
+                interp.watch(file)
+                apply(normalizeNewlines(read(file)))
               }
             }
-
-            def exec(file: Path): Unit = {
-              interp.watch(file)
-              apply(normalizeNewlines(read(file)))
-            }
           }
-        }
-      )),
+        )
+      ),
       colors = Ref(Colors.BlackWhite),
       getFrame = () => frames().head,
       createFrame = () => { val f = sess0.childFrame(frames().head); frames() = f :: frames(); f },

--- a/amm/repl/src/test/scala/ammonite/TestReplBridge.scala
+++ b/amm/repl/src/test/scala/ammonite/TestReplBridge.scala
@@ -1,0 +1,9 @@
+package ammonite
+
+import ammonite.runtime.APIHolder
+
+trait TestReplApi {
+  def message: String
+}
+
+object TestReplBridge extends APIHolder[TestReplApi]

--- a/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
@@ -383,5 +383,11 @@ object AdvancedTests extends TestSuite{
         res4: Boolean = true
       """)
     }
+    'customBridge{
+      check.session("""
+        @ val s = test.message
+        s: String = "ba"
+      """)
+    }
   }
 }


### PR DESCRIPTION
This PR adds a bridge in `TestRepl`, and ensures it can be used from the user code. For the test to be green, this required to pass the extra bridge class names to `SpecialClassLoader`, so that it can special case them too (like it does for the default Ammonite bridges).