### PR TITLE
Fix jline autocomplete

### DIFF
--- a/amm/repl/src/main/scala/ammonite/repl/FrontEndUtils.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/FrontEndUtils.scala
@@ -6,8 +6,12 @@ import ammonite.util.Util.newLine
  * Created by haoyi on 8/29/15.
  */
 object FrontEndUtils {
-  def width = ammonite.terminal.TTY.consoleDim("cols")
-  def height = ammonite.terminal.TTY.consoleDim("lines")
+  def width = 
+    if (scala.util.Properties.isWin) ammonite.repl.FrontEnd.JLineWindows.width
+    else ammonite.terminal.TTY.consoleDim("cols")
+  def height =
+    if (scala.util.Properties.isWin) ammonite.repl.FrontEnd.JLineWindows.width
+    else ammonite.terminal.TTY.consoleDim("lines")
   def tabulate(snippetsRaw: Seq[fansi.Str], width: Int): Iterator[String] = {
     val gap = 2
     val snippets = if (snippetsRaw.isEmpty) Seq(fansi.Str("")) else snippetsRaw


### PR DESCRIPTION
Fixes #817, #823.  
Cursor now behaves correctly. Please report if there are still issues with it.  
I still couldn't figure out why it doesn't accept a candidate when there are braces at the end (assume `|` is cursor): `x.toSt|()` (but it stays there now.. xD).

When you hit `Enter` now, it will only accept the input when cursor is at the end.

There's also a fix in `FrontEndUtils` for `width` and `height`, I forgot when the exception was happening...