### PR TITLE
Don't add stuff with wrong artifact types to the classpath

### DIFF
--- a/amm/repl/src/test/scala/ammonite/session/ProjectTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/ProjectTests.scala
@@ -394,6 +394,26 @@ object ProjectTests extends TestSuite{
           )
       }
     }
+    'onlyJarLikeArtifactTypes {
+      check.session(
+        """
+           @ import $ivy.`log4j:log4j:1.2.17`
+
+           @ val log4jStuff = {
+           @   repl
+           @     .sess
+           @     .frames
+           @     .flatMap(_.classpath)
+           @     .filter(_.getName.contains("log4j"))
+           @ }
+
+           @ assert(
+           @   // no zip or tar.gz stuff in particular
+           @   log4jStuff.forall(_.getName.endsWith(".jar"))
+           @ )
+           """
+      )
+    }
 
   }
 }


### PR DESCRIPTION
Artifacts returned by coursier have a type attached to them. Only a subset of those
are JARs that are relevant to us here. Without this PR, test jars or zip files could
be unnecessarily added to the classpath.