### PR TITLE
Don't go through compiler to add bridge imports

### DIFF
--- a/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
@@ -112,10 +112,15 @@ class Interpreter(val printer: Printer,
   // Needs to be run after the Interpreter has been instantiated, as some of the
   // ReplAPIs available in the predef need access to the Interpreter object
   def initializePredef(): Option[(Res.Failing, Seq[(os.Path, Long)])] = {
-    PredefInitialization.apply(
+
+    val bridgeImports = PredefInitialization.initBridges(
       ("ammonite.interp.api.InterpBridge", "interp", interpApi) +: extraBridges,
+      evalClassloader
+    )
+    predefImports = predefImports ++ bridgeImports
+
+    PredefInitialization.apply(
       interpApi,
-      evalClassloader,
       storage,
       basePredefs,
       customPredefs,

--- a/amm/interp/src/main/scala/ammonite/interp/PredefInitialization.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/PredefInitialization.scala
@@ -4,7 +4,7 @@ package ammonite.interp
 import ammonite.interp.api.{APIHolder, InterpAPI}
 import ammonite.runtime.{SpecialClassLoader, Storage}
 import ammonite.util.ScriptOutput.Metadata
-import ammonite.util.{Imports, Name, PredefInfo, Res}
+import ammonite.util.{ImportData, Imports, Name, PredefInfo, Res}
 import ammonite.util.Util.CodeSource
 
 /**
@@ -22,9 +22,27 @@ object PredefInitialization {
       .get
       .invoke(null, t)
   }
-  def apply(bridges: Seq[(String, String, AnyRef)],
-            interpApi: InterpAPI,
-            evalClassloader: SpecialClassLoader,
+  def initBridges(bridges: Seq[(String, String, AnyRef)],
+                  evalClassloader: SpecialClassLoader): Imports = {
+
+    for ((name, shortName, bridge) <- bridges)
+      initBridge(evalClassloader, name, bridge)
+
+    val allImports =
+      for ((name, shortName, _) <- bridges)
+        yield Imports(
+          Seq(ImportData(
+            Name("value"),
+            Name(shortName),
+            // FIXME Not sure special chars / backticked things in name are fine here
+            Name("_root_") +: name.stripPrefix("_root_.").split('.').map(Name(_)).toSeq,
+            ImportData.Term
+          ))
+        )
+
+    allImports.foldLeft(Imports())(_ ++ _)
+  }
+  def apply(interpApi: InterpAPI,
             storage: Storage,
             basePredefs: Seq[PredefInfo],
             customPredefs: Seq[PredefInfo],
@@ -32,23 +50,7 @@ object PredefInitialization {
             addImports: Imports => Unit,
             watch: os.Path => Unit): Res[_] = {
 
-    for ((name, shortName, bridge) <- bridges ){
-      initBridge(evalClassloader, name, bridge)
-    }
-
-    // import ammonite.repl.api.ReplBridge.{value => repl}
-    // import ammonite.interp.api.InterpBridge.{value => interp}
-    val bridgePredefs =
-      for ((name, shortName, bridge) <- bridges)
-      yield PredefInfo(
-        Name(s"${shortName}Bridge"),
-        s"import $name.{value => $shortName}",
-        true,
-        None
-      )
-
     val predefs = {
-      bridgePredefs ++
       basePredefs ++
       storage.loadPredef.map{
         case (code, path) =>

--- a/amm/src/test/scala/ammonite/interp/CachingTests.scala
+++ b/amm/src/test/scala/ammonite/interp/CachingTests.scala
@@ -37,16 +37,16 @@ object CachingTests extends TestSuite{
         val interp = createTestInterp(storage)
         val n0 = storage.compileCache.size
 
-        assert(n0 == 1) // customLolz predef
+        assert(n0 == 0)
         Scripts.runScript(os.pwd, scriptPath/fileName, interp)
 
         val n = storage.compileCache.size
         assert(n == expected)
 
       }
-      test - check("OneBlock.sc", 2)
-      test - check("TwoBlocks.sc", 3)
-      test - check("ThreeBlocks.sc", 4)
+      test - check("OneBlock.sc", 1)
+      test - check("TwoBlocks.sc", 2)
+      test - check("ThreeBlocks.sc", 3)
     }
 
     test("processModuleCaching"){
@@ -127,7 +127,7 @@ object CachingTests extends TestSuite{
       Scripts.runScript(os.pwd, scriptPath/"OneBlock.sc", interp2)
       val n1 = interp1.compilationCount
       val n2 = interp2.compilationCount
-      assert(n1 == 2) // customLolz predef + OneBlock.sc
+      assert(n1 == 1) // OneBlock.sc
       assert(n2 == 0) // both should be cached
     }
     test("tags"){
@@ -139,7 +139,7 @@ object CachingTests extends TestSuite{
       interp.loadIvy("com.lihaoyi" %% "scalatags" % "0.7.0")
       Scripts.runScript(os.pwd, scriptPath/"TagBase.sc", interp)
       val n = storage.compileCache.size
-      assert(n == 5) // customLolz predef + two blocks for each loaded file
+      assert(n == 4) // two blocks for each loaded file
     }
 
     test("compilerInit"){
@@ -245,8 +245,8 @@ object CachingTests extends TestSuite{
         )
 
 
-        // Upstream, downstream, and hardcoded predef
-        runScript(downstream, 3)
+        // Upstream, downstream
+        runScript(downstream, 2)
         runScript(downstream, 0)
         runScript(downstream, 0)
 
@@ -361,9 +361,9 @@ object CachingTests extends TestSuite{
         )
 
 
-        // predefs + upstream + middleA + middleB + downstream
+        // upstream + middleA + middleB + downstream
         // ensure we don't compile `upstream` twice when it's depended upon twice
-        runScript(downstream, 5)
+        runScript(downstream, 4)
         runScript(downstream, 0)
         runScript(downstream, 0)
 


### PR DESCRIPTION
This saves a few "Compiling…" steps when starting Ammonite with an empty cache.