### PR TITLE
Fix shellout on Windows

### DIFF
--- a/amm/repl/src/test/scala/ammonite/TestRepl.scala
+++ b/amm/repl/src/test/scala/ammonite/TestRepl.scala
@@ -164,7 +164,7 @@ class TestRepl {
 
     val steps = sess.replace(
       Util.newLineRegex + margin, Util.newLine
-    ).replaceAll(" *" + Util.newLineRegex, "\n").split("\n\n")
+    ).replaceAll(s" *(${Util.newLineRegex})", "\n").split("\n\n")
 
     for((step, index) <- steps.zipWithIndex){
       // Break the step into the command lines, starting with @,

--- a/amm/repl/src/test/scala/ammonite/TestRepl.scala
+++ b/amm/repl/src/test/scala/ammonite/TestRepl.scala
@@ -163,8 +163,8 @@ class TestRepl {
     // Strip margin & whitespace
 
     val steps = sess.replace(
-      Util.newLine + margin, Util.newLine
-    ).replaceAll(" *\n", "\n").split("\n\n")
+      Util.newLineRegex + margin, Util.newLine
+    ).replaceAll(" *" + Util.newLineRegex, "\n").split("\n\n")
 
     for((step, index) <- steps.zipWithIndex){
       // Break the step into the command lines, starting with @,

--- a/amm/util/src/main/scala/ammonite/util/Util.scala
+++ b/amm/util/src/main/scala/ammonite/util/Util.scala
@@ -59,6 +59,7 @@ object Util{
   val windowsPlatform = System.getProperty("os.name").startsWith("Windows")
   val java9OrAbove = !System.getProperty("java.specification.version").startsWith("1.")
   val newLine = System.lineSeparator()
+  val newLineRegex = "\r\n|\r|\n"
   // Type aliases for common things
 
   /**

--- a/integration/src/test/scala/ammonite/integration/BasicTests.scala
+++ b/integration/src/test/scala/ammonite/integration/BasicTests.scala
@@ -105,7 +105,6 @@ object BasicTests extends TestSuite{
       }
     }
 
-
     'shell {
       // make sure you can load the example-predef.sc, have it pull stuff in
       // from ivy, and make use of `cd!` and `wd` inside the executed script.

--- a/ops/src/main/scala/ammonite/ops/FileOps.scala
+++ b/ops/src/main/scala/ammonite/ops/FileOps.scala
@@ -6,7 +6,6 @@
  */
 package ammonite.ops
 
-import java.io.File
 import java.nio.file._
 
 import scala.io.Codec
@@ -20,14 +19,14 @@ object Internals{
     def apply(t: PartialFunction[String, String])(from: Path) = {
       if (check || t.isDefinedAt(from.last)){
         val dest = from/RelPath.up/t(from.last)
-        new File(from.toString).renameTo(new File(dest.toString))
+        Files.move(from.toNIO, dest.toNIO);
       }
     }
     def *(t: PartialFunction[Path, Path])(from: Path) = {
       if (check || t.isDefinedAt(from)) {
         val dest = t(from)
         mkdir(dest/RelPath.up)
-        new File(from.toString).renameTo(new File(t(from).toString))
+        Files.move(from.toNIO, dest.toNIO)
       }
     }
   }

--- a/ops/src/main/scala/ammonite/ops/Shellout.scala
+++ b/ops/src/main/scala/ammonite/ops/Shellout.scala
@@ -103,9 +103,7 @@ object Shellout{
 
   private def getCmd(cmd: Command[_]): Vector[String] = {
     if(scala.util.Properties.isWin) {
-      val cmdCommand = cmd.cmd.head
-      val cmdParams = cmd.cmd.tail.mkString(" ")
-      Vector("cmd.exe", "/C", s"$cmdCommand $cmdParams")
+      Vector("cmd.exe", "/C") ++ cmd.cmd
     } else {
       cmd.cmd
     }

--- a/ops/src/main/scala/ammonite/ops/Shellout.scala
+++ b/ops/src/main/scala/ammonite/ops/Shellout.scala
@@ -24,7 +24,7 @@ object Shellout{
 
     val proc =
       builder
-        .command(cmd.cmd:_*)
+        .command(getCmd(cmd): _*)
         .inheritIO()
         .start()
 
@@ -67,7 +67,7 @@ object Shellout{
     builder.directory(new java.io.File(wd.toString))
     val process =
       builder
-        .command(cmd.cmd:_*)
+        .command(getCmd(cmd): _*)
         .start()
     val stdout = process.getInputStream
     val stderr = process.getErrorStream
@@ -99,6 +99,16 @@ object Shellout{
     val res = CommandResult(process.exitValue(), chunks)
     if (res.exitCode == 0) res
     else throw ShelloutException(res)
+  }
+
+  private def getCmd(cmd: Command[_]): Vector[String] = {
+    if(scala.util.Properties.isWin) {
+      val cmdCommand = cmd.cmd.head
+      val cmdParams = cmd.cmd.tail.mkString(" ")
+      Vector("cmd.exe", "/C", s"$cmdCommand $cmdParams")
+    } else {
+      cmd.cmd
+    }
   }
 }
 

--- a/ops/src/test/scala/test/ammonite/ops/ExampleTests.scala
+++ b/ops/src/test/scala/test/ammonite/ops/ExampleTests.scala
@@ -199,7 +199,7 @@ object ExampleTests extends TestSuite{
           if (!f.delete())
             throw new RuntimeException("Failed to delete " + f.getAbsolutePath)
         }
-        new java.io.File(path).delete
+        java.nio.file.Files.delete(java.nio.file.Paths.get(path))
       }
       removeAll("target/folder/thing")
 

--- a/ops/src/test/scala/test/ammonite/ops/PathTests.scala
+++ b/ops/src/test/scala/test/ammonite/ops/PathTests.scala
@@ -34,22 +34,18 @@ object PathTests extends TestSuite{
       'RelPath{
         'Constructors {
           'Symbol {
-            if (Unix()){
               val rel1 = rel / 'ammonite
               assert(
                 rel1.segments == Seq("src", "main", "scala", "ammonite"),
                 rel1.toString == "src/main/scala/ammonite"
               )
-            }
           }
           'String {
-            if (Unix()){
               val rel1 = rel / "Path.scala"
               assert(
                 rel1.segments == Seq("src", "main", "scala", "Path.scala"),
                 rel1.toString == "src/main/scala/Path.scala"
               )
-            }
           }
           'Combos{
             def check(rel1: RelPath) = assert(
@@ -57,29 +53,23 @@ object PathTests extends TestSuite{
               rel1.toString == "src/main/scala/sub1/sub2"
             )
             'ArrayString - {
-              if (Unix()){
                 val arr = Array("sub1", "sub2")
                 check(rel / arr)
-              }
             }
             'ArraySymbol - {
-              if (Unix()){
                 val arr = Array('sub1, 'sub2)
                 check(rel / arr)
-              }
             }
             'SeqString - {
-              if (Unix()) check(rel / Seq("sub1", "sub2"))
+              check(rel / Seq("sub1", "sub2"))
             }
             'SeqSymbol - {
-              if (Unix()) check(rel / Seq('sub1, 'sub2))
+              check(rel / Seq('sub1, 'sub2))
             }
             'SeqSeqSeqSymbol - {
-              if (Unix()){
                 check(
                   rel / Seq(Seq(Seq('sub1), Seq()), Seq(Seq('sub2)), Seq())
                 )
-              }
             }
           }
         }
