### PR TITLE
Fix JLine dependencies

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -152,8 +152,9 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
       terminal()
     )
     def ivyDeps = Agg(
-      ivy"org.jline:jline:3.6.2",
+      ivy"org.jline:jline-terminal:3.6.2",
       ivy"org.jline:jline-terminal-jna:3.6.2",
+      ivy"org.jline:jline-reader:3.6.2",
       ivy"com.github.javaparser:javaparser-core:3.2.5",
       ivy"com.github.scopt::scopt:3.5.0"
     )


### PR DESCRIPTION
jline-$VERSION.jar is a bundle that contains the content of
jline-terminal-$VERSION.jar and other modules. jline-terminal-jna
depends on jline-terminal. This means that the Ammonite build depends on
both jline and jline-terminal and classfiles may be read from either
jar (dependencies on the classpath are usually not in a stable order).
They should be identical so it's not a big problem, but it breaks Zinc
incremental compilation. This commit fixes this by not using the jline
bundle jar anymore.