### PR TITLE
bug fix

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -653,7 +653,8 @@ def publishSonatype(publishArtifacts: mill.main.Tasks[PublishModule.PublishData]
       true,
       60000,
       60000,
-      T.ctx().log
+      T.ctx().log,
+      120000
     ).publishAll(
       true,
       x:_*


### PR DESCRIPTION
```
build.sc:647: not enough arguments for constructor SonatypePublisher: (uri: String, snapshotUri: String, credentials: String, gpgPassphrase: Option[String], gpgKeyName: Option[String], signed: Boolean, readTimeout: Int, connectTimeout: Int, log: mill.api.Logger, awaitTimeout: Int)mill.scalalib.publish.SonatypePublisher.
```
fix API change introduced in lihaoyi/mill#652