### PR TITLE
Allow to tweak FullReplAPI.Internal…

### DIFF
--- a/amm/repl/src/main/scala/ammonite/repl/FullReplAPI.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/FullReplAPI.scala
@@ -10,7 +10,7 @@ import scala.collection.mutable
 import scala.reflect.ClassTag
 import scala.reflect.classTag
 
-trait FullReplAPI extends ReplAPI{
+trait FullReplAPI extends ReplAPI{ replApi =>
 
   def typeOf[T: WeakTypeTag] = scala.reflect.runtime.universe.weakTypeOf[T]
   def typeOf[T: WeakTypeTag](t: => T) = scala.reflect.runtime.universe.weakTypeOf[T]
@@ -29,12 +29,27 @@ trait FullReplAPI extends ReplAPI{
 
 
   protected[this] def replArgs0: IndexedSeq[Bind[_]]
+  protected[this] def internal0: FullReplAPI.Internal =
+    new FullReplAPI.Internal {
+      def pprinter = replApi.pprinter
+      def colors = replApi.colors
+      def replArgs: IndexedSeq[Bind[_]] = replArgs0
+    }
+
   /**
     * This stuff is used for the REPL-generated code that prints things;
     * shouldn't really be used by users, but needs to be public and accessible
     */
-  object Internal {
-    def replArgs: IndexedSeq[Bind[_]] = replArgs0
+  lazy val Internal: FullReplAPI.Internal = internal0
+}
+
+object FullReplAPI {
+
+  trait Internal {
+    def pprinter: Ref[pprint.PPrinter]
+    def colors: Ref[Colors]
+    def replArgs: IndexedSeq[Bind[_]]
+
     def combinePrints(iters: Iterator[String]*) = {
       iters.toIterator
            .filter(_.nonEmpty)

--- a/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
@@ -151,6 +151,12 @@ object AdvancedTests extends TestSuite{
         res3: Int Array = Array(1)
       """)
     }
+    'trappedType{
+      check.session("""
+        @ val nope = ammonite.TestRepl.Nope(2); val n = 2
+        n: Int = 2
+      """)
+    }
     'unwrapping{
       check.session("""
         @ {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,11 +6,11 @@ environment:
   matrix:
   - JAVA_OPTS: -Dfile.encoding=UTF8
     JAVA_HOME: C:\Program Files\Java\jdk9
-    TEST_TASKS: ops[2.11.12].test terminal[2.12.7].test amm.repl[2.12.7].test
+    TEST_TASKS: ops[2.11.12].test terminal[2.12.8].test amm.repl[2.12.8].test
 
   - JAVA_OPTS: -Dfile.encoding=UTF8
     JAVA_HOME: C:\Program Files\Java\jdk1.8.0
-    TEST_TASKS: amm[2.11.12].test integration[2.12.7].test
+    TEST_TASKS: amm[2.11.12].test integration[2.12.8].test
 
 install:
   - SET MILL_URL=https://github.com/lihaoyi/mill/releases/download/0.2.7/0.2.7


### PR DESCRIPTION
…when using Ammonite as a library.

In particular, this allows to print nothing at all for types other than `Unit`. I'll also probably rely on it to do more fancy stuffs with pretty-printing from [almond / jupyter-scala](https://github.com/almond-sh/almond).