### PR TITLE
Fix caching tests

### DIFF
--- a/amm/src/test/resources/scriptLevelCaching/ivyCachedResourceTest.sc
+++ b/amm/src/test/resources/scriptLevelCaching/ivyCachedResourceTest.sc
@@ -1,2 +1,2 @@
-import $ivy.`io.kamon::kamon-core:0.6.3`
+import $ivy.`io.kamon::kamon-core:2.1.0`
 os.read(os.resource/"reference.conf")

--- a/amm/src/test/resources/scriptLevelCaching/testFileImport.sc
+++ b/amm/src/test/resources/scriptLevelCaching/testFileImport.sc
@@ -1,4 +1,4 @@
-import $file.amm.src.test.resources.scriptLevelCaching.fileToBeImported
+import $file.fileToBeImported
 
 @
 


### PR DESCRIPTION
Seems the return type of some `Scripts.runScript` calls weren't checked in `CachingTests`. Checking them showed that two tests weren't actually run. This PR fixes that.

(This test ended up actually failing, in developments of mine I didn't push yet…)