### PR TITLE
Remove unnecessary element in cache key

### DIFF
--- a/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
@@ -594,7 +594,7 @@ class Interpreter(val printer: Printer,
 
   def loadIvy(coordinates: Dependency*) = synchronized{
     val cacheKey = (
-      interpApi.repositories().hashCode.toString + classPathWhitelist.hashCode().toString,
+      interpApi.repositories().hashCode.toString,
       coordinates
     )
 


### PR DESCRIPTION
There's no point in hashing `classPathWhilelist` there, as it's not used during resolution.