### PR TITLE
Add ability to watch arbitrary expressions in scripts

### DIFF
--- a/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
@@ -66,7 +66,7 @@ class Interpreter(val printer: Printer,
 
   private var scriptImportCallback: Imports => Unit = handleImports
 
-  val watchedFiles = mutable.Buffer.empty[(os.Path, Long)]
+  val watchedValues = mutable.Buffer.empty[(() => Long, Long)]
 
   // We keep an *in-memory* cache of scripts, in additional to the global
   // filesystem cache shared between processes. This is because the global
@@ -103,7 +103,7 @@ class Interpreter(val printer: Printer,
     // running, so you can use them predef to e.g. configure
     // the REPL before it starts
     extraBridges: Seq[(String, String, AnyRef)]
-  ): Option[(Res.Failing, Seq[(os.Path, Long)])] = {
+  ): Option[(Res.Failing, Seq[(() => Long, Long)])] = {
 
     headFrame.classloader.specialLocalClasses ++= Seq(
       "ammonite.interp.api.InterpBridge",
@@ -135,15 +135,18 @@ class Interpreter(val printer: Printer,
     ) match{
       case Res.Success(_) => None
       case Res.Skip => None
-      case r @ Res.Exception(t, s) => Some((r, watchedFiles.toSeq))
-      case r @ Res.Failure(s) => Some((r, watchedFiles.toSeq))
-      case r @ Res.Exit(_) => Some((r, watchedFiles.toSeq))
+      case r @ Res.Exception(t, s) => Some((r, watchedValues.toSeq))
+      case r @ Res.Failure(s) => Some((r, watchedValues.toSeq))
+      case r @ Res.Exit(_) => Some((r, watchedValues.toSeq))
     }
   }
 
   // The ReplAPI requires some special post-Interpreter-initialization
   // code to run, so let it pass it in a callback and we'll run it here
-  def watch(p: os.Path) = watchedFiles.append(p -> Interpreter.pathSignature(p))
+  def watch(p: os.Path) = watchedValues.append(
+    (() => Interpreter.pathSignature(p), Interpreter.pathSignature(p))
+  )
+  def watchValue[T](v: => T) = watchedValues.append((() => v.hashCode, v.hashCode()))
 
   def resolveSingleImportHook(
     source: CodeSource,
@@ -662,6 +665,7 @@ class Interpreter(val printer: Printer,
     val colors = interp.colors
 
     def watch(p: os.Path) = interp.watch(p)
+    def watchValue[T](v: => T): T = {interp.watchValue(v); v}
 
     def configureCompiler(callback: scala.tools.nsc.Global => Unit) = {
       compilerManager.configureCompiler(callback)

--- a/amm/src/main/scala/ammonite/Main.scala
+++ b/amm/src/main/scala/ammonite/Main.scala
@@ -79,7 +79,10 @@ case class Main(predefCode: String = "",
     case Some(path) =>
       try Right(Some(PredefInfo(Name("FilePredef"), os.read(path), false, Some(path))))
       catch{case e: NoSuchFileException =>
-        Left((Res.Failure("Unable to load predef file " + path), Seq((() => Interpreter.pathSignature(path),  0L))))
+        Left((
+          Res.Failure("Unable to load predef file " + path),
+          Seq((() => Interpreter.pathSignature(path),  0L)))
+        )
       }
     case None => Right(None)
   }

--- a/amm/src/main/scala/ammonite/Main.scala
+++ b/amm/src/main/scala/ammonite/Main.scala
@@ -79,7 +79,7 @@ case class Main(predefCode: String = "",
     case Some(path) =>
       try Right(Some(PredefInfo(Name("FilePredef"), os.read(path), false, Some(path))))
       catch{case e: NoSuchFileException =>
-        Left((Res.Failure("Unable to load predef file " + path), Seq(path -> 0L)))
+        Left((Res.Failure("Unable to load predef file " + path), Seq((() => Interpreter.pathSignature(path),  0L))))
       }
     case None => Right(None)
   }
@@ -203,7 +203,7 @@ case class Main(predefCode: String = "",
     * a sequence of paths that were watched as a result of this REPL run, in
     * case you wish to re-start the REPL when any of them change.
     */
-  def run(replArgs: Bind[_]*): (Res[Any], Seq[(os.Path, Long)]) = {
+  def run(replArgs: Bind[_]*): (Res[Any], Seq[(() => Long, Long)]) = {
 
 
     instantiateRepl(replArgs.toIndexedSeq) match{
@@ -222,7 +222,7 @@ case class Main(predefCode: String = "",
           warmupThread.start()
 
           val exitValue = Res.Success(repl.run())
-          (exitValue.map(repl.beforeExit), repl.interp.watchedFiles.toSeq)
+          (exitValue.map(repl.beforeExit), repl.interp.watchedValues.toSeq)
         }
     }
   }
@@ -233,12 +233,12 @@ case class Main(predefCode: String = "",
     */
   def runScript(path: os.Path,
                 scriptArgs: Seq[(String, Option[String])])
-                : (Res[Any], Seq[(os.Path, Long)]) = {
+                : (Res[Any], Seq[(() => Long, Long)]) = {
 
     instantiateInterpreter() match{
       case Right(interp) =>
         val result = main.Scripts.runScript(wd, path, interp, scriptArgs)
-        (result, interp.watchedFiles.toSeq)
+        (result, interp.watchedValues.toSeq)
       case Left(problems) => problems
     }
   }
@@ -250,7 +250,7 @@ case class Main(predefCode: String = "",
     instantiateInterpreter() match{
       case Right(interp) =>
         val res = interp.processExec(code, 0, () => ())
-        (res, interp.watchedFiles.toSeq)
+        (res, interp.watchedValues.toSeq)
       case Left(problems) => problems
     }
   }
@@ -385,7 +385,7 @@ class MainRunner(cliConfig: Cli.Config,
 
   @tailrec final def watchLoop[T](isRepl: Boolean,
                                   printing: Boolean,
-                                  run: Main => (Res[T], Seq[(os.Path, Long)])): Boolean = {
+                                  run: Main => (Res[T], Seq[(() => Long, Long)])): Boolean = {
     val (result, watched) = run(initMain(isRepl))
 
     val success = handleWatchRes(result, printing)
@@ -407,10 +407,10 @@ class MainRunner(cliConfig: Cli.Config,
 
   def runRepl(): Unit = watchLoop(isRepl = true, printing = false, _.run())
 
-  def watchAndWait(watched: Seq[(os.Path, Long)]) = {
+  def watchAndWait(watched: Seq[(() => Long, Long)]) = {
     printInfo(s"Watching for changes to ${watched.length} files... (Ctrl-C to exit)")
-    def statAll() = watched.forall{ case (file, lastMTime) =>
-      Interpreter.pathSignature(file) == lastMTime
+    def statAll() = watched.forall{ case (check, lastMTime) =>
+      check() == lastMTime
     }
 
     while(statAll()) Thread.sleep(100)

--- a/mill
+++ b/mill
@@ -3,7 +3,7 @@
 # This is a wrapper script, that automatically download mill from GitHub release pages
 # You can give the required mill version with MILL_VERSION env variable
 # If no version is given, it falls back to the value of DEFAULT_MILL_VERSION
-DEFAULT_MILL_VERSION=0.5.7
+DEFAULT_MILL_VERSION=0.6.1
 
 set -e
 


### PR DESCRIPTION
This will allow us to do things like `interp.watchValue(os.list(...))` to re-run a script if the shallow listing of files changes, without caring about the deep hash of everything in the directory tree. 

This will be useful for e.g. Mill cross modules, where we only need to re-run the script when the shallow listing changes while "deep" changes are handled by Mill itself