### PR TITLE
Fix back some tty-related stuff

### DIFF
--- a/amm/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -184,13 +184,7 @@ class Repl(input: InputStream,
 
 
   def run(): Any = {
-
-    val initialConfigOpt =
-      if (scala.util.Properties.isWin)
-        None
-      else
-        Some(ammonite.terminal.TTY.init())
-
+    welcomeBanner.foreach(printer.outStream.println)
     @tailrec def loop(): Any = {
       val actionResult = action()
       remoteLogger.foreach(_.apply("Action"))
@@ -208,15 +202,8 @@ class Repl(input: InputStream,
         case Some(value) => value
       }
     }
-
-    try {
-      welcomeBanner.foreach(printer.outStream.println)
-      loop()
-    } finally {
-      for (config <- initialConfigOpt)
-        ammonite.terminal.TTY.stty(config)
-    }
-}
+    loop()
+  }
 
   def beforeExit(exitValue: Any): Any = {
     Function.chain(interp.beforeExitHooks)(exitValue)

--- a/terminal/src/main/scala/ammonite/terminal/Terminal.scala
+++ b/terminal/src/main/scala/ammonite/terminal/Terminal.scala
@@ -36,7 +36,20 @@ object Terminal {
                filters: Filter,
                displayTransform: (Vector[Char], Int) => (fansi.Str, Int) = LineReader.noTransform)
                : Option[String] = {
+
+
+    val initialConfig = TTY.init()
+    try {
       new LineReader(ConsoleDim.width(), prompt, reader, writer, filters, displayTransform)
         .readChar(TermState(LazyList.continually(reader.read()), Vector.empty, 0, ""), 0)
+    }finally{
+
+      // Don't close these! Closing these closes stdin/stdout,
+      // which seems to kill the entire program
+
+      // reader.close()
+      // writer.close()
+      TTY.stty(initialConfig)
+    }
   }
 }


### PR DESCRIPTION
This partly reverts https://github.com/lihaoyi/Ammonite/commit/84d48542654285a9268964e4571fe0a91ef335d8. See the commit message some details.

I guess the optimizations of https://github.com/lihaoyi/Ammonite/commit/84d48542654285a9268964e4571fe0a91ef335d8 could be added back more carefully in the future. (AFAIU, it basically needs to pass Ctrl-C to the code that reads input, and save / restore terminal state right before the user code runs external commands, like in https://github.com/lihaoyi/Ammonite/issues/922).

Fix https://github.com/lihaoyi/Ammonite/issues/920.

Fix https://github.com/lihaoyi/Ammonite/issues/922.