### PR TITLE
Don't print things marked as private

### DIFF
--- a/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
@@ -242,9 +242,8 @@ object AdvancedTests extends TestSuite{
       """)
     }
     'private{
-      check.session("""
+      'vals - check.session("""
         @ private val x = 1; val y = x + 1
-        x: Int = 1
         y: Int = 2
 
         @ y
@@ -264,6 +263,32 @@ object AdvancedTests extends TestSuite{
         @ b
         
       """)
+
+      'dontPrint - {
+        check.session(
+          """
+          @ private object Foo { def get = "a" }; val s = Foo.get
+          s: String = "a"
+
+          @ private class Foo { def get = "a" }; val s = (new Foo).get
+          s: String = "a"
+
+          @ private trait Foo { def get = "a" }; val s = (new Foo {}).get
+          s: String = "a"
+
+          @ private def foo(): String = "a"; val s = foo()
+          s: String = "a"
+
+          @ private lazy val foo: String = "a"; val s = foo
+          s: String = "a"
+
+          @ private val foo: String = "a"; val s = foo
+          s: String = "a"
+
+          @ private type T = String; private def foo(): T = "a"; val s: String = foo()
+          s: String = "a"
+        """)
+      }
     }
     'compilerPlugin - retry(3){
       if (!scala2_12) check.session("""

--- a/readme/Footer.scalatex
+++ b/readme/Footer.scalatex
@@ -3,6 +3,8 @@
 @def issue(n: Int) = {
   a("#", n, href := s"https://github.com/lihaoyi/Ammonite/issues/$n")
 }
+@val coderAbhishek = lnk("coderabhishek", "https://github.com/coderabhishek")
+
 @sect{Reference}
   @sect{Community}
     @p
@@ -118,8 +120,6 @@
     @p
       Although it's best to read the documentation on this page to learn how
       to use these projects, the Scaladoc is still useful as a reference.
-
-  @val coderAbhishek = lnk("coderabhishek", "https://github.com/coderabhishek")
 
 
   @sect{Changelog}


### PR DESCRIPTION
Previously, private things were printed back, even though they can't be used after the input block they're defined in, like
```scala
@ private val x = 2; val y = x + 1
x: Int = 2
y: Int = 3
@ x
cmd1.sc:1: not found: value x
val res1 = x
           ^
Compilation Failed
```

This PR changes that, not printing any private thing, like
```scala
@ private val x = 2; val y = x + 1
y: Int = 3
```