### PR TITLE
Ignore DirectoryNotEmptyException-s in ScriptCompiler

### DIFF
--- a/amm/interp/src/main/scala/ammonite/interp/script/SemanticdbProcessor.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/script/SemanticdbProcessor.scala
@@ -119,7 +119,7 @@ object SemanticdbProcessor {
             }
         }
       }
-      os.write(dest, updatedDocs.toByteArray, createFolders = true)
+      os.write.over(dest, updatedDocs.toByteArray, createFolders = true)
     } else
       System.err.println(s"Error: $orig not found (for $dest)")
   }


### PR DESCRIPTION
These can happen if when the BSP client is reading some of the files in the target directory, and we want to clean it up prior to writing new files in it. Those files should be overwritten later on anyway, or removed in a later successful clean-up.

I think this is what's happening [here](https://github.com/scalameta/metals/pull/1538/checks?check_run_id=599722489#step:6:4191).