### PR TITLE
Add sehbang

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -210,7 +210,8 @@ class MainModule(val crossScalaVersion: String) extends AmmModule with AmmDepend
       Agg("$0"),
       Agg("%~dpnx0"),
       // G1 Garbage Collector is awesome https://github.com/lihaoyi/Ammonite/issues/216
-      Seq("-Xmx500m", "-XX:+UseG1GC")
+      Seq("-Xmx500m", "-XX:+UseG1GC"),
+      shebang = true
     )
   }
 


### PR DESCRIPTION
Right now the assembled script seems to not have any shebang. This works well in shells like zsh and bash but not in fish.

I believe that by adding this "will" fix it. I wasn't really able to run `mill -i amm[2.12.8].assembly` so apologies in advance.

Update:
Managed to test this and it solves the issue.