### PR TITLE
Inline hard-coded predef imports

### DIFF
--- a/amm/interp/src/main/scala/ammonite/interp/CompilerLifecycleManager.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/CompilerLifecycleManager.scala
@@ -54,7 +54,7 @@ class CompilerLifecycleManager(
   def pressy: Pressy = Internal.pressy
 
   def preprocess(fileName: String) = synchronized{
-    if (compiler == null) init(force = true)
+    init()
     DefaultPreprocessor(compiler.parse(fileName, _))
   }
 
@@ -67,7 +67,8 @@ class CompilerLifecycleManager(
   // probably creates a pile of garbage
 
   def init(force: Boolean = false) = synchronized{
-    if ((headFrame ne lastFrame) ||
+    if (compiler == null ||
+        (headFrame ne lastFrame) ||
         headFrame.version != lastFrameVersion ||
         Internal.preConfiguredSettingsChanged ||
         force) {

--- a/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
@@ -99,6 +99,7 @@ class Interpreter(val printer: Printer,
   // Needs to be run after the Interpreter has been instantiated, as some of the
   // ReplAPIs available in the predef need access to the Interpreter object
   def initializePredef(
+    baseImports: Imports,
     basePredefs: Seq[PredefInfo],
     customPredefs: Seq[PredefInfo],
     // Allows you to set up additional "bridges" between the REPL
@@ -125,7 +126,7 @@ class Interpreter(val printer: Printer,
       ("ammonite.interp.api.InterpBridge", "interp", interpApi) +: extraBridges,
       evalClassloader
     )
-    predefImports = predefImports ++ bridgeImports
+    predefImports = predefImports ++ bridgeImports ++ baseImports
 
     PredefInitialization.apply(
       interpApi,

--- a/amm/repl/src/main/scala/ammonite/main/Defaults.scala
+++ b/amm/repl/src/main/scala/ammonite/main/Defaults.scala
@@ -31,19 +31,9 @@ object Defaults{
       "ammonite.interp.api.IvyConstructor.{ArtifactIdExt, GroupIdExt}",
       importType = ImportData.Type
     ),
-    ImportData("""ammonite.ops.{
-      PipeableImplicit,
-      FilterMapExtImplicit,
-      FilterMapArraysImplicit,
-      FilterMapIteratorsImplicit,
-      FilterMapGeneratorsImplicit,
-      SeqFactoryFunc,
-      RegexContextMaker,
-      Callable1Implicit
-    }"""),
     ImportData("ammonite.runtime.tools.{browse, grep, time}"),
     ImportData("ammonite.runtime.tools.tail", importType = ImportData.TermType),
-    ImportData("ammonite.repl.tools.{desugar, Desugared, source}")
+    ImportData("ammonite.repl.tools.{desugar, source}")
   )
 
 

--- a/amm/repl/src/main/scala/ammonite/main/Defaults.scala
+++ b/amm/repl/src/main/scala/ammonite/main/Defaults.scala
@@ -3,7 +3,7 @@ package ammonite.main
 
 import java.io.InputStream
 
-import ammonite.util.Util
+import ammonite.util.{ImportData, Imports, Util}
 import coursierapi.Dependency
 
 import scala.io.Codec
@@ -25,32 +25,37 @@ object Defaults{
   // Need to import stuff from ammonite.ops manually, rather than from the
   // ammonite.ops.Extensions bundle, because otherwise they result in ambiguous
   // imports if someone else imports maunally
-  val predefString = s"""
-    |import ammonite.ops.{
-    |  PipeableImplicit,
-    |  FilterMapExtImplicit,
-    |  FilterMapArraysImplicit,
-    |  FilterMapIteratorsImplicit,
-    |  FilterMapGeneratorsImplicit,
-    |  SeqFactoryFunc,
-    |  RegexContextMaker,
-    |  Callable1Implicit
-    |}
-    |import ammonite.runtime.tools._
-    |import ammonite.repl.tools._
-    |import ammonite.interp.api.IvyConstructor.{ArtifactIdExt, GroupIdExt}
-    |import ammonite.interp.api.InterpBridge.value.exit
-    |""".stripMargin
+  val predefImports = Imports(
+    ImportData("ammonite.interp.api.InterpBridge.value.exit"),
+    ImportData(
+      "ammonite.interp.api.IvyConstructor.{ArtifactIdExt, GroupIdExt}",
+      importType = ImportData.Type
+    ),
+    ImportData("""ammonite.ops.{
+      PipeableImplicit,
+      FilterMapExtImplicit,
+      FilterMapArraysImplicit,
+      FilterMapIteratorsImplicit,
+      FilterMapGeneratorsImplicit,
+      SeqFactoryFunc,
+      RegexContextMaker,
+      Callable1Implicit
+    }"""),
+    ImportData("ammonite.runtime.tools.{browse, grep, time}"),
+    ImportData("ammonite.runtime.tools.tail", importType = ImportData.TermType),
+    ImportData("ammonite.repl.tools.{desugar, Desugared, source}")
+  )
 
-  val replPredef = """
-    |import ammonite.repl.ReplBridge.value.{
-    |  codeColorsImplicit,
-    |  tprintColorsImplicit,
-    |  pprinterImplicit,
-    |  show,
-    |  typeOf
-    |}
-  """.stripMargin
+
+  val replImports = Imports(
+    ImportData("""ammonite.repl.ReplBridge.value.{
+      codeColorsImplicit,
+      tprintColorsImplicit,
+      pprinterImplicit,
+      show,
+      typeOf
+    }""")
+  )
   def ammoniteHome = os.Path(System.getProperty("user.home"))/".ammonite"
 
   def alreadyLoadedDependencies(

--- a/amm/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -16,6 +16,7 @@ class Repl(input: InputStream,
            output: OutputStream,
            error: OutputStream,
            storage: Storage,
+           baseImports: Imports,
            basePredefs: Seq[PredefInfo],
            customPredefs: Seq[PredefInfo],
            wd: os.Path,
@@ -138,7 +139,7 @@ class Repl(input: InputStream,
     )
   )
 
-  def initializePredef() = interp.initializePredef(basePredefs, customPredefs, bridges)
+  def initializePredef() = interp.initializePredef(baseImports, basePredefs, customPredefs, bridges)
 
   def warmup() = {
     // An arbitrary input, randomized to make sure it doesn't get cached or

--- a/amm/repl/src/test/scala/ammonite/TestRepl.scala
+++ b/amm/repl/src/test/scala/ammonite/TestRepl.scala
@@ -55,13 +55,8 @@ class TestRepl {
   val frames = Ref(List(Frame.createInitial(initialClassLoader)))
   val sess0 = new SessionApiImpl(frames)
 
+  val baseImports = ammonite.main.Defaults.replImports ++ ammonite.main.Defaults.predefImports
   val basePredefs = Seq(
-    PredefInfo(
-      Name("defaultPredef"),
-      ammonite.main.Defaults.replPredef + ammonite.main.Defaults.predefString,
-      true,
-      None
-    ),
     PredefInfo(Name("testPredef"), predef._1, false, predef._2)
   )
   val customPredefs = Seq()
@@ -167,7 +162,11 @@ class TestRepl {
     )
   )
 
-  for ((error, _) <- interp.initializePredef(basePredefs, customPredefs, extraBridges)) {
+  for {
+    (error, _) <- interp.initializePredef(
+      baseImports, basePredefs, customPredefs, extraBridges
+    )
+  } {
     val (msgOpt, causeOpt) = error match {
       case r: Res.Exception => (Some(r.msg), Some(r.t))
       case r: Res.Failure => (Some(r.msg), None)

--- a/amm/repl/src/test/scala/ammonite/TestUtils.scala
+++ b/amm/repl/src/test/scala/ammonite/TestUtils.scala
@@ -12,7 +12,11 @@ object TestUtils {
   def scala2_11 = scala.util.Properties.versionNumberString.startsWith("2.11")
   def scala2_12 = scala.util.Properties.versionNumberString.startsWith("2.12")
 
-  def createTestInterp(storage: Storage, predef: String = "") = {
+  def createTestInterp(
+    storage: Storage,
+    predefImports: Imports = Imports(),
+    predef: String = ""
+  ) = {
     val initialClassLoader = Thread.currentThread().getContextClassLoader
     val startFrame = Frame.createInitial(initialClassLoader)
     val printStream = new PrintStream(System.out)
@@ -35,7 +39,12 @@ object TestUtils {
       classPathWhitelist = ammonite.repl.Repl.getClassPathWhitelist(thin = true)
     )
     // Provide a custom predef so we can verify in tests that the predef gets cached
-    interp.initializePredef(Seq(), Seq(PredefInfo(Name("predef"), predef, false, None)), Seq())
+    interp.initializePredef(
+      predefImports,
+      Seq(),
+      Seq(PredefInfo(Name("predef"), predef, false, None)),
+      Seq()
+    )
     interp
   }
 }

--- a/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
@@ -356,7 +356,7 @@ object AdvancedTests extends TestSuite{
     test("desugar"){
       check.session("""
         @ desugar{1 + 2 max 3}
-        res0: Desugared = scala.Predef.intWrapper(3).max(3)
+        res0: ammonite.repl.tools.Desugared = scala.Predef.intWrapper(3).max(3)
       """)
     }
     test("loadingModulesInPredef"){

--- a/amm/runtime/src/main/scala/ammonite/runtime/Storage.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/Storage.scala
@@ -213,7 +213,11 @@ object Storage{
       }
 
       def update(t: History): Unit = {
-        os.write.over(historyFile, upickle.default.stream(t.toVector, indent = 4))
+        os.write.over(
+          historyFile,
+          upickle.default.stream(t.toVector, indent = 4),
+          createFolders = true
+        )
       }
     }
 
@@ -229,7 +233,8 @@ object Storage{
       try {
         os.write.over(
           codeCacheDir/classFilesOrder,
-          upickle.default.stream((tag, perBlockMetadata), indent = 4)
+          upickle.default.stream((tag, perBlockMetadata), indent = 4),
+          createFolders = true
         )
       } catch {
         case _: FileAlreadyExistsException => // ignore
@@ -278,10 +283,11 @@ object Storage{
       os.makeDir.all(tagCacheDir)
       os.write.over(
         tagCacheDir/metadataFile,
-        upickle.default.stream((tag, data.imports), indent = 4)
+        upickle.default.stream((tag, data.imports), indent = 4),
+          createFolders = true
       )
       data.classFiles.foreach{ case (name, bytes) =>
-        os.write.over(tagCacheDir/s"$name.class", bytes)
+        os.write.over(tagCacheDir/s"$name.class", bytes, createFolders = true)
       }
 
     }
@@ -325,7 +331,7 @@ object Storage{
         map.filter(_._2.forall(str => Files.exists(Paths.get(str)))).asInstanceOf[IvyMap]
       }
       def update(map: IvyMap) = {
-        os.write.over(ivyCacheFile, upickle.default.stream(map, indent = 4))
+        os.write.over(ivyCacheFile, upickle.default.stream(map, indent = 4), createFolders = true)
       }
     }
 

--- a/amm/src/test/scala/ammonite/interp/CachingTests.scala
+++ b/amm/src/test/scala/ammonite/interp/CachingTests.scala
@@ -67,7 +67,7 @@ object CachingTests extends TestSuite{
 
         val interp1 = createTestInterp(
           storage,
-          Defaults.predefString
+          predefImports = Defaults.predefImports
         )
 
         runScript(os.pwd, resourcesPath/script, interp1)
@@ -75,7 +75,7 @@ object CachingTests extends TestSuite{
         assert(interp1.compilerManager.compiler != null)
         val interp2 = createTestInterp(
           storage,
-          Defaults.predefString
+          predefImports = Defaults.predefImports
         )
         assert(interp2.compilerManager.compiler == null)
 
@@ -102,7 +102,7 @@ object CachingTests extends TestSuite{
       os.write(numFile, "1", createFolders = true)
       val interp1 = createTestInterp(
         storage,
-        Defaults.predefString
+        predefImports = Defaults.predefImports
       )
 
       runScript(
@@ -113,7 +113,7 @@ object CachingTests extends TestSuite{
 
       val interp2 = createTestInterp(
         storage,
-        Defaults.predefString
+        predefImports = Defaults.predefImports
       )
       val Res.Exception(ex, _) = Scripts.runScript(
         os.pwd,
@@ -187,7 +187,7 @@ object CachingTests extends TestSuite{
           new Storage.Folder(tempDir){
             override val predef = predefFile
           },
-          Defaults.predefString
+          predefImports = Defaults.predefImports
         )
         runScript(os.pwd, scriptFile, interp)
         assert(f(interp.compilerManager.compiler))

--- a/amm/src/test/scala/ammonite/session/ScriptTests.scala
+++ b/amm/src/test/scala/ammonite/session/ScriptTests.scala
@@ -257,7 +257,7 @@ object ScriptTests extends TestSuite{
           val storage = new Storage.Folder(os.temp.dir(prefix = "ammonite-tester"))
           val interp2 = createTestInterp(
             storage,
-            Defaults.predefString + Main.extraPredefString
+            predefImports = Defaults.predefImports ++ Main.extraPredefImports
           )
 
           val Res.Failure(msg) =

--- a/amm/util/src/main/scala/ammonite/util/Imports.scala
+++ b/amm/util/src/main/scala/ammonite/util/Imports.scala
@@ -59,6 +59,26 @@ object ImportData{
   val Type = ImportType("Type")
   val Term = ImportType("Term")
   val TermType = ImportType("TermType")
+
+  def apply(name: String, importType: ImportType = Term): Seq[ImportData] = {
+    val elements = name.split('.')
+    assert(elements.nonEmpty)
+
+    val simpleNames =
+      if (elements.last.startsWith("{") && elements.last.endsWith("}"))
+        elements.last.stripPrefix("{").stripSuffix("}").split(',').map(_.trim).toSeq
+      else
+        Seq(elements.last)
+
+    simpleNames.map { simpleName =>
+      ImportData(
+        Name(simpleName),
+        Name(simpleName),
+        Name("_root_") :: elements.init.map(Name(_)).toList,
+        importType
+      )
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
This PR replaces the hardcoded predef scripts (like [these](https://github.com/lihaoyi/Ammonite/blob/6e2245ec489eef51e7971e89205aa3dc8d1dbbfa/amm/repl/src/main/scala/ammonite/main/Defaults.scala#L28-L53) or [this one](https://github.com/lihaoyi/Ammonite/blob/d8b22aa47bcc0f26f8d435f73c8e98b401621932/amm/src/main/scala/ammonite/Main.scala#L358-L361)), by hardcoded `ImportData`. This is made possible by the hardcoded predef scripts consisting only of imports.

This allows to scrap the frequent upfront predef compilations, like
```
Compiling (synthetic)/ammonite/predef/DefaultPredef.sc
```
(which happen when starting a new Ammonite version, or when starting Ammonite for the first time in a given directory)