### PR TITLE
Tweak predef imports

### DIFF
--- a/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
@@ -99,7 +99,6 @@ class Interpreter(val printer: Printer,
   // Needs to be run after the Interpreter has been instantiated, as some of the
   // ReplAPIs available in the predef need access to the Interpreter object
   def initializePredef(
-    baseImports: Imports,
     basePredefs: Seq[PredefInfo],
     customPredefs: Seq[PredefInfo],
     // Allows you to set up additional "bridges" between the REPL
@@ -110,7 +109,8 @@ class Interpreter(val printer: Printer,
     // bridges need to be in place *before* the predef starts
     // running, so you can use them predef to e.g. configure
     // the REPL before it starts
-    extraBridges: Seq[(String, String, AnyRef)]
+    extraBridges: Seq[(String, String, AnyRef)],
+    baseImports: Imports = Interpreter.predefImports
   ): Option[(Res.Failing, Seq[(Watchable, Long)])] = {
 
     headFrame.classloader.specialLocalClasses ++= Seq(
@@ -697,6 +697,19 @@ class Interpreter(val printer: Printer,
 }
 
 object Interpreter{
+
+  val predefImports = Imports(
+    ImportData("ammonite.interp.api.InterpBridge.value.exit"),
+    ImportData(
+      "ammonite.interp.api.IvyConstructor.{ArtifactIdExt, GroupIdExt}",
+      importType = ImportData.Type
+    ),
+    ImportData("ammonite.runtime.tools.{browse, grep, time}"),
+    ImportData("ammonite.runtime.tools.tail", importType = ImportData.TermType),
+    ImportData("ammonite.repl.tools.{desugar, source}"),
+    ImportData("ammonite.main.Router.{doc, main}"),
+    ImportData("ammonite.repl.tools.Util.pathScoptRead")
+  )
 
 
 

--- a/amm/repl/src/main/scala/ammonite/main/Defaults.scala
+++ b/amm/repl/src/main/scala/ammonite/main/Defaults.scala
@@ -22,9 +22,6 @@ object Defaults{
     )
   }
 
-  // Need to import stuff from ammonite.ops manually, rather than from the
-  // ammonite.ops.Extensions bundle, because otherwise they result in ambiguous
-  // imports if someone else imports maunally
   val predefImports = Imports(
     ImportData("ammonite.interp.api.InterpBridge.value.exit"),
     ImportData(

--- a/amm/repl/src/main/scala/ammonite/main/Defaults.scala
+++ b/amm/repl/src/main/scala/ammonite/main/Defaults.scala
@@ -22,18 +22,6 @@ object Defaults{
     )
   }
 
-  val predefImports = Imports(
-    ImportData("ammonite.interp.api.InterpBridge.value.exit"),
-    ImportData(
-      "ammonite.interp.api.IvyConstructor.{ArtifactIdExt, GroupIdExt}",
-      importType = ImportData.Type
-    ),
-    ImportData("ammonite.runtime.tools.{browse, grep, time}"),
-    ImportData("ammonite.runtime.tools.tail", importType = ImportData.TermType),
-    ImportData("ammonite.repl.tools.{desugar, source}")
-  )
-
-
   val replImports = Imports(
     ImportData("""ammonite.repl.ReplBridge.value.{
       codeColorsImplicit,

--- a/amm/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -139,7 +139,7 @@ class Repl(input: InputStream,
     )
   )
 
-  def initializePredef() = interp.initializePredef(baseImports, basePredefs, customPredefs, bridges)
+  def initializePredef() = interp.initializePredef(basePredefs, customPredefs, bridges, baseImports)
 
   def warmup() = {
     // An arbitrary input, randomized to make sure it doesn't get cached or

--- a/amm/repl/src/test/scala/ammonite/TestRepl.scala
+++ b/amm/repl/src/test/scala/ammonite/TestRepl.scala
@@ -55,7 +55,7 @@ class TestRepl {
   val frames = Ref(List(Frame.createInitial(initialClassLoader)))
   val sess0 = new SessionApiImpl(frames)
 
-  val baseImports = ammonite.main.Defaults.replImports ++ ammonite.main.Defaults.predefImports
+  val baseImports = ammonite.main.Defaults.replImports ++ Interpreter.predefImports
   val basePredefs = Seq(
     PredefInfo(Name("testPredef"), predef._1, false, predef._2)
   )
@@ -164,7 +164,7 @@ class TestRepl {
 
   for {
     (error, _) <- interp.initializePredef(
-      baseImports, basePredefs, customPredefs, extraBridges
+      basePredefs, customPredefs, extraBridges, baseImports
     )
   } {
     val (msgOpt, causeOpt) = error match {

--- a/amm/repl/src/test/scala/ammonite/TestUtils.scala
+++ b/amm/repl/src/test/scala/ammonite/TestUtils.scala
@@ -40,10 +40,10 @@ object TestUtils {
     )
     // Provide a custom predef so we can verify in tests that the predef gets cached
     interp.initializePredef(
-      predefImports,
       Seq(),
       Seq(PredefInfo(Name("predef"), predef, false, None)),
-      Seq()
+      Seq(),
+      predefImports
     )
     interp
   }

--- a/amm/src/main/scala/ammonite/Main.scala
+++ b/amm/src/main/scala/ammonite/Main.scala
@@ -101,7 +101,7 @@ case class Main(predefCode: String = "",
 
     loadedPredefFile.right.map{ predefFileInfoOpt =>
       val augmentedImports =
-        if (defaultPredef) Defaults.replImports ++ Defaults.predefImports ++ Main.extraPredefImports
+        if (defaultPredef) Defaults.replImports ++ Interpreter.predefImports
         else Imports()
 
       val argString = replArgs.zipWithIndex.map{ case (b, idx) =>
@@ -145,7 +145,7 @@ case class Main(predefCode: String = "",
   def instantiateInterpreter() = {
     loadedPredefFile.right.flatMap { predefFileInfoOpt =>
       val augmentedImports =
-        if (defaultPredef) Defaults.predefImports ++ Main.extraPredefImports
+        if (defaultPredef) Interpreter.predefImports
         else Imports()
 
       val (colorsRef, printer) = Interpreter.initPrinters(
@@ -186,7 +186,7 @@ case class Main(predefCode: String = "",
           new FrontEndAPIImpl {}
         )
       )
-      interp.initializePredef(augmentedImports, Seq(), customPredefs, bridges) match{
+      interp.initializePredef(Seq(), customPredefs, bridges, augmentedImports) match{
         case None => Right(interp)
         case Some(problems) => Left(problems)
       }
@@ -346,11 +346,6 @@ object Main{
     * https://stackoverflow.com/a/1403817/871202
     */
   def isInteractive() = System.console() != null
-
-  val extraPredefImports = Imports(
-    ImportData("ammonite.main.Router.{doc, main}"),
-    ImportData("ammonite.repl.tools.Util.pathScoptRead")
-  )
 
 
   class WhiteListClassLoader(whitelist: Set[Seq[String]], parent: ClassLoader)

--- a/amm/src/test/scala/ammonite/interp/CachingTests.scala
+++ b/amm/src/test/scala/ammonite/interp/CachingTests.scala
@@ -67,7 +67,7 @@ object CachingTests extends TestSuite{
 
         val interp1 = createTestInterp(
           storage,
-          predefImports = Defaults.predefImports
+          predefImports = Interpreter.predefImports
         )
 
         runScript(os.pwd, resourcesPath/script, interp1)
@@ -75,7 +75,7 @@ object CachingTests extends TestSuite{
         assert(interp1.compilerManager.compiler != null)
         val interp2 = createTestInterp(
           storage,
-          predefImports = Defaults.predefImports
+          predefImports = Interpreter.predefImports
         )
         assert(interp2.compilerManager.compiler == null)
 
@@ -102,7 +102,7 @@ object CachingTests extends TestSuite{
       os.write(numFile, "1", createFolders = true)
       val interp1 = createTestInterp(
         storage,
-        predefImports = Defaults.predefImports
+        predefImports = Interpreter.predefImports
       )
 
       runScript(
@@ -113,7 +113,7 @@ object CachingTests extends TestSuite{
 
       val interp2 = createTestInterp(
         storage,
-        predefImports = Defaults.predefImports
+        predefImports = Interpreter.predefImports
       )
       val Res.Exception(ex, _) = Scripts.runScript(
         os.pwd,
@@ -187,7 +187,7 @@ object CachingTests extends TestSuite{
           new Storage.Folder(tempDir){
             override val predef = predefFile
           },
-          predefImports = Defaults.predefImports
+          predefImports = Interpreter.predefImports
         )
         runScript(os.pwd, scriptFile, interp)
         assert(f(interp.compilerManager.compiler))

--- a/amm/src/test/scala/ammonite/session/ScriptTests.scala
+++ b/amm/src/test/scala/ammonite/session/ScriptTests.scala
@@ -257,7 +257,7 @@ object ScriptTests extends TestSuite{
           val storage = new Storage.Folder(os.temp.dir(prefix = "ammonite-tester"))
           val interp2 = createTestInterp(
             storage,
-            predefImports = Defaults.predefImports ++ Main.extraPredefImports
+            predefImports = ammonite.interp.Interpreter.predefImports
           )
 
           val Res.Failure(msg) =


### PR DESCRIPTION
This mainly merges `Default.predefImports` and `Main.extraPredefImports`. They were used together almost all the time. Except in some tests, where `Default.predefImports` was used alone, but adding `extraPredefImports` isn't a problem.

This also moves them to `Interpreter`, where they make a sensible default for `Interpreter.initializePredef` (and the BSP support will be able to re-use them from there).