### PR TITLE
Bump coursier

### DIFF
--- a/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
@@ -615,12 +615,11 @@ class Interpreter(val printer: Printer,
           hooks = resolutionHooks.toSeq
         )match{
           case Right((canBeCached, loaded)) =>
-            val loadedSet = loaded.toSet
             if (canBeCached)
               storage.ivyCache() = storage.ivyCache().updated(
-                cacheKey, loadedSet.map(_.getAbsolutePath)
+                cacheKey, loaded.map(_.getAbsolutePath)
               )
-            Right(loadedSet)
+            Right(loaded)
           case Left(l) =>
             Left(l)
         }

--- a/amm/interp/src/main/scala/ammonite/interp/IvyThing.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/IvyThing.scala
@@ -16,11 +16,13 @@ object IvyThing{
     val cache = Cache.create()
       .withLogger(if (verbose) Logger.progressBars() else Logger.nop)
     val sv = scala.util.Properties.versionNumberString
+    val sbv = sv.split('.').take(2).mkString(".")
 
     s =>
       val res = coursierapi.Complete.create()
         .withCache(cache)
         .withScalaVersion(sv)
+        .withScalaBinaryVersion(sbv)
         .withInput(s)
         .complete()
       (res.getFrom, res.getCompletions.asScala.toVector)

--- a/amm/runtime/src/main/scala/ammonite/runtime/ImportHook.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/ImportHook.scala
@@ -51,7 +51,7 @@ object ImportHook{
     * default this is what is available.
     */
   trait InterpreterInterface{
-    def loadIvy(coordinates: Dependency*): Either[String, Set[File]]
+    def loadIvy(coordinates: Dependency*): Either[String, Seq[File]]
     def watch(p: os.Path): Unit
   }
 

--- a/amm/runtime/src/main/scala/ammonite/runtime/Storage.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/Storage.scala
@@ -35,7 +35,7 @@ trait Storage{
 
 object Storage{
   case class CompileCache(classFiles: Vector[(String, Array[Byte])], imports: Imports)
-  type IvyMap = Map[(String, Seq[Dependency]), Set[String]]
+  type IvyMap = Map[(String, Seq[Dependency]), Seq[String]]
 
   private final case class DependencyLike(
     module: DependencyLike.ModuleLike,

--- a/build.sc
+++ b/build.sc
@@ -185,7 +185,7 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
       def ivyDeps = Agg(
         ivy"org.scala-lang:scala-compiler:$crossScalaVersion",
         ivy"org.scala-lang:scala-reflect:$crossScalaVersion",
-        ivy"io.get-coursier:interface:0.0.8"
+        ivy"io.get-coursier:interface:0.0.21"
       )
     }
   }


### PR DESCRIPTION
This bumps the coursier-interface version. An extra commit also makes sure we preserve the order of the JARs returned by coursier, now that coursier returns them in a deterministic order by default.