### PR TITLE
Allow building from release archive

### DIFF
--- a/ops/src/test/scala/test/ammonite/ops/ShelloutTests.scala
+++ b/ops/src/test/scala/test/ammonite/ops/ShelloutTests.scala
@@ -63,7 +63,7 @@ object ShelloutTests extends TestSuite{
         if(Unix()){
           val res = %%('which, 'echo)
           val echoRoot = Path(res.out.string.trim)
-          assert(echoRoot == root/'bin/'echo)
+          assert(echoRoot == root/'bin/'echo || echoRoot == root/'usr/'bin/'echo)
 
           assert(%%(echoRoot, 'HELLO).out.lines == Seq("HELLO"))
         }


### PR DESCRIPTION
Add support for `RELEASE_ARCHIVE_VERSION` environment variable to `build.sc`.
If `RELEASE_ARCHIVE_VERSION` is set, it assumes, that build is performed from the
release source archive and does not invoke `git` command, which otherwise would result
in `fatal: not a git repository` error.
`RELEASE_ARCHIVE_VERSION` should be set to the source archive version, e.g:
```
$ RELEASE_ARCHIVE_VERSION=2.3.8 mill -i amm[2.13.3].assembly
```

Addresses issue #1130 