### PR TITLE
Full cross scala version for runtime

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -156,9 +156,10 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
     )
   }
 
-  object runtime extends Cross[RuntimeModule](binCrossScalaVersions:_*)
+  object runtime extends Cross[RuntimeModule](fullCrossScalaVersions:_*)
   class RuntimeModule(val crossScalaVersion: String) extends AmmModule{
     def moduleDeps = Seq(ops(), amm.util(), interp.api(), amm.repl.api())
+    def crossFullScalaVersion = true
     def ivyDeps = Agg(
       ivy"com.lihaoyi::upickle:0.7.5",
       ivy"com.lihaoyi::requests:0.2.0"


### PR DESCRIPTION
It depends on interp-api, that is fully cross-versioned, so it should be fully cross-versioned itself too.

Without this, `com.lihaoy:ammonite-runtime_2.12` depends on `com.lihaoyi:ammonite-repl-api_2.12.9`, which makes `com.lihaoyi:ammonite_2.12.8` pulls both `com.lihaoy:ammonite-repl-api_2.12.8` and `com.lihaoy:ammonite-repl-api_2.12.9`.