### PR TITLE
Filtering URLs loaded in Classpath to just those with "file"

### DIFF
--- a/amm/runtime/src/main/scala/ammonite/runtime/Classpath.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/Classpath.scala
@@ -43,7 +43,10 @@ object Classpath {
     while(current != null){
       current match{
         case t: java.net.URLClassLoader =>
-          files.appendAll(t.getURLs.map(u => new java.io.File(u.toURI)))
+          files.appendAll(
+            t.getURLs
+              .filter(u => "file".equals(u.getProtocol))
+              .map(u => new java.io.File(u.toURI)))
         case _ =>
       }
       current = current.getParent


### PR DESCRIPTION
protocol.  Without this change the .classpath method could throw
IllegalArgumentException if any non-file scheme was encountered.

https://docs.oracle.com/javase/10/docs/api/java/io/File.html#%3Cinit%3E(java.net.URI)