### PR TITLE
Report wrong import $file-s via diagnostics in BSP

### DIFF
--- a/amm/interp/src/main/scala/ammonite/interp/script/AmmoniteBuildServer.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/script/AmmoniteBuildServer.scala
@@ -385,20 +385,14 @@ class AmmoniteBuildServer(
     result
   }
 
-  private def compileScript(script: Script, target: BuildTargetIdentifier): Boolean =
-    if (script.processorDiagnostics.isEmpty) {
-      val (_, res) = compiler.compile(
-        script,
-        proc,
-        doCompile = compileScript(_, _)
-      )
-
-      res.isRight
-    } else {
-      for (client <- clientOpt)
-        sendDiagnostics(client, script, target, Nil)
-      false
-    }
+  private def compileScript(script: Script, target: BuildTargetIdentifier): Boolean = {
+    val (_, res) = compiler.compile(
+      script,
+      proc,
+      doCompile = compileScript(_, _)
+    )
+    script.processorDiagnostics.isEmpty && res.isRight
+  }
 
   def buildTargetCompile(params: CompileParams): CompletableFuture[CompileResult] =
     on(compileEc) {

--- a/amm/interp/src/main/scala/ammonite/interp/script/Script.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/script/Script.scala
@@ -8,7 +8,8 @@ import ammonite.util.Name
 final case class Script(
   code: String,
   codeSource: CodeSource,
-  blocks: Seq[Script.Block]
+  blocks: Seq[Script.Block],
+  processorDiagnostics: Seq[Diagnostic]
 ) {
 
   lazy val dependencyImports: Imports = {

--- a/amm/interp/src/main/scala/ammonite/interp/script/ScriptCache.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/script/ScriptCache.scala
@@ -43,13 +43,8 @@ final class ScriptCache(
       .filter(os.isFile(_))
       .flatMap { p =>
         // FIXME Blocking
-        proc.load(p) match {
-          case Left(err) =>
-            // TODO Log error
-            Nil
-          case Right(script) =>
-            Seq(script)
-        }
+        val script = proc.load(p)
+        Seq(script)
       }
 
     val dependencies = scripts0

--- a/amm/interp/src/main/scala/ammonite/interp/script/SingleScriptCompiler.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/script/SingleScriptCompiler.scala
@@ -144,18 +144,21 @@ class SingleScriptCompiler(
     blocksOffsetAndCode: Vector[(Int, String)]
   ): Unit = {
 
-    def adjust(blockIdx: Int): (Int, Int) => Option[(Int, Int)] = {
-      val startOffsetInSc = module.blocks(blockIdx - 1).startIdx
-      val startPosInSc = offsetToPosSc(startOffsetInSc)
+    def adjust(blockIdx: Int): (Int, Int) => Option[(Int, Int)] =
+      if (module.blocks.isEmpty) // can happen if there were errors during preprocessing
+        (_, _) => None
+      else {
+        val startOffsetInSc = module.blocks(blockIdx - 1).startIdx
+        val startPosInSc = offsetToPosSc(startOffsetInSc)
 
-      PositionOffsetConversion.scalaPosToScPos(
-        module.code,
-        startPosInSc.line,
-        startPosInSc.char,
-        blocksOffsetAndCode(blockIdx - 1)._2,
-        blocksOffsetAndCode(blockIdx - 1)._1
-      )
-    }
+        PositionOffsetConversion.scalaPosToScPos(
+          module.code,
+          startPosInSc.line,
+          startPosInSc.char,
+          blocksOffsetAndCode(blockIdx - 1)._2,
+          blocksOffsetAndCode(blockIdx - 1)._1
+        )
+      }
 
     for {
       target <- moduleTarget

--- a/amm/repl/src/main/scala/ammonite/repl/AmmoniteFrontEnd.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/AmmoniteFrontEnd.scala
@@ -28,7 +28,7 @@ case class AmmoniteFrontEnd(extraFilters: Filter = Filter.empty) extends FrontEn
         addHistory(code)
         fastparse.parse(code, Parsers.Splitter(_)) match{
           case Parsed.Success(value, idx) =>
-            Res.Success((code, value))
+            Res.Success((code, value.map(_._2)))
           case f @ Parsed.Failure(_, index, extra) =>
             Res.Failure(
               Preprocessor.formatFastparseError("(console)", code, f)

--- a/amm/src/test/resources/bsp/error/error-and-invalid-import-file.sc
+++ b/amm/src/test/resources/bsp/error/error-and-invalid-import-file.sc
@@ -1,0 +1,3 @@
+import $file.nope.nope.nope
+
+zz

--- a/amm/src/test/resources/bsp/error/invalid-import-file.sc
+++ b/amm/src/test/resources/bsp/error/invalid-import-file.sc
@@ -1,0 +1,4 @@
+import scala.collection.mutable._
+import $file.nope.nope.nope
+
+val n = 2

--- a/amm/src/test/scala/ammonite/interp/script/AmmoniteBuildServerTests.scala
+++ b/amm/src/test/scala/ammonite/interp/script/AmmoniteBuildServerTests.scala
@@ -422,6 +422,33 @@ object AmmoniteBuildServerTests extends TestSuite {
           _ = assert(diagnostics == expectedDiagnostics)
         } yield ()
       }
+
+      "import file and compilation" - {
+        val runner = new BspScriptRunner(wd / "error" / "error-and-invalid-import-file.sc")
+
+        val expectedDiagnostics = List(
+          new BDiagnostic(
+            new Range(new BPosition(0, 7), new BPosition(0, 27)),
+            "Cannot resolve $file import: ./error/nope/nope/nope.sc"
+          ),
+          new BDiagnostic(
+            new Range(new BPosition(2, 0), new BPosition(2, 2)),
+            "not found: value zz"
+          )
+        )
+        expectedDiagnostics.foreach(_.setSeverity(DiagnosticSeverity.ERROR))
+
+        for {
+          _ <- runner.init()
+          _ <- runner.compile(StatusCode.ERROR)
+
+          diagnostics = runner.diagnostics()
+          _ = diagnostics.foreach { diag =>
+            diag.setMessage(diag.getMessage.replace(wd.toString, "."))
+          }
+          _ = assert(diagnostics == expectedDiagnostics)
+        } yield ()
+      }
     }
 
     "multi" - {

--- a/amm/src/test/scala/ammonite/interp/script/AmmoniteBuildServerTests.scala
+++ b/amm/src/test/scala/ammonite/interp/script/AmmoniteBuildServerTests.scala
@@ -374,29 +374,54 @@ object AmmoniteBuildServerTests extends TestSuite {
     }
 
     "errored" - {
-      val runner = new BspScriptRunner(wd / "error" / "foo.sc")
+      "compilation" - {
+        val runner = new BspScriptRunner(wd / "error" / "foo.sc")
 
-      val expectedDiagnostics = List(
-        new BDiagnostic(
-          new Range(new BPosition(0, 0), new BPosition(0, 2)),
-          "not found: value aa"
-        ),
-        new BDiagnostic(
-          new Range(new BPosition(3, 0), new BPosition(3, 2)),
-          "not found: value zz"
+        val expectedDiagnostics = List(
+          new BDiagnostic(
+            new Range(new BPosition(0, 0), new BPosition(0, 2)),
+            "not found: value aa"
+          ),
+          new BDiagnostic(
+            new Range(new BPosition(3, 0), new BPosition(3, 2)),
+            "not found: value zz"
+          )
         )
-      )
-      expectedDiagnostics.foreach(_.setSeverity(DiagnosticSeverity.ERROR))
+        expectedDiagnostics.foreach(_.setSeverity(DiagnosticSeverity.ERROR))
 
-      for {
-        _ <- runner.init()
+        for {
+          _ <- runner.init()
 
-        _ <- runner.compile(StatusCode.ERROR)
+          _ <- runner.compile(StatusCode.ERROR)
 
-        diagnostics = runner.diagnostics()
-        _ = assert(diagnostics == expectedDiagnostics)
+          diagnostics = runner.diagnostics()
+          _ = assert(diagnostics == expectedDiagnostics)
 
-      } yield ()
+        } yield ()
+      }
+
+      "import file" - {
+        val runner = new BspScriptRunner(wd / "error" / "invalid-import-file.sc")
+
+        val expectedDiagnostics = List(
+          new BDiagnostic(
+            new Range(new BPosition(1, 7), new BPosition(1, 27)),
+            "Cannot resolve $file import: ./error/nope/nope/nope.sc"
+          )
+        )
+        expectedDiagnostics.foreach(_.setSeverity(DiagnosticSeverity.ERROR))
+
+        for {
+          _ <- runner.init()
+          _ <- runner.compile(StatusCode.ERROR)
+
+          diagnostics = runner.diagnostics()
+          _ = diagnostics.foreach { diag =>
+            diag.setMessage(diag.getMessage.replace(wd.toString, "."))
+          }
+          _ = assert(diagnostics == expectedDiagnostics)
+        } yield ()
+      }
     }
 
     "multi" - {


### PR DESCRIPTION
This allows to get red squiggles under `import $file`s when the corresponding fie is not found, when editing Ammonite scripts in metals.