### PR TITLE
Add back requests-scala to the classpath

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -253,7 +253,8 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
   class RuntimeModule(val crossScalaVersion: String) extends AmmModule{
     def moduleDeps = Seq(ops(), amm.util(), `interp-api`(), `repl-api`())
     def ivyDeps = Agg(
-      ivy"com.lihaoyi::upickle:0.7.5"
+      ivy"com.lihaoyi::upickle:0.7.5",
+      ivy"com.lihaoyi::requests:0.2.0"
     )
   }
 


### PR DESCRIPTION
Not technically used anywhere within Ammonite, but I find it extremely useful and use it extensively. Now that `--thin` is a thing, anyone who doesn't want it doesn't need to suffer it anyway