### PR TITLE
Import pgp key like sbt-ci-release does

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,16 +42,19 @@ matrix:
 
   # Everything worked, *then* kick off a release
   - stage: release
+    before_script: test -z "$SONATYPE_PGP_SECRET" || echo "$SONATYPE_PGP_SECRET" | base64 --decode | gpg --import
     env: CI_SCRIPT="./mill -i publishSonatype __.publishArtifacts 1 3"
     jdk: oraclejdk8
     scala: 2.11.12
 
   - stage: release
+    before_script: test -z "$SONATYPE_PGP_SECRET" || echo "$SONATYPE_PGP_SECRET" | base64 --decode | gpg --import
     env: CI_SCRIPT="./mill -i publishSonatype __.publishArtifacts 2 3"
     jdk: oraclejdk8
     scala: 2.11.12
 
   - stage: release
+    before_script: test -z "$SONATYPE_PGP_SECRET" || echo "$SONATYPE_PGP_SECRET" | base64 --decode | gpg --import
     env: CI_SCRIPT="./mill -i publishSonatype __.publishArtifacts 3 3"
     jdk: oraclejdk8
     scala: 2.11.12

--- a/build.sc
+++ b/build.sc
@@ -692,10 +692,6 @@ def publishSonatype(publishArtifacts: mill.main.Tasks[PublishModule.PublishData]
   if (!isMasterCommit) T.command{()}
   else T.command{
 
-    write(pwd/"gpg_key", sys.env("SONATYPE_PGP_KEY_CONTENTS").replace("\\n", "\n"))
-    %("gpg", "--import", "gpg_key")
-    rm(pwd/"gpg_key")
-
     val x: Seq[(Seq[(Path, String)], Artifact)] = {
       mill.define.Task.sequence(partition(publishArtifacts, shard, divisionCount))().map{
         case PublishModule.PublishData(a, s) => (s.map{case (p, f) => (p.path, f)}, a)


### PR DESCRIPTION
The changes here import the PGP secret key the same way as [sbt-ci-release](https://github.com/olafurpg/sbt-ci-release).

@lihaoyi You should just have to add a Travis env var named `SONATYPE_PGP_SECRET`, whose value can be copied with
```bash
# macOS
gpg --armor --export-secret-keys $LONG_ID | base64 | pbcopy
# Ubuntu (assuming GNU base64)
gpg --armor --export-secret-keys $LONG_ID | base64 -w0 | xclip
```
for this to work. `LONG_ID` can be found in the output of `gpg --list-keys`
```bash
$ gpg --list-keys
…
pub   rsa2048 2020-01-29 [SC] [expire : 2022-01-28]
      8011FD49DC1749CD64137AF3CD1B9D8DC84ECA56
uid          [  ultime ] Alexandre Archambault (Travis CI coursier) <alexandre.archambault+traviscicoursier@gmail.com>
sub   rsa2048 2020-01-29 [E] [expire : 2022-01-28]
…
```
(in this example it's `8011FD49DC1749CD64137AF3CD1B9D8DC84ECA56`).

That should fix releases hopefully.