### PR TITLE
Make Pressy and its compiler accessible

### DIFF
--- a/amm/interp/src/main/scala/ammonite/interp/CompilerLifecycleManager.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/CompilerLifecycleManager.scala
@@ -46,6 +46,8 @@ class CompilerLifecycleManager(storage: Storage, headFrame: => Frame){
   def compiler = Internal.compiler
   def compilationCount = Internal.compilationCount
 
+  def pressy: Pressy = Internal.pressy
+
   def preprocess(fileName: String) = synchronized{
     if (compiler == null) init(force = true)
     Preprocessor(compiler.parse(fileName, _))


### PR DESCRIPTION
Like https://github.com/lihaoyi/Ammonite/pull/891, but without an extra method to also access it via `ReplAPI`. See the discussion in https://github.com/lihaoyi/Ammonite/pull/891 for the issues this triggers.