### PR TITLE
Tweak ivy cache

### DIFF
--- a/amm/repl/src/test/scala/ammonite/session/ProjectTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/ProjectTests.scala
@@ -457,6 +457,50 @@ object ProjectTests extends TestSuite{
       }
     }
 
+    test("extra artifact types"){
+      val core =
+        """
+            @ import $ivy.`com.almworks.sqlite4java:libsqlite4java-linux-amd64:1.0.392`
+
+            @ val cp = {
+            @   repl.sess
+            @     .frames
+            @     .flatMap(_.classpath)
+            @     .map(_.toString)
+            @ }
+            cp: List[String] = ?
+
+            @ def soFound() = cp.exists(_.endsWith("/libsqlite4java-linux-amd64-1.0.392.so"))
+            defined function soFound
+        """
+
+      test("default"){
+        check.session(
+          s"""
+            $core
+
+            @ val soFound0 = soFound()
+            soFound0: Boolean = false
+           """
+        )
+      }
+
+      test("with so"){
+        check.session(
+          s"""
+            @ interp.resolutionHooks += { fetch =>
+            @   fetch.addArtifactTypes("so")
+            @ }
+
+            $core
+
+            @ val soFound0 = soFound()
+            soFound0: Boolean = true
+           """
+        )
+      }
+    }
+
   }
 }
 

--- a/amm/src/main/scala/ammonite/Main.scala
+++ b/amm/src/main/scala/ammonite/Main.scala
@@ -467,7 +467,7 @@ class MainRunner(cliConfig: Cli.Config,
       replCodeWrapper = codeWrapper,
       scriptCodeWrapper = codeWrapper,
       alreadyLoadedDependencies =
-        if(cliConfig.thin) Nil else Defaults.alreadyLoadedDependencies(),
+        Defaults.alreadyLoadedDependencies(),
       classPathWhitelist = ammonite.repl.Repl.getClassPathWhitelist(cliConfig.thin)
 
     )

--- a/build.sc
+++ b/build.sc
@@ -254,7 +254,7 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
 }
 
 class MainModule(val crossScalaVersion: String)
-  extends AmmModule with AmmDependenciesResourceFileModule {
+  extends AmmModule {
 
   def artifactName = "ammonite"
 
@@ -282,8 +282,6 @@ class MainModule(val crossScalaVersion: String)
     amm.repl().sources() ++
     sources() ++
     externalSources()
-
-  def dependencyResourceFileName = "amm-dependencies.txt"
 
   def prependShellScript = T{
     mill.modules.Jvm.launcherUniversalScript(


### PR DESCRIPTION
This PR adds tests illustrating how:
- not to fetch source JARs (https://github.com/lihaoyi/Ammonite/issues/763#issuecomment-495812048)
- fetch artifacts with fancy types (`so` - https://github.com/lihaoyi/Ammonite/issues/988, …)

Both rely on "resolution hooks" (`interp.resolutionHooks += { fetch => /* customize coursierapi.Fetch instance */ }`), added some time ago.

This required a small fix to work well (ensuring we don't check from and write results to the ivy cache if some resolution hooks were added, as the possible tweaks from resolution hooks aren't reflected in the ivy cache key - and I'm not sure adding them to the cache key is worth the hassle…).