### PR TITLE
Allow to access byte code of in-memory classes via the api

### DIFF
--- a/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
@@ -520,5 +520,28 @@ object AdvancedTests extends TestSuite{
         @ assert(t.endsWith(".List"))
       """)
     }
+
+    test("accessInMemoryClassMap"){
+      check.session("""
+        @ class Foo
+        defined class Foo
+
+        @ val classes = {
+        @   implicitly[ammonite.repl.api.ReplAPI]
+        @     .sess
+        @     .frames
+        @     .head
+        @     .classloader
+        @     .inMemoryClasses
+        @ }
+        classes: Map[String, Array[Byte]] = ?
+
+        @ val name = classOf[Foo].getName
+        name: String = ?
+
+        @ val found = classes.contains(name)
+        found: Boolean = true
+      """)
+    }
   }
 }

--- a/amm/replApi/src/main/scala/ammonite/repl/api/Frame.scala
+++ b/amm/replApi/src/main/scala/ammonite/repl/api/Frame.scala
@@ -3,8 +3,8 @@ package ammonite.repl.api
 import java.net.URL
 
 trait Frame {
-  def classloader: ClassLoader
-  def pluginClassloader: ClassLoader
+  def classloader: ReplClassLoader
+  def pluginClassloader: ReplClassLoader
 
   def classpath: Seq[URL]
 }

--- a/amm/replApi/src/main/scala/ammonite/repl/api/ReplClassLoader.scala
+++ b/amm/replApi/src/main/scala/ammonite/repl/api/ReplClassLoader.scala
@@ -1,0 +1,8 @@
+package ammonite.repl.api
+
+import java.net.{URL, URLClassLoader}
+
+abstract class ReplClassLoader(urls: Array[URL], parent: ClassLoader)
+    extends URLClassLoader(urls, parent) {
+  def inMemoryClasses: Map[String, Array[Byte]]
+}

--- a/amm/runtime/src/main/scala/ammonite/runtime/ClassLoaders.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/ClassLoaders.scala
@@ -204,7 +204,7 @@ class SpecialClassLoader(parent: ClassLoader,
                          parentSignature: Seq[(Either[String, java.net.URL], Long)],
                          var specialLocalClasses: Set[String],
                          urls: URL*)
-  extends URLClassLoader(urls.toArray, parent){
+  extends ammonite.repl.api.ReplClassLoader(urls.toArray, parent){
 
   /**
     * Files which have been compiled, stored so that our special
@@ -323,5 +323,8 @@ class SpecialClassLoader(parent: ClassLoader,
 
      clone
   }
+
+  def inMemoryClasses: Map[String, Array[Byte]] =
+    newFileDict.toMap
 
 }

--- a/build.sc
+++ b/build.sc
@@ -43,7 +43,7 @@ trait AmmInternalModule extends mill.scalalib.CrossSbtModule{
   trait Tests extends super.Tests{
     def ivyDeps = Agg(ivy"com.lihaoyi::utest:0.7.1")
     def testFrameworks = Seq("utest.runner.Framework")
-    def forkArgs = Seq("-Xmx4g", "-Dfile.encoding=UTF8")
+    def forkArgs = Seq("-Xmx2g", "-Dfile.encoding=UTF8")
   }
   def allIvyDeps = T{transitiveIvyDeps() ++ scalaLibraryIvyDeps()}
   def externalSources = T{

--- a/integration/src/test/resources/some-dummy-library/project/build.properties
+++ b/integration/src/test/resources/some-dummy-library/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.2.8

--- a/integration/src/test/scala/ammonite/integration/BasicTests.scala
+++ b/integration/src/test/scala/ammonite/integration/BasicTests.scala
@@ -225,7 +225,7 @@ object BasicTests extends TestSuite{
           )
 
           // 2. build & publish code locally
-          os.proc("sbt", "-batch", "-no-colors", "publishLocal").call(
+          os.proc("sbt", "-J-Xmx1g", "-batch", "-no-colors", "publishLocal").call(
             env = Map(
               "SCALA_VERSION" -> scala.util.Properties.versionNumberString,
               "FIRST_RUN" -> s"$firstRun",

--- a/integration/src/test/scala/ammonite/integration/ProjectTests.scala
+++ b/integration/src/test/scala/ammonite/integration/ProjectTests.scala
@@ -54,7 +54,7 @@ object ProjectTests extends TestSuite{
 
     test("httpApi"){
       test("addPost"){
-        val res = execNonThin('basic / "HttpApi.sc", "addPost", "title", "some text")
+        val res = exec('basic / "HttpApi.sc", "addPost", "title", "some text")
         assert(res.out.trim.contains("101"))
       }
       test("comments"){

--- a/integration/src/test/scala/ammonite/integration/TestUtils.scala
+++ b/integration/src/test/scala/ammonite/integration/TestUtils.scala
@@ -33,7 +33,7 @@ object TestUtils {
       home,
       replStandaloneResources / name,
       args
-    ).call()
+    ).call(env = Map("JAVA_OPTS" -> null))
   }
   def exec(name: RelPath, args: String*) =
     execBase(name, Nil, tmp.dir(), args, thin = true)


### PR DESCRIPTION
This PR gives a more precise type to `ammonite.repl.api.Frame.classLoader`. This gives access via the api to the in-memory byte code of the repl-defined classes, that `SpecialClassLoader` has.

I'm using that from [ammonite-spark](https://github.com/alexarchambault/ammonite-spark) in particular, to pass the repl-defined classes to spark.

This is somehow a substitute to the [`-Yrepl-outdir`](https://github.com/apache/spark/blob/5264164a67df498b73facae207eda12ee133be7d/repl/src/main/scala/org/apache/spark/repl/Main.scala#L70) option of the default scala repl. Except that we directly access the byte code in memory here, rather than on disk. And no option has to be passed beforehand for that to work.