### PR TITLE
Use UTF-8 when compiling sources

### DIFF
--- a/amm/interp/src/main/scala/ammonite/interp/CompilerLifecycleManager.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/CompilerLifecycleManager.scala
@@ -121,7 +121,7 @@ class CompilerLifecycleManager(storage: Storage, headFrame: => Frame){
     for {
       compiled <- Res.Success{
         compiler.compile(
-          processed.code.getBytes,
+          processed.code.getBytes(scala.util.Properties.sourceEncoding),
           printer,
           processed.prefixCharLength,
           processed.userCodeNestingLevel,


### PR DESCRIPTION
Fixes #752 and hopefully some other encoding related errors. E.g. I was getting this one when trying to use shapeless:
```
IO error while decoding cmd1.sc with UTF-8 
Please try specifying another one using the -encoding option
```