### PR TITLE
Bump os-lib, upickle, requests versions

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -132,7 +132,7 @@ trait AmmDependenciesResourceFileModule extends JavaModule{
 object ops extends Cross[OpsModule](binCrossScalaVersions:_*)
 class OpsModule(val crossScalaVersion: String) extends AmmModule{
   def ivyDeps = Agg(
-    ivy"com.lihaoyi::os-lib:0.4.2",
+    ivy"com.lihaoyi::os-lib:0.5.0",
     ivy"org.scala-lang.modules::scala-collection-compat:2.1.2"
   )
   def scalacOptions = super.scalacOptions().filter(!_.contains("acyclic"))
@@ -170,8 +170,8 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
     def moduleDeps = Seq(ops(), amm.util(), interp.api(), amm.repl.api())
     def crossFullScalaVersion = true
     def ivyDeps = Agg(
-      ivy"com.lihaoyi::upickle:0.8.0",
-      ivy"com.lihaoyi::requests:0.2.0"
+      ivy"com.lihaoyi::upickle:0.9.0",
+      ivy"com.lihaoyi::requests:0.3.0"
     )
   }
 

--- a/ops/src/test/scala/test/ammonite/ops/OpTests.scala
+++ b/ops/src/test/scala/test/ammonite/ops/OpTests.scala
@@ -242,7 +242,7 @@ object OpTests extends TestSuite{
         test("concatenating"){
           write(d/'concat1, Seq("a", "b", "c"))
           assert(read(d/'concat1) == "abc")
-          write(d/'concat2, Array(Array[Byte](1, 2), Array[Byte](3, 4)))
+          write(d/'concat2, Seq(Array[Byte](1, 2), Array[Byte](3, 4)))
           assert(read.bytes(d/'concat2).toSeq == Array[Byte](1, 2, 3, 4).toSeq)
         }
         test("writeAppend"){


### PR DESCRIPTION
This brings in the new standardization on [geny.Writable](https://github.com/lihaoyi/geny#writable), allowing much more seamless interop between the various libraries