### PR TITLE
Fix interp-api and repl-api module names

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -35,7 +35,7 @@ val (buildVersion, unstable) = sys.env.get("TRAVIS_TAG") match{
 }
 
 trait AmmInternalModule extends mill.scalalib.CrossSbtModule{
-  def artifactName = "ammonite-" + millOuterCtx.segments.parts.last
+  def artifactName = "ammonite-" + millOuterCtx.segments.parts.mkString("-").stripPrefix("amm-")
   def testFramework = "utest.runner.Framework"
   def scalacOptions = Seq("-P:acyclic:force", "-target:jvm-1.7")
   def compileIvyDeps = Agg(ivy"com.lihaoyi::acyclic:0.2.0")


### PR DESCRIPTION
Both had module name [`ammonite-api`](https://repo1.maven.org/maven2/com/lihaoyi/ammonite-api_2.13.0/) before that. This changes this to `ammonite-interp-api` and `ammonite-repl-api`.