### PR TITLE
Create session directory if not exists

### DIFF
--- a/amm/runtime/src/main/scala/ammonite/runtime/Storage.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/Storage.scala
@@ -129,7 +129,7 @@ object Storage{
       try os.read(sessionFile).toLong
       catch{case e: Throwable =>
         val randomId = math.abs(util.Random.nextLong)
-        os.write.over(sessionFile, randomId.toString)
+        os.write.over(sessionFile, randomId.toString, createFolders = true)
         randomId
       }
     }


### PR DESCRIPTION
When running `amm` for the first time after installation, sometimes I got this error (on Archlinux and Ubuntu 16.04)
```
Exception in thread "main" java.nio.file.NoSuchFileException: /home/kien/.ammonite/session
	at sun.nio.fs.UnixException.translateToIOException(UnixException.java:86)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
	at sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:214)
	at java.nio.file.Files.newByteChannel(Files.java:361)
	at os.write$.write(ReadWriteOps.scala:61)
	at os.write$over$.apply(ReadWriteOps.scala:137)
	at ammonite.runtime.Storage$Folder.getSessionId(Storage.scala:132)
	at ammonite.Main.run(Main.scala:185)
	at ammonite.MainRunner.$anonfun$runRepl$1(Main.scala:374)
	at ammonite.MainRunner.watchLoop(Main.scala:355)
	at ammonite.MainRunner.runRepl(Main.scala:374)
	at ammonite.Main$.main0(Main.scala:291)
	at ammonite.Main$.main(Main.scala:255)
	at ammonite.Main.main(Main.scala)
```
because it tries to overwrite `dir/"session"` when `dir` doesn't exist
https://github.com/lihaoyi/Ammonite/blob/da131e9dd9218bce793d79a0ff7b4c8bb48b8b7b/amm/runtime/src/main/scala/ammonite/runtime/Storage.scala#L126
https://github.com/lihaoyi/Ammonite/blob/da131e9dd9218bce793d79a0ff7b4c8bb48b8b7b/amm/runtime/src/main/scala/ammonite/runtime/Storage.scala#L132