### PR TITLE
Injecting import hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ project/.sbtserver
 tags
 nohup.out
 out
+.bloop
+.vscode
+.metals

--- a/amm/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -22,7 +22,8 @@ class Repl(input: InputStream,
            initialColors: Colors = Colors.Default,
            replCodeWrapper: CodeWrapper,
            scriptCodeWrapper: CodeWrapper,
-           alreadyLoadedDependencies: Seq[coursier.Dependency]) { repl =>
+           alreadyLoadedDependencies: Seq[coursier.Dependency],
+           importHooks: Map[Seq[String], ImportHook]) { repl =>
 
   val prompt = Ref("@ ")
 
@@ -115,7 +116,8 @@ class Repl(input: InputStream,
     createFrame = () => { val f = sess0.childFrame(frames().head); frames() = f :: frames(); f },
     replCodeWrapper = replCodeWrapper,
     scriptCodeWrapper = scriptCodeWrapper,
-    alreadyLoadedDependencies = alreadyLoadedDependencies
+    alreadyLoadedDependencies = alreadyLoadedDependencies,
+    importHooks
   )
 
   def initializePredef() = interp.initializePredef()

--- a/amm/repl/src/test/scala/ammonite/TestRepl.scala
+++ b/amm/repl/src/test/scala/ammonite/TestRepl.scala
@@ -13,6 +13,7 @@ import utest._
 
 import scala.collection.mutable
 import scala.reflect.ClassTag
+import ammonite.runtime.ImportHook
 
 /**
  * A test REPL which does not read from stdin or stdout files, but instead lets
@@ -142,7 +143,8 @@ class TestRepl {
       createFrame = () => { val f = sess0.childFrame(frames().head); frames() = f :: frames(); f },
       replCodeWrapper = codeWrapper,
       scriptCodeWrapper = codeWrapper,
-      alreadyLoadedDependencies = Defaults.alreadyLoadedDependencies("amm-test-dependencies.txt")
+      alreadyLoadedDependencies = Defaults.alreadyLoadedDependencies("amm-test-dependencies.txt"),
+      importHooks = ImportHook.defaults
     )
 
   }catch{ case e: Throwable =>

--- a/amm/repl/src/test/scala/ammonite/TestUtils.scala
+++ b/amm/repl/src/test/scala/ammonite/TestUtils.scala
@@ -6,6 +6,7 @@ import ammonite.interp.{CodeWrapper, Interpreter, Preprocessor}
 import ammonite.main.Defaults
 import ammonite.runtime.{Frame, History, Storage}
 import ammonite.util._
+import ammonite.runtime.ImportHook
 
 object TestUtils {
   def scala2_11 = scala.util.Properties.versionNumberString.contains("2.11")
@@ -33,7 +34,8 @@ object TestUtils {
       createFrame = () => throw new Exception("unsupported"),
       replCodeWrapper = CodeWrapper,
       scriptCodeWrapper = CodeWrapper,
-      alreadyLoadedDependencies = Defaults.alreadyLoadedDependencies("amm-test-dependencies.txt")
+      alreadyLoadedDependencies = Defaults.alreadyLoadedDependencies("amm-test-dependencies.txt"),
+      importHooks = ImportHook.defaults
     )
     interp.initializePredef()
     interp

--- a/amm/runtime/src/main/scala/ammonite/runtime/ImportHook.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/ImportHook.scala
@@ -35,6 +35,16 @@ trait ImportHook{
 
 object ImportHook{
 
+  val defaults = Map[Seq[String], ImportHook](
+    Seq("url") -> URL,
+    Seq("file") -> File,
+    Seq("exec") -> Exec,
+    Seq("ivy") -> Ivy,
+    Seq("cp") -> Classpath,
+    Seq("plugin", "ivy") -> PluginIvy,
+    Seq("plugin", "cp") -> PluginClasspath
+  )
+
   /**
     * The minimal interface that is exposed to the import hooks from the
     * Interpreter. Open for extension, if someone needs more stuff, but by

--- a/amm/src/main/scala/ammonite/Main.scala
+++ b/amm/src/main/scala/ammonite/Main.scala
@@ -11,6 +11,7 @@ import ammonite.util.Util.newLine
 import ammonite.util._
 
 import scala.annotation.tailrec
+import ammonite.runtime.ImportHook
 
 
 
@@ -68,7 +69,8 @@ case class Main(predefCode: String = "",
                 replCodeWrapper: CodeWrapper = CodeWrapper,
                 scriptCodeWrapper: CodeWrapper = CodeWrapper,
                 alreadyLoadedDependencies: Seq[coursier.Dependency] =
-                  Defaults.alreadyLoadedDependencies()){
+                  Defaults.alreadyLoadedDependencies(),
+                importHooks: Map[Seq[String], ImportHook] = ImportHook.defaults){
 
   def loadedPredefFile = predefFile match{
     case Some(path) =>
@@ -119,7 +121,8 @@ case class Main(predefCode: String = "",
         initialColors = colors,
         replCodeWrapper = replCodeWrapper,
         scriptCodeWrapper = scriptCodeWrapper,
-        alreadyLoadedDependencies = alreadyLoadedDependencies
+        alreadyLoadedDependencies = alreadyLoadedDependencies,
+        importHooks = importHooks
       )
     }
 
@@ -157,7 +160,8 @@ case class Main(predefCode: String = "",
         () => throw new Exception("session loading / saving not possible here"),
         replCodeWrapper,
         scriptCodeWrapper,
-        alreadyLoadedDependencies = alreadyLoadedDependencies
+        alreadyLoadedDependencies = alreadyLoadedDependencies,
+        importHooks = importHooks
       )
       interp.initializePredef() match{
         case None => Right(interp)

--- a/build.sc
+++ b/build.sc
@@ -531,3 +531,4 @@ def publishSonatype(publishArtifacts: mill.main.Tasks[PublishModule.PublishData]
       x:_*
     )
   }
+


### PR DESCRIPTION
Rather than having the import hooks hardcoded, this allows to inject them as a `Map[Seq[String], ImportHook]` from the main.

The aim at this is for ammonite's downstreams to have a mean of changing the behaviour of the import hooks. In particular, this should allow mill to inject its own version into the resolution logic, in order to avoid discrepencies of versions between mill and the loaded contrib-module / plugins 