### PR TITLE
Simplify Interpreter creation…

### DIFF
--- a/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
@@ -25,8 +25,6 @@ import coursierapi.{Dependency, Fetch}
  */
 class Interpreter(val printer: Printer,
                   val storage: Storage,
-                  basePredefs: Seq[PredefInfo],
-                  customPredefs: Seq[PredefInfo],
                   // Allows you to set up additional "bridges" between the REPL
                   // world and the outside world, by passing in the full name
                   // of the `APIHolder` object that will hold the bridge and
@@ -111,7 +109,10 @@ class Interpreter(val printer: Printer,
 
   // Needs to be run after the Interpreter has been instantiated, as some of the
   // ReplAPIs available in the predef need access to the Interpreter object
-  def initializePredef(): Option[(Res.Failing, Seq[(os.Path, Long)])] = {
+  def initializePredef(
+    basePredefs: Seq[PredefInfo],
+    customPredefs: Seq[PredefInfo]
+  ): Option[(Res.Failing, Seq[(os.Path, Long)])] = {
 
     val bridgeImports = PredefInitialization.initBridges(
       ("ammonite.interp.api.InterpBridge", "interp", interpApi) +: extraBridges,

--- a/amm/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -72,8 +72,6 @@ class Repl(input: InputStream,
   val interp: Interpreter = new Interpreter(
     printer,
     storage,
-    basePredefs,
-    customPredefs,
     Seq(
       (
         "ammonite.repl.ReplBridge",
@@ -139,7 +137,7 @@ class Repl(input: InputStream,
     classPathWhitelist = classPathWhitelist
   )
 
-  def initializePredef() = interp.initializePredef()
+  def initializePredef() = interp.initializePredef(basePredefs, customPredefs)
 
   def warmup() = {
     // An arbitrary input, randomized to make sure it doesn't get cached or

--- a/amm/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -69,61 +69,9 @@ class Repl(input: InputStream,
 
   def usedEarlierDefinitions = frames().head.usedEarlierDefinitions
 
-  val interp: Interpreter = new Interpreter(
+  val interp = new Interpreter(
     printer,
     storage,
-    Seq(
-      (
-        "ammonite.repl.ReplBridge",
-        "repl",
-        new ReplApiImpl {
-          def replArgs0 = repl.replArgs
-          def printer = repl.printer
-          val colors = repl.colors
-          def sess = repl.sess0
-          val prompt = repl.prompt
-          val frontEnd = repl.frontEnd
-
-          def lastException = repl.lastException
-          def fullHistory = storage.fullHistory()
-          def history = repl.history
-          def newCompiler() = interp.compilerManager.init(force = true)
-          def compiler = interp.compilerManager.compiler.compiler
-          def interactiveCompiler = interp.compilerManager.pressy.compiler
-          def fullImports = repl.fullImports
-          def imports = repl.imports
-          def usedEarlierDefinitions = repl.usedEarlierDefinitions
-          def width = frontEnd().width
-          def height = frontEnd().height
-
-          object load extends ReplLoad with (String => Unit){
-
-            def apply(line: String) = {
-              interp.processExec(line, currentLine, () => currentLine += 1) match{
-                case Res.Failure(s) => throw new CompilationError(s)
-                case Res.Exception(t, s) => throw t
-                case _ =>
-              }
-            }
-
-            def exec(file: os.Path): Unit = {
-              interp.watch(file)
-              apply(normalizeNewlines(os.read(file)))
-            }
-          }
-        }
-      ),
-      (
-        "ammonite.repl.api.SourceBridge",
-        "source",
-        new SourceAPIImpl {}
-      ),
-      (
-        "ammonite.repl.api.FrontEndBridge",
-        "frontEnd",
-        new FrontEndAPIImpl {}
-      )
-    ),
     wd,
     colors,
     verboseOutput = true,
@@ -137,7 +85,60 @@ class Repl(input: InputStream,
     classPathWhitelist = classPathWhitelist
   )
 
-  def initializePredef() = interp.initializePredef(basePredefs, customPredefs)
+  val bridges = Seq(
+    (
+      "ammonite.repl.ReplBridge",
+      "repl",
+      new ReplApiImpl {
+        def replArgs0 = repl.replArgs
+        def printer = repl.printer
+        val colors = repl.colors
+        def sess = repl.sess0
+        val prompt = repl.prompt
+        val frontEnd = repl.frontEnd
+
+        def lastException = repl.lastException
+        def fullHistory = storage.fullHistory()
+        def history = repl.history
+        def newCompiler() = interp.compilerManager.init(force = true)
+        def compiler = interp.compilerManager.compiler.compiler
+        def interactiveCompiler = interp.compilerManager.pressy.compiler
+        def fullImports = repl.fullImports
+        def imports = repl.imports
+        def usedEarlierDefinitions = repl.usedEarlierDefinitions
+        def width = frontEnd().width
+        def height = frontEnd().height
+
+        object load extends ReplLoad with (String => Unit){
+
+          def apply(line: String) = {
+            interp.processExec(line, currentLine, () => currentLine += 1) match{
+              case Res.Failure(s) => throw new CompilationError(s)
+              case Res.Exception(t, s) => throw t
+              case _ =>
+            }
+          }
+
+          def exec(file: os.Path): Unit = {
+            interp.watch(file)
+            apply(normalizeNewlines(os.read(file)))
+          }
+        }
+      }
+    ),
+    (
+      "ammonite.repl.api.SourceBridge",
+      "source",
+      new SourceAPIImpl {}
+    ),
+    (
+      "ammonite.repl.api.FrontEndBridge",
+      "frontEnd",
+      new FrontEndAPIImpl {}
+    )
+  )
+
+  def initializePredef() = interp.initializePredef(basePredefs, customPredefs, bridges)
 
   def warmup() = {
     // An arbitrary input, randomized to make sure it doesn't get cached or

--- a/amm/repl/src/test/scala/ammonite/TestRepl.scala
+++ b/amm/repl/src/test/scala/ammonite/TestRepl.scala
@@ -55,22 +55,23 @@ class TestRepl {
   val frames = Ref(List(Frame.createInitial(initialClassLoader)))
   val sess0 = new SessionApiImpl(frames)
 
+  val basePredefs = Seq(
+    PredefInfo(
+      Name("defaultPredef"),
+      ammonite.main.Defaults.replPredef + ammonite.main.Defaults.predefString,
+      true,
+      None
+    ),
+    PredefInfo(Name("testPredef"), predef._1, false, predef._2)
+  )
+  val customPredefs = Seq()
+
   var currentLine = 0
   val interp: Interpreter = try {
     new Interpreter(
       printer0,
       storage = storage,
       wd = os.pwd,
-      basePredefs = Seq(
-        PredefInfo(
-          Name("defaultPredef"),
-          ammonite.main.Defaults.replPredef + ammonite.main.Defaults.predefString,
-          true,
-          None
-        ),
-        PredefInfo(Name("testPredef"), predef._1, false, predef._2)
-      ),
-      customPredefs = Seq(),
       extraBridges = Seq(
         (
           "ammonite.TestReplBridge",
@@ -166,7 +167,7 @@ class TestRepl {
   }
 
 
-  for ((error, _) <- interp.initializePredef()) {
+  for ((error, _) <- interp.initializePredef(basePredefs, customPredefs)) {
     val (msgOpt, causeOpt) = error match {
       case r: Res.Exception => (Some(r.msg), Some(r.t))
       case r: Res.Failure => (Some(r.msg), None)

--- a/amm/repl/src/test/scala/ammonite/TestUtils.scala
+++ b/amm/repl/src/test/scala/ammonite/TestUtils.scala
@@ -24,7 +24,6 @@ object TestUtils {
       ),
       storage = storage,
       wd = os.pwd,
-      extraBridges = Seq(),
       colors = Ref(Colors.BlackWhite),
       getFrame = () => startFrame,
       createFrame = () => throw new Exception("unsupported"),
@@ -36,7 +35,7 @@ object TestUtils {
       classPathWhitelist = ammonite.repl.Repl.getClassPathWhitelist(thin = true)
     )
     // Provide a custom predef so we can verify in tests that the predef gets cached
-    interp.initializePredef(Seq(), Seq(PredefInfo(Name("predef"), predef, false, None)))
+    interp.initializePredef(Seq(), Seq(PredefInfo(Name("predef"), predef, false, None)), Seq())
     interp
   }
 }

--- a/amm/repl/src/test/scala/ammonite/TestUtils.scala
+++ b/amm/repl/src/test/scala/ammonite/TestUtils.scala
@@ -24,11 +24,6 @@ object TestUtils {
       ),
       storage = storage,
       wd = os.pwd,
-      // Provide a custom predef so we can verify in tests that the predef gets cached
-      basePredefs = Seq(),
-      customPredefs = Seq(
-        PredefInfo(Name("predef"), predef, false, None)
-      ),
       extraBridges = Seq(),
       colors = Ref(Colors.BlackWhite),
       getFrame = () => startFrame,
@@ -40,7 +35,8 @@ object TestUtils {
       importHooks = ImportHook.defaults,
       classPathWhitelist = ammonite.repl.Repl.getClassPathWhitelist(thin = true)
     )
-    interp.initializePredef()
+    // Provide a custom predef so we can verify in tests that the predef gets cached
+    interp.initializePredef(Seq(), Seq(PredefInfo(Name("predef"), predef, false, None)))
     interp
   }
 }

--- a/amm/src/main/scala/ammonite/Main.scala
+++ b/amm/src/main/scala/ammonite/Main.scala
@@ -154,15 +154,15 @@ case class Main(predefCode: String = "",
       )
       val frame = Frame.createInitial(initialClassLoader)
 
+      val basePredefs = Seq(
+        PredefInfo(Name("DefaultPredef"), augmentedPredef, false, None)
+      )
+      val customPredefs = predefFileInfoOpt.toSeq ++ Seq(
+        PredefInfo(Name("CodePredef"), predefCode, false, None)
+      )
       val interp: Interpreter = new Interpreter(
         printer,
         storageBackend,
-        basePredefs = Seq(
-          PredefInfo(Name("DefaultPredef"), augmentedPredef, false, None)
-        ),
-        predefFileInfoOpt.toSeq ++ Seq(
-          PredefInfo(Name("CodePredef"), predefCode, false, None)
-        ),
         Seq(
           (
             "ammonite.repl.api.SourceBridge",
@@ -187,7 +187,7 @@ case class Main(predefCode: String = "",
         importHooks = importHooks,
         classPathWhitelist = classPathWhitelist
       )
-      interp.initializePredef() match{
+      interp.initializePredef(basePredefs, customPredefs) match{
         case None => Right(interp)
         case Some(problems) => Left(problems)
       }

--- a/amm/src/main/scala/ammonite/Main.scala
+++ b/amm/src/main/scala/ammonite/Main.scala
@@ -160,21 +160,9 @@ case class Main(predefCode: String = "",
       val customPredefs = predefFileInfoOpt.toSeq ++ Seq(
         PredefInfo(Name("CodePredef"), predefCode, false, None)
       )
-      val interp: Interpreter = new Interpreter(
+      val interp = new Interpreter(
         printer,
         storageBackend,
-        Seq(
-          (
-            "ammonite.repl.api.SourceBridge",
-            "source",
-            new SourceAPIImpl {}
-          ),
-          (
-            "ammonite.repl.api.FrontEndBridge",
-            "frontEnd",
-            new FrontEndAPIImpl {}
-          )
-        ),
         wd,
         colorsRef,
         verboseOutput,
@@ -187,7 +175,19 @@ case class Main(predefCode: String = "",
         importHooks = importHooks,
         classPathWhitelist = classPathWhitelist
       )
-      interp.initializePredef(basePredefs, customPredefs) match{
+      val bridges = Seq(
+        (
+          "ammonite.repl.api.SourceBridge",
+          "source",
+          new SourceAPIImpl {}
+        ),
+        (
+          "ammonite.repl.api.FrontEndBridge",
+          "frontEnd",
+          new FrontEndAPIImpl {}
+        )
+      )
+      interp.initializePredef(basePredefs, customPredefs, bridges) match{
         case None => Right(interp)
         case Some(problems) => Left(problems)
       }


### PR DESCRIPTION
…by passing bridges and predefs only to its `initializePredef` method. They're only used there.

That simplifies `Interpreter` creation by avoiding having to reference the interpreter instance when we create it, like
```scala
// before
val interp: Interpreter = // type annotation required
  new Interpreter(
    predefs = …,
    bridges = Seq(
      // reference interp to build bridges
    )
  )
interp.initializePredefs()

// after
val interp = // no type annotation needed
  new Interpreter(
    …
  )
val bridges = Seq(
  // use interp…
)
interp.initializePredefs(predefs, bridges)

```