### PR TITLE
Fix pre scala 2.11.8 builds

### DIFF
--- a/amm/interp/src/main/scala/ammonite/interp/Pressy.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Pressy.scala
@@ -92,11 +92,12 @@ object Pressy {
       }
 
       (member: pressy.Member) => {
+        import pressy._
         // nsc returns certain members w/ a suffix (LOCAL_SUFFIX_STRING, " ").
         // See usages of symNameDropLocal in nsc's PresentationCompilerCompleter.
         // Several people have asked that Scala mask this implementation detail:
         // https://github.com/scala/bug/issues/5736
-        val decodedName = member.symNameDropLocal.decodedName
+        val decodedName = member.sym.name.dropLocal.decodedName
         backQuoter(decodedName)
       }
     }


### PR DESCRIPTION
https://github.com/lihaoyi/Ammonite/pull/863 uses stuff not available in scala-reflect < 2.11.8, which broke [one of the *release* jobs](https://travis-ci.org/lihaoyi/Ammonite/jobs/428887990) that builds Ammonite against pre 2.11.8 scala versions. This PR fixes that.