### PR TITLE
Allow non-files in classpath

### DIFF
--- a/amm/interp/src/main/scala-2.11/ammonite/interp/GlobalInitCompat.scala
+++ b/amm/interp/src/main/scala-2.11/ammonite/interp/GlobalInitCompat.scala
@@ -62,7 +62,11 @@ object GlobalInitCompat {
     val jarCP =
       jarDeps.filter(x => x.getPath.endsWith(".jar") || Classpath.canBeOpenedAsJar(x))
         .map { x =>
-          val arc = new FileZipArchive(java.nio.file.Paths.get(x.toURI).toFile)
+          val arc =
+            if (x.getProtocol == "file")
+              new FileZipArchive(java.nio.file.Paths.get(x.toURI).toFile)
+            else
+              new internal.CustomURLZipArchive(x)
           new DirectoryClassPath(arc, jCtx)
         }
         .toVector

--- a/amm/interp/src/main/scala-2.11/ammonite/interp/GlobalInitCompat.scala
+++ b/amm/interp/src/main/scala-2.11/ammonite/interp/GlobalInitCompat.scala
@@ -53,15 +53,18 @@ object GlobalInitCompat {
     * normal and presentation compiler
     */
   def initGlobalClasspath(dirDeps: Seq[java.io.File],
-                          jarDeps: Seq[java.io.File],
+                          jarDeps: Seq[java.net.URL],
                           dynamicClasspath: VirtualDirectory,
                           settings: Settings) = {
 
     val jCtx = new JavaContext()
 
     val jarCP =
-      jarDeps.filter(x => x.getName.endsWith(".jar") || Classpath.canBeOpenedAsJar(x))
-        .map(x => new DirectoryClassPath(new FileZipArchive(x), jCtx))
+      jarDeps.filter(x => x.getPath.endsWith(".jar") || Classpath.canBeOpenedAsJar(x))
+        .map { x =>
+          val arc = new FileZipArchive(java.nio.file.Paths.get(x.toURI).toFile)
+          new DirectoryClassPath(arc, jCtx)
+        }
         .toVector
 
     val dirCP =

--- a/amm/interp/src/main/scala-2.12/ammonite/interp/GlobalInitCompat.scala
+++ b/amm/interp/src/main/scala-2.12/ammonite/interp/GlobalInitCompat.scala
@@ -57,13 +57,16 @@ object GlobalInitCompat{
     * normal and presentation compiler
     */
   def initGlobalClasspath(dirDeps: Seq[java.io.File],
-                          jarDeps: Seq[java.io.File],
+                          jarDeps: Seq[java.net.URL],
                           dynamicClasspath: VirtualDirectory,
                           settings: Settings) = {
 
     val jarCP =
-      jarDeps.filter(x => x.getName.endsWith(".jar") || Classpath.canBeOpenedAsJar(x))
-        .map(x => ZipAndJarClassPathFactory.create(new FileZipArchive(x), settings))
+      jarDeps.filter(x => x.getPath.endsWith(".jar") || Classpath.canBeOpenedAsJar(x))
+        .map { x =>
+          val arc = new FileZipArchive(java.nio.file.Paths.get(x.toURI).toFile)
+          ZipAndJarClassPathFactory.create(arc, settings)
+        }
         .toVector
 
     val dirCP = dirDeps.map(x => new DirectoryClassPath(x))

--- a/amm/interp/src/main/scala-2.12/scala/tools/nsc/CustomZipAndJarFileLookupFactory.scala
+++ b/amm/interp/src/main/scala-2.12/scala/tools/nsc/CustomZipAndJarFileLookupFactory.scala
@@ -1,0 +1,118 @@
+package scala.tools.nsc
+
+import java.io.File
+
+import scala.reflect.io.{AbstractFile, FileZipArchive}
+import scala.tools.nsc.classpath.{ClassPathEntries, _}
+import scala.tools.nsc.util.{ClassPath, ClassRepresentation}
+import java.io.File
+import java.net.URL
+
+import ammonite.interp.internal.CustomURLZipArchive
+
+import scala.collection.Seq
+import scala.reflect.io.AbstractFile
+import scala.reflect.io.FileZipArchive
+import FileUtils.AbstractFileOps
+import scala.tools.nsc.util.{ClassPath, ClassRepresentation}
+
+// Originally based on
+// https://github.com/scala/scala/blob/329deac9ab4f39e5e766ec3ab3f3f4cddbc44aa1
+// /src/compiler/scala/tools/nsc/classpath/ZipAndJarFileLookupFactory.scala#L50-L166,
+// then adapted to rely on ammonite.interp.internal.CustomURLZipArchive (accepting URLs)
+// rather than FileZipArchive (only accepting files).
+
+object CustomZipAndJarFileLookupFactory {
+
+  private final class ZipArchiveClassPath(val zipUrl: URL) extends ClassPath with NoSourcePaths {
+
+    def zipFile: File = null
+
+    override def asURLs: Seq[URL] = Seq(zipUrl)
+    override def asClassPathStrings: Seq[String] = Seq(zipUrl.toURI.toASCIIString) // ???
+
+    private val archive = new CustomURLZipArchive(zipUrl)
+
+    override private[nsc] def packages(inPackage: String): Seq[PackageEntry] = {
+      val prefix = PackageNameUtils.packagePrefix(inPackage)
+      for {
+        dirEntry <- findDirEntry(inPackage).toSeq
+        entry <- dirEntry.iterator if entry.isPackage
+      } yield PackageEntryImpl(prefix + entry.name)
+    }
+
+    protected def files(inPackage: String): Seq[ClassFileEntryImpl] =
+      for {
+        dirEntry <- findDirEntry(inPackage).toSeq
+        entry <- dirEntry.iterator if isRequiredFileType(entry)
+      } yield createFileEntry(entry)
+
+    protected def file(inPackage: String, name: String): Option[ClassFileEntryImpl] =
+      for {
+        dirEntry <- findDirEntry(inPackage)
+        entry <- Option(dirEntry.lookupName(name, directory = false))
+        if isRequiredFileType(entry)
+      } yield createFileEntry(entry)
+
+    override private[nsc] def hasPackage(pkg: String) = findDirEntry(pkg).isDefined
+    override private[nsc] def list(inPackage: String): ClassPathEntries = {
+      val foundDirEntry = findDirEntry(inPackage)
+
+      foundDirEntry map { dirEntry =>
+        val pkgBuf = collection.mutable.ArrayBuffer.empty[PackageEntry]
+        val fileBuf = collection.mutable.ArrayBuffer.empty[ClassFileEntryImpl]
+        val prefix = PackageNameUtils.packagePrefix(inPackage)
+
+        for (entry <- dirEntry.iterator) {
+          if (entry.isPackage)
+            pkgBuf += PackageEntryImpl(prefix + entry.name)
+          else if (isRequiredFileType(entry))
+            fileBuf += createFileEntry(entry)
+        }
+        ClassPathEntries(pkgBuf, fileBuf)
+      } getOrElse ClassPathEntries.empty
+    }
+
+    private def findDirEntry(pkg: String): Option[archive.DirEntry] =
+      archive.allDirsByDottedName.get(pkg)
+
+    override def findClassFile(className: String): Option[AbstractFile] = {
+      val (pkg, simpleClassName) = PackageNameUtils.separatePkgAndClassNames(className)
+      file(pkg, simpleClassName + ".class").map(_.file)
+    }
+    // This method is performance sensitive as it is used by SBT's ExtractDependencies phase.
+    override def findClass(className: String): Option[ClassRepresentation] = {
+      val (pkg, simpleClassName) = PackageNameUtils.separatePkgAndClassNames(className)
+      file(pkg, simpleClassName + ".class")
+    }
+
+    override private[nsc] def classes(inPackage: String): Seq[ClassFileEntry] =
+      files(inPackage)
+
+    protected def createFileEntry(file: CustomURLZipArchive#Entry): ClassFileEntryImpl =
+      ClassFileEntryImpl(file)
+    protected def isRequiredFileType(file: AbstractFile): Boolean =
+      !file.isDirectory && file.hasExtension("class")
+  }
+
+
+  private val cache = new FileBasedCache[ClassPath]
+
+  def create(zipFile: AbstractFile, settings: Settings): ClassPath = {
+    if (settings.YdisableFlatCpCaching || zipFile.file == null)
+      createForZipFile(zipFile, settings.releaseValue)
+    else
+      createUsingCache(zipFile, settings)
+  }
+
+  def createForZipFile(zipFile: AbstractFile, release: Option[String]): ClassPath = {
+    new ZipArchiveClassPath(zipFile.toURL)
+  }
+
+  private def createUsingCache(zipFile: AbstractFile, settings: Settings): ClassPath = {
+    cache.getOrCreate(
+      List(zipFile.file.toPath),
+      () => createForZipFile(zipFile, settings.releaseValue)
+    )
+  }
+}

--- a/amm/interp/src/main/scala/ammonite/interp/InterpAPI.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/InterpAPI.scala
@@ -75,6 +75,10 @@ trait LoadJar {
    */
   def cp(jar: os.Path): Unit
   /**
+    * Load a `.jar` from a URL into your JVM classpath
+    */
+  def cp(jar: java.net.URL): Unit
+  /**
    * Load one or more `.jar` files or directories into your JVM classpath
    */
   def cp(jars: Seq[os.Path]): Unit

--- a/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
@@ -640,6 +640,9 @@ class Interpreter(val printer: Printer,
     def cp(jars: Seq[os.Path]): Unit = {
       jars.map(_.toNIO.toUri.toURL).foreach(handleClasspath)
     }
+    def cp(jar: java.net.URL): Unit = {
+      handleClasspath(jar)
+    }
     def ivy(coordinates: coursier.Dependency*): Unit = {
       loadIvy(coordinates:_*) match{
         case Left(failureMsg) =>

--- a/amm/interp/src/main/scala/ammonite/interp/internal/CustomURLZipArchive.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/internal/CustomURLZipArchive.scala
@@ -1,0 +1,171 @@
+package ammonite.interp.internal
+
+import java.io.ByteArrayInputStream
+import java.util.zip.{ZipEntry, ZipFile, ZipInputStream}
+
+import scala.reflect.io.{AbstractFile, Streamable, VirtualFile}
+
+// Adapted from scala.reflect.io.URLZipArchive.
+// The only relevant change here is that it doesn't rely on
+// java.util.zip.ZipEntry.getSize to get the actual size of
+// a zip entry, as it is usually -1 (size unknown).
+// Plus allDirsByDottedName was added for scala 2.12, and dirs is memo-ized via a lazy val.
+final class CustomURLZipArchive(val url: java.net.URL) extends AbstractFile with Equals { self =>
+
+  override def toURL = url
+
+  def file: java.io.File = null
+
+  private def dirPath(path: String)  = path.split('/').toSeq.filter(_.nonEmpty)
+  private def dirName(path: String)  = splitPath(path, front = true)
+  private def baseName(path: String) = splitPath(path, front = false)
+  private def splitPath(path0: String, front: Boolean): String = {
+    val isDir = path0.charAt(path0.length - 1) == '/'
+    val path  = if (isDir) path0.substring(0, path0.length - 1) else path0
+    val idx   = path.lastIndexOf('/')
+
+    if (idx < 0)
+      if (front) "/"
+      else path
+    else
+    if (front) path.substring(0, idx + 1)
+    else path.substring(idx + 1)
+  }
+  override def underlyingSource = Some(this)
+  def isDirectory = true
+  def lookupName(name: String, directory: Boolean) = unsupported()
+  def lookupNameUnchecked(name: String, directory: Boolean) = unsupported()
+  def create()  = unsupported()
+  def delete()  = unsupported()
+  def output    = unsupported()
+  def container = unsupported()
+  def absolute  = unsupported()
+
+  abstract class Entry(path: String) extends VirtualFile(baseName(path), path) {
+    // have to keep this name for compat with sbt's compiler-interface
+    def getArchive: ZipFile = null
+    override def underlyingSource = Some(self)
+    override def toString = self.path + "(" + path + ")"
+  }
+
+  final class DirEntry(path: String) extends Entry(path) {
+    val entries = collection.mutable.HashMap[String, Entry]()
+
+    override def isDirectory = true
+    override def iterator: Iterator[Entry] = entries.valuesIterator
+    override def lookupName(name: String, directory: Boolean): Entry = {
+      if (directory) entries(name + "/")
+      else entries(name)
+    }
+  }
+
+  private object Entry {
+
+    final class EmptyFile(name: String) extends Entry(name) {
+      override def toByteArray: Array[Byte] = null
+      override def sizeOption = Some(0)
+    }
+
+    final class File(name: String, content: Array[Byte]) extends Entry(name) {
+      override val toByteArray: Array[Byte] = content
+      override def sizeOption = Some(toByteArray.length)
+    }
+  }
+
+  private def ensureDir(
+    dirs: collection.mutable.Map[Seq[String], DirEntry],
+    path: String,
+    zipEntry: ZipEntry
+  ): DirEntry =
+    dirs.get(dirPath(path)) match {
+      case Some(v) => v
+      case None =>
+        val parent = ensureDir(dirs, dirName(path), null)
+        val dir    = new DirEntry(path)
+        parent.entries(baseName(path)) = dir
+        dirs(dirPath(path)) = dir
+        dir
+    }
+
+  private def getDir(
+    dirs: collection.mutable.Map[Seq[String], DirEntry],
+    entry: ZipEntry
+  ): DirEntry = {
+    if (entry.isDirectory) ensureDir(dirs, entry.getName, entry)
+    else ensureDir(dirs, dirName(entry.getName), null)
+  }
+
+
+  private lazy val dirs: Map[Seq[String], DirEntry] = {
+    val root     = new DirEntry("/")
+    val dirs     = collection.mutable.HashMap[Seq[String], DirEntry](Nil -> root)
+    val in       = new ZipInputStream(new ByteArrayInputStream(Streamable.bytes(input)))
+
+    @annotation.tailrec def loop() {
+      val zipEntry = in.getNextEntry
+
+      if (zipEntry != null) {
+        val dir = getDir(dirs, zipEntry)
+        if (!zipEntry.isDirectory) {
+          val f =
+            if (zipEntry.getSize == 0)
+              new Entry.EmptyFile(zipEntry.getName)
+            else {
+              val content = {
+                val baos = new java.io.ByteArrayOutputStream
+                val b = Array.ofDim[Byte](16*1024)
+
+                def loop() {
+                  val read = in.read(b, 0, b.length)
+                  if (read >= 0) {
+                    baos.write(b, 0, read)
+                    loop()
+                  }
+                }
+                loop()
+
+                baos.toByteArray
+              }
+              new Entry.File(zipEntry.getName, content)
+            }
+          dir.entries(f.name) = f
+        }
+        in.closeEntry()
+        loop()
+      }
+    }
+
+    loop()
+    dirs.toMap
+  }
+
+  def iterator: Iterator[AbstractFile] =
+    dirs(Nil).iterator
+
+  def name  = url.getFile
+  def path  = url.getPath
+  def input = url.openStream()
+  def lastModified =
+    try url.openConnection().getLastModified
+    catch { case _: java.io.IOException => 0 }
+
+  override def canEqual(other: Any) = other.isInstanceOf[CustomURLZipArchive]
+  override def hashCode() = url.hashCode
+  override def equals(that: Any) = that match {
+    case x: CustomURLZipArchive=> url == x.url
+    case _                => false
+  }
+
+
+  def allDirsByDottedName: collection.Map[String, DirEntry] = {
+    dirs.map {
+      case (k, v) =>
+        k.mkString(".") -> v
+    }
+  }
+
+}
+
+object CustomURLZipArchive{
+  def closeZipFile = false
+}

--- a/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
@@ -443,5 +443,19 @@ object AdvancedTests extends TestSuite{
         """)
       }
     }
+
+    'loadURL - {
+      val sbv = scala.util.Properties.versionNumberString.split('.').take(2).mkString(".")
+      val url = "https://repo1.maven.org/maven2/" +
+        s"io/argonaut/argonaut_$sbv/6.2.2/argonaut_$sbv-6.2.2.jar"
+      check.session(s"""
+        @ interp.load.cp(new java.net.URL("$url"))
+
+        @ import argonaut._, Argonaut._
+
+        @ val json = Json.obj("a" -> Json.jBool(false)).nospaces
+        json: String = "{\\"a\\":false}"
+      """)
+    }
   }
 }

--- a/amm/repl/src/test/scala/ammonite/session/ProjectTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/ProjectTests.scala
@@ -400,12 +400,12 @@ object ProjectTests extends TestSuite{
            @     .sess
            @     .frames
            @     .flatMap(_.classpath)
-           @     .filter(_.getName.contains("log4j"))
+           @     .filter(_.getPath.split('/').last.contains("log4j"))
            @ }
 
            @ assert(
            @   // no zip or tar.gz stuff in particular
-           @   log4jStuff.forall(_.getName.endsWith(".jar"))
+           @   log4jStuff.forall(_.getPath.split('/').last.endsWith(".jar"))
            @ )
            """
       )

--- a/amm/runtime/src/main/scala/ammonite/runtime/ClassLoaders.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/ClassLoaders.scala
@@ -24,7 +24,7 @@ import scala.collection.mutable
 class Frame(val classloader: SpecialClassLoader,
             val pluginClassloader: SpecialClassLoader,
             private[this] var imports0: Imports,
-            private[this] var classpath0: Seq[java.io.File],
+            private[this] var classpath0: Seq[java.net.URL],
             private[this] var usedEarlierDefinitions0: Seq[String]){
   private var frozen0 = false
   def frozen = frozen0
@@ -39,23 +39,23 @@ class Frame(val classloader: SpecialClassLoader,
   private[this] var version0: Int = 0
   def version = version0
   def imports = imports0
-  def classpath = classpath0
+  def classpath: Seq[java.net.URL] = classpath0
   def usedEarlierDefinitions = usedEarlierDefinitions0
   def addImports(additional: Imports) = {
     if (!frozen0)
       imports0 = imports0 ++ additional
   }
-  def addClasspath(additional: Seq[java.io.File]) = {
+  def addClasspath(additional: Seq[java.net.URL]) = {
     if (!frozen0) {
       version0 += 1
-      additional.map(_.toURI.toURL).foreach(classloader.add)
+      additional.foreach(classloader.add)
       classpath0 = classpath0 ++ additional
     }
   }
-  def addPluginClasspath(additional: Seq[java.io.File]) = {
+  def addPluginClasspath(additional: Seq[java.net.URL]) = {
     if (!frozen0) {
       version0 += 1
-      additional.map(_.toURI.toURL).foreach(pluginClassloader.add)
+      additional.foreach(pluginClassloader.add)
     }
   }
   def usedEarlierDefinitions_=(usedEarlierDefinitions: Seq[String]): Unit =
@@ -114,7 +114,9 @@ object SpecialClassLoader{
     * heuristic improves perf by greatly cutting down on the amount of files we
     * need to mtime in many common cases.
     */
-  def initialClasspathSignature(classloader: ClassLoader): Seq[(Either[String, os.Path], Long)] = {
+  def initialClasspathSignature(
+    classloader: ClassLoader
+  ): Seq[(Either[String, java.net.URL], Long)] = {
     val allClassloaders = {
       val all = mutable.Buffer.empty[ClassLoader]
       var current = classloader
@@ -125,14 +127,17 @@ object SpecialClassLoader{
       all
     }
 
-    def findMtimes(d: java.nio.file.Path): Seq[(Either[String, os.Path], Long)] = {
+    def findMtimes(d: java.nio.file.Path): Seq[(Either[String, java.net.URL], Long)] = {
       def skipSuspicious(path: os.Path) = {
         // Leave out sketchy files which don't look like package names or
         // class files
         (simpleNameRegex.findPrefixOf(path.last) != Some(path.last)) &&
         !path.last.endsWith(".class")
       }
-      os.walk(os.Path(d), skip = skipSuspicious).map(x => (Right(x), os.mtime(x)))
+      os.walk(os.Path(d), skip = skipSuspicious).map(x => (Right(x), os.mtime(x))).map {
+        case (e, lm) =>
+          (e.right.map(_.toNIO.toUri.toURL), lm)
+      }
     }
 
 
@@ -140,20 +145,41 @@ object SpecialClassLoader{
       allClassloaders
         .collect{case cl: java.net.URLClassLoader => cl.getURLs}
         .flatten
-        .filter(_.getProtocol == "file")
-        .map(p => java.nio.file.Paths.get(p.toURI).toAbsolutePath)
 
     val bootClasspathRoots = sys.props("java.class.path")
       .split(java.io.File.pathSeparator)
-      .map(java.nio.file.Paths.get(_).toAbsolutePath)
+      .map(java.nio.file.Paths.get(_).toAbsolutePath.toUri.toURL)
 
     val mtimes = (bootClasspathRoots ++ classpathRoots).flatMap{ p =>
-      if (!java.nio.file.Files.exists(p)) Nil
-      else if (java.nio.file.Files.isDirectory(p)) findMtimes(p)
-      else Seq(Right(os.Path(p)) -> os.mtime(os.Path(p)))
+      if (p.getProtocol == "file") {
+        val f = java.nio.file.Paths.get(p.toURI)
+        if (!java.nio.file.Files.exists(f)) Nil
+        else if (java.nio.file.Files.isDirectory(f)) findMtimes(f)
+        else Seq(Right(p) -> os.mtime(os.Path(f)))
+      } else
+        SpecialClassLoader.urlLastModified(p).toSeq.map((Right(p), _))
     }
 
     mtimes
+  }
+
+  def urlLastModified(url: URL): Option[Long] = {
+    if (url.getProtocol == "file") {
+      val path = os.Path(java.nio.file.Paths.get(url.toURI()).toFile(), os.root)
+      if (os.exists(path)) Some(os.mtime(path)) else None
+    } else {
+      var c: java.net.URLConnection = null
+      try {
+        c = url.openConnection()
+        Some(c.getLastModified)
+      } catch {
+        case e: java.io.FileNotFoundException =>
+          None
+      } finally {
+        if (c != null)
+          scala.util.Try(c.getInputStream.close())
+      }
+    }
   }
 }
 
@@ -175,7 +201,7 @@ class ForkClassLoader(realParent: ClassLoader, fakeParent: ClassLoader)
   * http://stackoverflow.com/questions/3544614/how-is-the-control-flow-to-findclass-of
   */
 class SpecialClassLoader(parent: ClassLoader,
-                         parentSignature: Seq[(Either[String, os.Path], Long)],
+                         parentSignature: Seq[(Either[String, java.net.URL], Long)],
                          var specialLocalClasses: Set[String],
                          urls: URL*)
   extends URLClassLoader(urls.toArray, parent){
@@ -228,12 +254,12 @@ class SpecialClassLoader(parent: ClassLoader,
   }
 
   private def jarSignature(url: URL) = {
-    val path = os.Path(java.nio.file.Paths.get(url.toURI()).toFile(), os.root)
-    Right(path) -> (if (os.exists(path)) os.mtime(path) else 0)
+    val lastModified = SpecialClassLoader.urlLastModified(url).getOrElse(0L)
+    Right(url) -> lastModified
   }
 
   private var classpathSignature0 = parentSignature
-  def classpathSignature = classpathSignature0
+  def classpathSignature: Seq[(Either[String, java.net.URL], Long)] = classpathSignature0
   def classpathHash(wd: Option[os.Path]) = {
     Util.md5Hash(
       // Include the current working directory in the classpath hash, to make

--- a/amm/runtime/src/main/scala/ammonite/runtime/Classpath.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/Classpath.scala
@@ -1,7 +1,8 @@
 package ammonite.runtime
 
 import java.io.File
-import java.util.zip.ZipFile
+import java.net.URL
+import java.util.zip.{ZipFile, ZipInputStream}
 
 
 import io.github.retronym.java9rtexport.Export
@@ -24,7 +25,7 @@ object Classpath {
    * memory but is better than reaching all over the filesystem every time we
    * want to do something.
    */
-  def classpath(classLoader: ClassLoader, storage: Storage): Vector[File] = {
+  def classpath(classLoader: ClassLoader, storage: Storage): Vector[URL] = {
     val cache = storage.classpathCache()
     if (cache.isDefined) return cache.get
     def rtCacheDir(storage: Storage): Option[os.Path] = storage match {
@@ -39,13 +40,13 @@ object Classpath {
     }
 
     var current = classLoader
-    val files = collection.mutable.Buffer.empty[java.io.File]
+    val files = collection.mutable.Buffer.empty[java.net.URL]
     val seenClassLoaders = collection.mutable.Buffer.empty[ClassLoader]
     while(current != null){
       seenClassLoaders.append(current)
       current match{
         case t: java.net.URLClassLoader =>
-          files.appendAll(t.getURLs.map(u => new java.io.File(u.toURI)))
+          files.appendAll(t.getURLs)
         case _ =>
       }
       current = current.getParent
@@ -58,12 +59,16 @@ object Classpath {
         sunBoot
           .split(java.io.File.pathSeparator)
           .map(new java.io.File(_))
+          .filter(_.exists())
+          .map(_.toURI.toURL)
       )
     } else {
       if (seenClassLoaders.contains(ClassLoader.getSystemClassLoader)) {
         for (p <- System.getProperty("java.class.path")
           .split(File.pathSeparatorChar) if !p.endsWith("sbt-launch.jar")) {
-          files.append(new File(p))
+          val f = new File(p)
+          if (f.exists())
+            files.append(f.toURI.toURL)
         }
         try {
           new java.net.URLClassLoader(files.map(_.toURI.toURL).toArray, null)
@@ -71,30 +76,34 @@ object Classpath {
         } catch {
           case _: ClassNotFoundException =>
             rtCacheDir(storage) match {
-              case Some(path) => files.append(Export.rtAt(path.toIO))
-              case _ => files.append(Export.rt())
+              case Some(path) => files.append(Export.rtAt(path.toIO).toURI.toURL)
+              case _ => files.append(Export.rt().toURI.toURL)
             }
         }
       }
     }
-    val r = files.toVector.filter(_.exists)
+    val r = files.toVector
     storage.classpathCache.update(Some(r))
     r
   }
 
-  def canBeOpenedAsJar(file: File): Boolean =
+  def canBeOpenedAsJar(url: URL): Boolean = {
+    var zis: ZipInputStream = null
     try {
-      val zf = new ZipFile(file)
-      zf.close()
-      true
+      zis = new ZipInputStream(url.openStream())
+      zis.getNextEntry != null
     } catch {
       case NonFatal(e) =>
         traceClasspathProblem(
-          s"Classpath element '${file.getAbsolutePath}' "+
-            "could not be opened as jar file because of $e"
+          s"Classpath element '$url' "+
+            s"could not be opened as jar file because of $e"
         )
         false
+    } finally {
+      if (zis != null)
+        zis.close()
     }
+  }
   def traceClasspathProblem(msg: String): Unit =
     if (traceClasspathIssues) println(msg)
 }

--- a/amm/runtime/src/main/scala/ammonite/runtime/Storage.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/Storage.scala
@@ -33,10 +33,10 @@ trait Storage{
   def getSessionId: Long
 
   // Store classpathCache in-memory regardless of Storage impl
-  private var _classpathCache: Option[Vector[java.io.File]] = None
-  val classpathCache = new StableRef[Option[Vector[java.io.File]]]{
+  private var _classpathCache: Option[Vector[java.net.URL]] = None
+  val classpathCache = new StableRef[Option[Vector[java.net.URL]]]{
     def apply() = _classpathCache
-    def update(value: Option[Vector[java.io.File]]): Unit = _classpathCache = value
+    def update(value: Option[Vector[java.net.URL]]): Unit = _classpathCache = value
   }
 }
 


### PR DESCRIPTION
~*Not sure I'd like that to be merged yet*, but weighting in / out welcome~

Motivation for that PR is to have Ammonite be fine with unusual setups, where the initial classpath isn't necessarily made entirely of files, but could be made of more general `java.net.URL`s.

For now, Ammonite assumes its initial classpath [is made of files](https://github.com/lihaoyi/Ammonite/blob/c4ab4986cd950ae2efd6e97b56d212db7cfe050c/amm/runtime/src/main/scala/ammonite/runtime/Classpath.scala#L27). This PR keeps that classpath as URLs a bit longer. If a URL doesn't correspond to a file, a `scala.reflect.io.URLZipArchive` rather than a [`scala.reflect.io.FileZipArchive`](https://github.com/lihaoyi/Ammonite/blob/c4ab4986cd950ae2efd6e97b56d212db7cfe050c/amm/interp/src/main/scala-2.11/ammonite/interp/GlobalInitCompat.scala#L64) is passed to scalac.

`scala.reflect.io.URLZipArchive` seems buggy, so this PR also adds a substitute for it (second commit).

The main case of unusual setup where this is useful is when one uses "standalone bootstraps" of coursier (`--standalone` option of `coursier bootstrap`). The classpath of the apps it launches corresponds to resources in the bootstrap, so aren't files per se.