### PR TITLE
Fixed NoSuchFile when building with mill 0.3.6

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -368,6 +368,7 @@ def generateDependenciesFile(scalaVersion: String,
     }
     .mkString("\n")
 
+  mkdir(dir)
   println(s"Writing $dest")
   write(dest, content.getBytes("UTF-8"))
 


### PR DESCRIPTION
amm[2.12.8].resources java.nio.file.NoSuchFileException: /Users/oliviermelois/lab/Ammonite/out/amm/2.12.8/resources/dest/extra-resources/amm-dependencies.txt
