### PR TITLE
Update scala-collection-compat to fix jdk.CollectionConverters issue

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -133,7 +133,7 @@ object ops extends Cross[OpsModule](binCrossScalaVersions:_*)
 class OpsModule(val crossScalaVersion: String) extends AmmModule{
   def ivyDeps = Agg(
     ivy"com.lihaoyi::os-lib:0.3.0",
-    ivy"org.scala-lang.modules::scala-collection-compat:2.0.0"
+    ivy"org.scala-lang.modules::scala-collection-compat:2.1.2"
   )
   def scalacOptions = super.scalacOptions().filter(!_.contains("acyclic"))
   object test extends Tests


### PR DESCRIPTION
Improve cross scala releases support within ammonite for libraries relying on `org.scala-lang.modules::scala-collection-compat` which bring back some scala 2.13 scala collection feature to scala release 2.11 and 2.12. 