### PR TITLE
Properly escape identifiers when generating wrapper code

### DIFF
--- a/amm/interp/src/main/scala/ammonite/interp/Preprocessor.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Preprocessor.scala
@@ -139,7 +139,7 @@ object Preprocessor{
             .ReplBridge
             .value
             .Internal
-            .print($ident, "$ident", $customCode)
+            .print($ident, ${fastparse.utils.Utils.literalize(ident)}, $customCode)
       """
     }
     def definedStr(definitionLabel: String, name: String) =
@@ -149,7 +149,7 @@ object Preprocessor{
             .ReplBridge
             .value
             .Internal
-            .printDef("$definitionLabel", "$name")
+            .printDef("$definitionLabel", ${fastparse.utils.Utils.literalize(name)})
       """
 
     def pprint(ident: String) = pprintSignature(ident, None)
@@ -198,7 +198,7 @@ object Preprocessor{
                 .ReplBridge
                 .value
                 .Internal
-                .printImport($tq$body$tq)
+                .printImport(${fastparse.utils.Utils.literalize(body)})
           """
         ))
     }


### PR DESCRIPTION
Use our standard `literalize` functions rather than just quoting and hoping.

There are probably other places this needs to happen but let's just do this for now

Fixes https://github.com/lihaoyi/Ammonite/issues/882