### PR TITLE
Ensure we don't keep changing artifacts in ivymap

### DIFF
--- a/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
@@ -618,11 +618,12 @@ class Interpreter(val printer: Printer,
           output = printer.errStream,
           hooks = resolutionHooks
         )match{
-          case Right(loaded) =>
+          case Right((canBeCached, loaded)) =>
             val loadedSet = loaded.toSet
-            storage.ivyCache() = storage.ivyCache().updated(
-              cacheKey, loadedSet.map(_.getAbsolutePath)
-            )
+            if (canBeCached)
+              storage.ivyCache() = storage.ivyCache().updated(
+                cacheKey, loadedSet.map(_.getAbsolutePath)
+              )
             Right(loadedSet)
           case Left(l) =>
             Left(l)

--- a/amm/runtime/src/main/scala/ammonite/runtime/tools/IvyThing.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/tools/IvyThing.scala
@@ -38,9 +38,13 @@ object IvyThing{
       .withMainArtifacts()
       .addClassifiers(Classifier.sources)
 
-    Function.chain(hooks)(fetch)
-      .either()
-      .left.map(err => "Failed to resolve ivy dependencies:" + err.getMessage)
+    Function.chain(hooks)(fetch).eitherResult() match {
+      case Left(err) => Left("Failed to resolve ivy dependencies:" + err.getMessage)
+      case Right((_, artifacts)) =>
+        val canBeCached = artifacts.forall(!_._1.changing)
+        val files = artifacts.map(_._2)
+        Right((canBeCached, files))
+    }
   }
 
   val defaultRepositories = List(

--- a/amm/runtime/src/main/scala/ammonite/runtime/tools/IvyThing.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/tools/IvyThing.scala
@@ -41,9 +41,12 @@ object IvyThing{
     Function.chain(hooks)(fetch).eitherResult() match {
       case Left(err) => Left("Failed to resolve ivy dependencies:" + err.getMessage)
       case Right((_, artifacts)) =>
-        val canBeCached = artifacts.forall(!_._1.changing)
+        val noChangingArtifact = artifacts.forall(!_._1.changing)
+        def noVersionInterval = dependencies.map(_.version).forall { v =>
+          coursier.core.Parse.versionConstraint(v).interval == coursier.core.VersionInterval.zero
+        }
         val files = artifacts.map(_._2)
-        Right((canBeCached, files))
+        Right((noChangingArtifact && noVersionInterval, files))
     }
   }
 

--- a/integration/src/test/resources/ammonite/integration/basic/ivyResolveItv1.sc
+++ b/integration/src/test/resources/ammonite/integration/basic/ivyResolveItv1.sc
@@ -1,0 +1,6 @@
+import $ivy.`com.lihaoyi::some-dummy-library:0.2+`
+
+import io.circe._
+val json = Json.obj("a" -> Json.True)
+
+println(dummy.Dummy.thing)

--- a/integration/src/test/resources/ammonite/integration/basic/ivyResolveItv2.sc
+++ b/integration/src/test/resources/ammonite/integration/basic/ivyResolveItv2.sc
@@ -1,0 +1,6 @@
+import $ivy.`com.lihaoyi::some-dummy-library:0.2+`
+
+import argonaut._
+val json = Json.obj("a" -> Json.jTrue, "c" -> Json.jString("b"))
+
+println(dummy.Dummy.thing)

--- a/integration/src/test/resources/ammonite/integration/basic/ivyResolveSnapshot1.sc
+++ b/integration/src/test/resources/ammonite/integration/basic/ivyResolveSnapshot1.sc
@@ -1,2 +1,6 @@
 import $ivy.`com.lihaoyi::some-dummy-library:0.1-SNAPSHOT`
+
+import io.circe._
+val json = Json.obj("a" -> Json.True)
+
 println(dummy.Dummy.thing)

--- a/integration/src/test/resources/ammonite/integration/basic/ivyResolveSnapshot2.sc
+++ b/integration/src/test/resources/ammonite/integration/basic/ivyResolveSnapshot2.sc
@@ -1,0 +1,6 @@
+import $ivy.`com.lihaoyi::some-dummy-library:0.1-SNAPSHOT`
+
+import argonaut._
+val json = Json.obj("a" -> Json.jTrue, "c" -> Json.jString("b"))
+
+println(dummy.Dummy.thing)

--- a/integration/src/test/resources/some-dummy-library/build.sbt
+++ b/integration/src/test/resources/some-dummy-library/build.sbt
@@ -1,11 +1,14 @@
 
-scalaVersion := "2.11.8"
-crossScalaVersions := Seq("2.11.8")
-
 lazy val root = (project in file(".")).
   settings(
     name := "some-dummy-library",
     organization := "com.lihaoyi",
     version := "0.1-SNAPSHOT",
-    scalaVersion := "2.11.8"
+    scalaVersion := sys.env("SCALA_VERSION"),
+    libraryDependencies += {
+      if (java.lang.Boolean.parseBoolean(sys.env("FIRST_RUN")))
+        "io.circe" %% "circe-core" % "0.10.0"
+      else
+        "io.argonaut" %% "argonaut" % "6.2.2"
+    }
   )

--- a/integration/src/test/resources/some-dummy-library/build.sbt
+++ b/integration/src/test/resources/some-dummy-library/build.sbt
@@ -3,7 +3,7 @@ lazy val root = (project in file(".")).
   settings(
     name := "some-dummy-library",
     organization := "com.lihaoyi",
-    version := "0.1-SNAPSHOT",
+    version := sys.env("VERSION"),
     scalaVersion := sys.env("SCALA_VERSION"),
     libraryDependencies += {
       if (java.lang.Boolean.parseBoolean(sys.env("FIRST_RUN")))

--- a/integration/src/test/scala/ammonite/integration/TestUtils.scala
+++ b/integration/src/test/scala/ammonite/integration/TestUtils.scala
@@ -18,19 +18,20 @@ object TestUtils {
   val exampleBarePredef = shellAmmoniteResources/"example-predef-bare.sc"
 
   //we use an empty predef file here to isolate the tests from external forces.
-  def execBase(name: RelPath, extraAmmArgs: Seq[String], args: Seq[String]) = {
+  def execBase(name: RelPath, extraAmmArgs: Seq[String], home: os.Path, args: Seq[String]) = {
     %%bash(
       executable,
       extraAmmArgs,
       "--no-remote-logging",
       "--home",
-      tmp.dir(),
+      home,
       replStandaloneResources / name,
       args
     )
   }
-  def exec(name: RelPath, args: String*) = execBase(name, Nil, args)
-  def execSilent(name: RelPath, args: String*) = execBase(name, Seq("-s"), args)
+  def exec(name: RelPath, args: String*) = execBase(name, Nil, tmp.dir(), args)
+  def execWithHome(home: os.Path, name: RelPath, args: String*) = execBase(name, Nil, home, args)
+  def execSilent(name: RelPath, args: String*) = execBase(name, Seq("-s"), tmp.dir(), args)
 
   /**
     *Counts number of non-overlapping occurrences of `subs` in `s`


### PR DESCRIPTION
This makes `IvyThing.resolveArtifact` return a boolean along the list of artifacts, saying whether that list can be cached or not. This is then taken into account before writing things to the cache.