### PR TITLE
Only use coursier via coursier-interface 

### DIFF
--- a/amm/interp/api/src/main/scala/ammonite/interp/api/InterpAPI.scala
+++ b/amm/interp/api/src/main/scala/ammonite/interp/api/InterpAPI.scala
@@ -2,7 +2,7 @@ package ammonite.interp.api
 
 
 import ammonite.util.{Colors, Ref}
-import coursier.util.Task
+import coursierapi.{Dependency, Fetch, Repository}
 
 import scala.collection.mutable
 
@@ -31,14 +31,14 @@ trait InterpAPI {
   /**
    * resolvers to use when loading jars
    */
-  def repositories: Ref[List[coursier.Repository]]
+  def repositories: Ref[List[Repository]]
 
   /**
     * Functions that will be chained and called on the coursier
     * Fetch object right before they are run
     */
   val resolutionHooks: mutable.Buffer[
-    coursier.Fetch[Task] => coursier.Fetch[Task]
+    Fetch => Fetch
   ]
 
   /**
@@ -86,7 +86,7 @@ trait LoadJar {
   /**
    * Load a library from its maven/ivy coordinates
    */
-  def ivy(coordinates: coursier.Dependency*): Unit
+  def ivy(coordinates: Dependency*): Unit
 }
 
 trait InterpLoad extends LoadJar{

--- a/amm/interp/api/src/main/scala/ammonite/interp/api/IvyConstructor.scala
+++ b/amm/interp/api/src/main/scala/ammonite/interp/api/IvyConstructor.scala
@@ -1,6 +1,6 @@
 package ammonite.interp.api
 
-import coursier.core.{ModuleName, Organization}
+import coursierapi.{Dependency, Module}
 
 object IvyConstructor extends IvyConstructor {
 
@@ -19,13 +19,13 @@ object IvyConstructor extends IvyConstructor {
 }
 trait IvyConstructor{
   implicit class GroupIdExt(groupId: String){
-    def %(artifactId: String) = coursier.Module(Organization(groupId), ModuleName(artifactId))
-    def %%(artifactId: String) = coursier.Module(
-      Organization(groupId),
-      ModuleName(artifactId + "_" + IvyConstructor.scalaBinaryVersion)
+    def %(artifactId: String) = Module.of(groupId, artifactId)
+    def %%(artifactId: String) = Module.of(
+      groupId,
+      artifactId + "_" + IvyConstructor.scalaBinaryVersion
     )
   }
-  implicit class ArtifactIdExt(t: coursier.Module){
-    def %(version: String) = coursier.Dependency(t, version)
+  implicit class ArtifactIdExt(t: Module){
+    def %(version: String) = Dependency.of(t, version)
   }
 }

--- a/amm/interp/src/main/scala/ammonite/interp/Pressy.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Pressy.scala
@@ -46,6 +46,8 @@ object Pressy {
             allCode: String,
             index: Int){
 
+    val blacklistedPackages = Set("shaded")
+
     /**
      * Dumb things that turn up in the autocomplete that nobody needs or wants
      */
@@ -118,12 +120,16 @@ object Pressy {
      */
     def deepCompletion(name: String) = {
       def rec(t: pressy.Symbol): Seq[pressy.Symbol] = {
-        val children =
-          if (t.hasPackageFlag || t.isPackageObject) {
-            pressy.ask(() => t.typeSignature.members.filter(_ != t).flatMap(rec))
-          } else Nil
+        if (blacklistedPackages(t.nameString))
+          Nil
+        else {
+          val children =
+            if (t.hasPackageFlag || t.isPackageObject) {
+              pressy.ask(() => t.typeSignature.members.filter(_ != t).flatMap(rec))
+            } else Nil
 
-        t +: children.toSeq
+          t +: children.toSeq
+        }
       }
 
       for {

--- a/amm/repl/src/main/scala/ammonite/main/Defaults.scala
+++ b/amm/repl/src/main/scala/ammonite/main/Defaults.scala
@@ -4,7 +4,7 @@ package ammonite.main
 import java.io.InputStream
 
 import ammonite.util.Util
-import coursier.core.{ModuleName, Organization}
+import coursierapi.Dependency
 
 import scala.io.Codec
 
@@ -58,7 +58,7 @@ object Defaults{
 
   def alreadyLoadedDependencies(
     resourceName: String = "amm-dependencies.txt"
-  ): Seq[coursier.Dependency] = {
+  ): Seq[Dependency] = {
 
     var is: InputStream = null
 
@@ -72,7 +72,7 @@ object Defaults{
         .filter(_.nonEmpty)
         .map(l => l.split(':') match {
           case Array(org, name, ver) =>
-            coursier.Dependency(coursier.Module(Organization(org), ModuleName(name)), ver)
+            Dependency.of(org, name, ver)
           case other =>
             throw new Exception(s"Cannot parse line '$other' from resource $resourceName")
         })

--- a/amm/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -8,6 +8,7 @@ import ammonite.terminal.Filter
 import ammonite.util.Util.{newLine, normalizeNewlines}
 import ammonite.util._
 import ammonite.interp.{CodeWrapper, Interpreter, Parsers, Preprocessor}
+import coursierapi.Dependency
 
 import scala.annotation.tailrec
 
@@ -23,7 +24,7 @@ class Repl(input: InputStream,
            initialColors: Colors = Colors.Default,
            replCodeWrapper: CodeWrapper,
            scriptCodeWrapper: CodeWrapper,
-           alreadyLoadedDependencies: Seq[coursier.Dependency],
+           alreadyLoadedDependencies: Seq[Dependency],
            importHooks: Map[Seq[String], ImportHook],
            initialClassLoader: ClassLoader =
              classOf[ammonite.repl.api.ReplAPI].getClassLoader,

--- a/amm/repl/src/test/scala/ammonite/session/ProjectTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/ProjectTests.scala
@@ -72,9 +72,8 @@ object ProjectTests extends TestSuite{
               @ import $ivy.`com.ambiata::mundane:1.2.1-20141230225616-50fc792`
               error: Failed to resolve ivy dependencies
 
-              @ interp.repositories() ++= Seq(coursier.ivy.IvyRepository.fromPattern(
-              @   "https://ambiata-oss.s3-ap-southeast-2.amazonaws.com/" +:
-              @   coursier.ivy.Pattern.default
+              @ interp.repositories() ++= Seq(coursierapi.IvyRepository.of(
+              @   "https://ambiata-oss.s3-ap-southeast-2.amazonaws.com/[defaultPattern]"
               @ ))
 
               @ import $ivy.`com.ambiata::mundane:1.2.1-20141230225616-50fc792`
@@ -290,7 +289,7 @@ object ProjectTests extends TestSuite{
       check.session(
         """
         @ interp.repositories() ++= Seq(
-        @     coursier.maven.MavenRepository("https://jitpack.io")
+        @     coursierapi.MavenRepository.of("https://jitpack.io")
         @ )
 
         @ import $ivy.`com.github.vidstige:jadb:v1.0.1`
@@ -377,7 +376,7 @@ object ProjectTests extends TestSuite{
             @ interp.resolutionHooks += { fetch =>
             @   fetch.withResolutionParams(
             @     fetch
-            @       .resolutionParams
+            @       .getResolutionParams
             @       .addProfile("hadoop-3.1")
             @   )
             @ }

--- a/amm/runtime/src/main/scala/ammonite/runtime/ImportHook.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/ImportHook.scala
@@ -6,7 +6,7 @@ import java.net.URI
 import ammonite.interp.api.IvyConstructor
 import ammonite.util.Util.CodeSource
 import ammonite.util._
-import coursier.core.{ModuleName, Organization}
+import coursierapi.Dependency
 
 import scala.io.Source
 import scala.util.{Failure, Success, Try}
@@ -51,7 +51,7 @@ object ImportHook{
     * default this is what is available.
     */
   trait InterpreterInterface{
-    def loadIvy(coordinates: coursier.Dependency*): Either[String, Set[File]]
+    def loadIvy(coordinates: Dependency*): Either[String, Set[File]]
     def watch(p: os.Path): Unit
   }
 
@@ -167,27 +167,11 @@ object ImportHook{
       val splitted = for (signature <- signatures) yield {
         signature.split(':') match{
           case Array(a, b, c) =>
-            Right(coursier.Dependency(coursier.Module(Organization(a), ModuleName(b)), c))
+            Right(Dependency.of(a, b, c))
           case Array(a, "", b, c) =>
-            Right(
-              coursier.Dependency(
-                coursier.Module(
-                  Organization(a),
-                  ModuleName(b + "_" + IvyConstructor.scalaBinaryVersion)
-                ),
-                c
-              )
-            )
+            Right(Dependency.of(a, b + "_" + IvyConstructor.scalaBinaryVersion, c))
           case Array(a, "", "", b, c) =>
-            Right(
-              coursier.Dependency(
-                coursier.Module(
-                  Organization(a),
-                  ModuleName(b + "_" + IvyConstructor.scalaFullBinaryVersion)
-                ),
-                c
-              )
-            )
+            Right(Dependency.of(a, b + "_" + IvyConstructor.scalaFullBinaryVersion, c))
           case _ => Left(signature)
         }
       }

--- a/amm/src/main/scala/ammonite/Main.scala
+++ b/amm/src/main/scala/ammonite/Main.scala
@@ -13,6 +13,7 @@ import ammonite.util._
 
 import scala.annotation.tailrec
 import ammonite.runtime.ImportHook
+import coursierapi.Dependency
 
 
 
@@ -69,7 +70,7 @@ case class Main(predefCode: String = "",
                 colors: Colors = Colors.Default,
                 replCodeWrapper: CodeWrapper = CodeWrapper,
                 scriptCodeWrapper: CodeWrapper = CodeWrapper,
-                alreadyLoadedDependencies: Seq[coursier.Dependency] =
+                alreadyLoadedDependencies: Seq[Dependency] =
                   Defaults.alreadyLoadedDependencies(),
                 importHooks: Map[Seq[String], ImportHook] = ImportHook.defaults,
                 classPathWhitelist: Set[Seq[String]] = Set.empty){

--- a/amm/src/test/resources/scripts/Resolvers.sc
+++ b/amm/src/test/resources/scripts/Resolvers.sc
@@ -1,6 +1,5 @@
-interp.repositories() ++= Seq(coursier.ivy.IvyRepository.fromPattern(
-  "https://ambiata-oss.s3-ap-southeast-2.amazonaws.com/" +:
-    coursier.ivy.Pattern.default
+interp.repositories() ++= Seq(coursierapi.IvyRepository.of(
+  "https://ambiata-oss.s3-ap-southeast-2.amazonaws.com/[defaultPattern]"
 ))
 
 @

--- a/amm/src/test/resources/scripts/ResolversFail.sc
+++ b/amm/src/test/resources/scripts/ResolversFail.sc
@@ -1,6 +1,5 @@
-interp.repositories() ++= Seq(coursier.ivy.IvyRepository.fromPattern(
-  "https://ambiata-oss.s3-ap-southeast-2.amazonaws.com/" +:
-    coursier.ivy.Pattern.default
+interp.repositories() ++= Seq(coursierapi.IvyRepository.of(
+  "https://ambiata-oss.s3-ap-southeast-2.amazonaws.com/[defaultPattern]"
 ))
 
 import $ivy.`com.ambiata::mundane:1.2.1-20141230225616-50fc792`

--- a/amm/src/test/resources/scripts/loadIvyAdvanced.sc
+++ b/amm/src/test/resources/scripts/loadIvyAdvanced.sc
@@ -1,11 +1,12 @@
-import coursier.dependencyString
+import coursierapi.Dependency
 
 interp.load.ivy(
   // Using SBT-style syntax
   "xom" % "xom" % "1.1",
   // Directly using coursier API. Can pass in exclusions,
   // attributes, configurations, classifiers, etc.
-  dep"net.sf.json-lib:json-lib:2.4,classifier=jdk15"
+  Dependency.of("net.sf.json-lib", "json-lib", "2.4")
+    .withClassifier("jdk15")
 )
 
 @

--- a/build.sc
+++ b/build.sc
@@ -158,7 +158,7 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
       def ivyDeps = Agg(
         ivy"org.scala-lang:scala-compiler:$crossScalaVersion",
         ivy"org.scala-lang:scala-reflect:$crossScalaVersion",
-        ivy"io.get-coursier::coursier:2.0.0-RC2"
+        ivy"io.get-coursier:interface:0.0.8"
       )
     }
   }
@@ -169,7 +169,8 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
       ivy"org.scala-lang:scala-compiler:$crossScalaVersion",
       ivy"org.scala-lang:scala-reflect:$crossScalaVersion",
       ivy"com.lihaoyi::scalaparse:2.1.3",
-      ivy"org.javassist:javassist:3.21.0-GA"
+      ivy"org.javassist:javassist:3.21.0-GA",
+      ivy"org.scala-lang.modules::scala-xml:1.2.0"
     )
   }
 

--- a/build.sc
+++ b/build.sc
@@ -2,8 +2,6 @@ import mill._, scalalib._, publish._
 import ammonite.ops._, ImplicitWd._
 import $file.ci.upload
 
-import $ivy.`io.get-coursier::coursier-bootstrap:2.0.0-RC2-4+5-6ccc572b`
-
 val isMasterCommit =
   sys.env.get("TRAVIS_PULL_REQUEST") == Some("false") &&
   (sys.env.get("TRAVIS_BRANCH") == Some("master") || sys.env("TRAVIS_TAG") != "")


### PR DESCRIPTION
This PR replaces `io.get-coursier::coursier` by `io.get-coursier:interface` (living [there](https://github.com/coursier/interface)), which provides a stripped down coursier API and has no dependency (thanks to shading / proguarding).

This allows to remove the dependencies towards:
- shapeless,
- argonaut,
- argonaut-shapeless,
- scala-xml (only when `--thin` is passed for that one).

This changes a little bit how custom dependencies can be loaded with written-down `coursier.Dependency`, like
```
@ interp.load.ivy(coursierapi.Dependency.of("org", "name", "ver").withClassifier("classifier"))
```
instead of
```
@ import coursier._
@ interp.load.ivy(dep"org:name:ver".copy(attributes = Attributes(classifier = Classifier("classifier"))))
```