### PR TITLE
Handle SIGINT When Reading User Input

### DIFF
--- a/amm/repl/src/main/scala/ammonite/repl/AmmoniteFrontEnd.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/AmmoniteFrontEnd.scala
@@ -50,7 +50,9 @@ case class AmmoniteFrontEnd(extraFilters: Filter = Filter.empty) extends FrontEn
 
     val autocompleteFilter: Filter = Filter.action(SpecialKeys.Tab){
       case TermState(rest, b, c, _) =>
-        val (newCursor, completions, details) = compilerComplete(c, b.mkString)
+        val (newCursor, completions, details) = TTY.withSttyOverride(TTY.restoreSigInt()) {
+          compilerComplete(c, b.mkString)
+        }
         val details2 = for (d <- details) yield {
 
           Highlighter.defaultHighlight(

--- a/amm/repl/src/main/scala/ammonite/repl/Signaller.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/Signaller.scala
@@ -41,6 +41,6 @@ case class Signaller(sigStr: String)(f: => Unit) extends Scoped{
 trait Scoped{
   def apply[T](t: => T): T
   def foreach[T](t: Unit => T): T = apply(t(()))
-  def flatMap[T, M[_]](t: Unit => M[T]): M[T] = apply(t(()))
+  def flatMap[T](t: Unit => T): T = apply(t(()))
   def map[T](t: Unit => T): T = apply(t(()))
 }

--- a/amm/repl/src/main/scala/ammonite/repl/Signaller.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/Signaller.scala
@@ -29,7 +29,8 @@ case class Signaller(sigStr: String)(f: => Unit) extends Scoped{
     finally{
       val head::tail = handlers(sig)
       handlers(sig) = tail
-      sun.misc.Signal.handle(sig, head)
+      val handlerToRegister = tail.headOption.getOrElse(sun.misc.SignalHandler.SIG_DFL)
+      sun.misc.Signal.handle(sig, handlerToRegister)
     }
   }
 }

--- a/terminal/src/main/scala/ammonite/terminal/Terminal.scala
+++ b/terminal/src/main/scala/ammonite/terminal/Terminal.scala
@@ -36,20 +36,9 @@ object Terminal {
                filters: Filter,
                displayTransform: (Vector[Char], Int) => (fansi.Str, Int) = LineReader.noTransform)
                : Option[String] = {
-
-
-    val initialConfig = TTY.init()
-    try {
+    TTY.withSttyOverride(TTY.readLineStty()) {
       new LineReader(ConsoleDim.width(), prompt, reader, writer, filters, displayTransform)
         .readChar(TermState(LazyList.continually(reader.read()), Vector.empty, 0, ""), 0)
-    }finally{
-
-      // Don't close these! Closing these closes stdin/stdout,
-      // which seems to kill the entire program
-
-      // reader.close()
-      // writer.close()
-      TTY.stty(initialConfig)
     }
   }
 }


### PR DESCRIPTION
This closes issue #729.

There are several issues with the interaction between the terminal, SIGINT, and signal handling:
* `Signaller` actually does not restore the previous signal handler in its finally block; it reinstalls the current handler (unless someone modifies `Signaller.handlers` directly). This seems to be simply a bug.
* Users cannot send SIGINT to Ammonite while the input line is being read in, including during auto completion. Instead, Ammonite interprets the control character literally. However, this behavior is still in place during autocompletion, so users cannot Ctrl-C to cancel autocompletion, as this doesn't send SIGINT.
* Even if users could send SIGINT to Ammonite when typing, the Signaller is only invoked after having read in the users' input.

This PR addresses all three issues: we correct the behavior of Signaller, modify the TTY configuration so Ctrl-C results in SIGINT during autocomplete, and move the Signaller invocation before the frontend call so that the SIGINT handler is registered during autocomplete.

A screenshot of the new behavior:
<img width="765" alt="Screenshot 2020-05-10 at 01 26 34" src="https://user-images.githubusercontent.com/1850319/81487467-54c48300-925d-11ea-8036-0f4ac5c73fca.png">
(This was made by typing tab then Ctrl-C in quick succession.)