@@ -97,8 +87,8 @@ object PathTests extends TestSuite{
         val d = pwd
         val abs = d / rel
         'Constructor {
-          if (Unix()) assert(
-            abs.toString.drop(d.toString.length) == "/src/main/scala",
+          assert(
+            abs.toString.drop(d.toString.length).replace("\\", "/") == "/src/main/scala",
             abs.toString.length > d.toString.length
           )
         }
@@ -168,7 +158,6 @@ object PathTests extends TestSuite{
         }
       }
     }
-
     'Errors{
       'InvalidChars {
         val ex = intercept[PathError.InvalidSegment]('src/"Main/.scala")
@@ -197,9 +186,11 @@ object PathTests extends TestSuite{
       'CannotRelativizeAbsAndRel{
         val abs = pwd
         val rel = 'omg/'wtf
-        compileError("""
+        compileError(
+          """
           abs relativeTo rel
-        """).check(
+          """
+        ).check(
           """
           abs relativeTo rel
                          ^
@@ -263,19 +254,19 @@ object PathTests extends TestSuite{
         if(Unix()){
           val relStr = "hello/cow/world/.."
           val absStr = "/hello/world"
-
+  
           assert(
             RelPath(relStr) == 'hello/'cow,
             // Path(...) also allows paths starting with ~,
             // which is expanded to become your home directory
             Path(absStr) == root/'hello/'world
           )
-
+  
           // You can also pass in java.io.File and java.nio.file.Path
           // objects instead of Strings when constructing paths
           val relIoFile = new java.io.File(relStr)
           val absNioFile = java.nio.file.Paths.get(absStr)
-
+  
           assert(
             RelPath(relIoFile) == 'hello/'cow,
             Path(absNioFile) == root/'hello/'world,
@@ -312,12 +303,12 @@ object PathTests extends TestSuite{
           intercept[java.lang.IllegalArgumentException]{
             Path(relStr)
           }
-
+  
           val absStr = "/hello"
           intercept[java.lang.IllegalArgumentException]{
             RelPath(absStr)
           }
-
+  
           val tooManyUpsStr = "/hello/../.."
           intercept[PathError.AbsolutePathOutsideRoot.type]{
             Path(tooManyUpsStr)
@@ -330,7 +321,6 @@ object PathTests extends TestSuite{
         val twd = tmp.dir()
 
         'nestedSymlinks{
-          if(Unix()) {
             names.foreach(p => rm ! twd/p)
             mkdir ! twd/'test123
             ln.s(twd/'test123, twd/'test124)
@@ -339,11 +329,9 @@ object PathTests extends TestSuite{
             assert(os.followLink(twd/'test126).get == os.followLink(twd/'test123).get)
             names.foreach(p => rm ! twd/p)
             names.foreach(p => assert(!exists(twd/p)))
-          }
         }
 
         'danglingSymlink{
-          if(Unix()) {
             names.foreach(p => rm ! twd/p)
             mkdir ! twd/'test123
             ln.s(twd/'test123, twd/'test124)
@@ -355,7 +343,6 @@ object PathTests extends TestSuite{
             names.foreach(p => assert(!exists(twd / p)))
             names.foreach(p => rm ! twd/p)
             names.foreach(p => assert(!exists(twd/p)))
-          }
         }
       }
     }

--- a/ops/src/test/scala/test/ammonite/ops/ShelloutTests.scala
+++ b/ops/src/test/scala/test/ammonite/ops/ShelloutTests.scala
@@ -44,7 +44,10 @@ object ShelloutTests extends TestSuite{
       'listMixAndMatch{
         val stuff = List("I", "am", "bovine")
         val result = %%('echo, "Hello,", stuff, "hear me roar")
-        assert(result.out.string.contains("Hello, " + stuff.mkString(" ") + " hear me roar"))
+        if(Unix())
+          assert(result.out.string.contains("Hello, " + stuff.mkString(" ") + " hear me roar"))
+        else // win quotes multiword args
+          assert(result.out.string.contains("Hello, " + stuff.mkString(" ") + " \"hear me roar\""))
       }
       'failures{
         val ex = intercept[ShelloutException]{ %%(listCmd, "does-not-exist") }


### PR DESCRIPTION
With these changes `mill -i ops[2.12.7].test` passes on Windows also.