### PR TITLE
mill build files with no newline after and comment at end of file cause compiler

### DIFF
--- a/amm/interp/src/main/scala/ammonite/interp/Preprocessor.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Preprocessor.scala
@@ -392,7 +392,7 @@ object ${indexedWrapperName.backticked}{
 """
         )
 
-        val bottom = normalizeNewlines(s"""\ndef $$main() = { $printCode }
+        val bottom = normalizeNewlines(s"""\ndef $$main() = { $printCode\n }
   override def toString = "${indexedWrapperName.encoded}"
   $extraCode
 }}


### PR DESCRIPTION
the end of file comment means that the final } in the line below is commented out

sorry I don't time to check this properly and check this through at the moment so feel free to
reject.