### PR TITLE
Support auto-complete of back-quoted symbols.

### DIFF
--- a/amm/interp/src/main/scala/ammonite/interp/Pressy.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Pressy.scala
@@ -84,7 +84,7 @@ object Pressy {
       // - There's a public-but-incomplete implementation of rule-based backquoting in
       //   Printers.quotedName
       val nullOutputStream = new OutputStream() { def write(b: Int): Unit = {} }
-      object backQuoter extends pressy.CodePrinter(
+      val backQuoter = new pressy.CodePrinter(
         new PrintWriter(nullOutputStream),
         printRootPkg = false
       ) {

--- a/amm/interp/src/main/scala/ammonite/interp/Pressy.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Pressy.scala
@@ -74,7 +74,7 @@ object Pressy {
       s.decodedName.contains('$')
     }
 
-    private val memberToString = new {
+    private val memberToString = {
       // Some hackery here to get at the protected CodePrinter.printedName which was the only
       // mildly reusable prior art I could locate. Other related bits:
       // - When constructing Trees, Scala captures the back-quoted nature into the AST as
@@ -83,15 +83,15 @@ object Pressy {
       //   leveragable without big changes inside nsc.
       // - There's a public-but-incomplete implementation of rule-based backquoting in
       //   Printers.quotedName
-      private val nullOutputStream = new OutputStream() { def write(b: Int): Unit = {} }
-      private object backQuoter extends pressy.CodePrinter(
+      val nullOutputStream = new OutputStream() { def write(b: Int): Unit = {} }
+      object backQuoter extends pressy.CodePrinter(
         new PrintWriter(nullOutputStream),
         printRootPkg = false
       ) {
         def apply(decodedName: pressy.Name): String = printedName(decodedName, decoded = true)
       }
 
-      def apply(member: pressy.Member): String = {
+      (member: pressy.Member) => {
         // nsc returns certain members w/ a suffix (LOCAL_SUFFIX_STRING, " ").
         // See usages of symNameDropLocal in nsc's PresentationCompilerCompleter.
         // Several people have asked that Scala mask this implementation detail:

--- a/amm/repl/src/test/scala/ammonite/interp/AutocompleteTests.scala
+++ b/amm/repl/src/test/scala/ammonite/interp/AutocompleteTests.scala
@@ -191,6 +191,31 @@ object AutocompleteTests extends TestSuite{
         //Test around https://github.com/lihaoyi/Ammonite/issues/252
         complete("""new Array<caret>""", Set() ^)
       }
+
+      'LOCAL_SUFFIX_STRING - checking { complete =>
+        complete(
+          // The following object creation pattern triggers nsc to return
+          // symbols w/ trailing whitespace, which we strip.
+          """object x { val foo = 1 }; x.<caret>""",
+          Set("foo") -- _
+        )
+      }
+    }
+
+    'backquotes {
+      'spaces - checking { complete =>
+        complete(
+          """object x { val `Backquoted Bar` = 1 }; x.<caret>""",
+          Set("`Backquoted Bar`") -- _
+        )
+      }
+
+      'keywords - checking { complete =>
+        complete(
+          """object x { val `new` = 1; }; x.<caret>""",
+          Set("`new`") -- _
+        )
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes #861.

First-time contributor, apologies in advance 😄 

1. This includes a hack to leverage protected backquoting method in scala-compiler. Arguably better to just re-implement the backquoting rules in Ammonite until they're exposed more-accessibly upstream.
2. I stumbled upon a dubious prior behavior. Prior to my changes:
  a. `val x = new { val foo = 1 }; x.<caret>` completed as `"foo"`
  b. `object x { val foo = 1 }; x.<caret>` completed as `"foo "` (note trailing space)

I tracked this back to the a Scala implementation detail called LOCAL_SUFFIX_STRING which seems to have [caused head-scratching for others](https://github.com/scala/bug/issues/5736).

I had to strip this whitespace to avoid having the trailing space trigger back-quoting unnecessarily.

There's a risk that users' muscle memory is actually relying on the whitespace.

I'm also worried there's nuance to the whitespace that I'm missing. The nsc REPL alters behaviors based on the trailing space in ways that I don't fully grok. See uses of `symNameDropLocal` [here](https://github.com/scala/scala/blob/1e904d75450373d7845eb7452d940e52d955b27d/src/repl/scala/tools/nsc/interpreter/PresentationCompilation.scala#L158).
