### PR TITLE
Update scala-collection-compat to 2.3.1

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -151,7 +151,7 @@ object ops extends Cross[OpsModule](binCrossScalaVersions:_*)
 class OpsModule(val crossScalaVersion: String) extends AmmModule{
   def ivyDeps = Agg(
     ivy"com.lihaoyi::os-lib:0.7.1",
-    ivy"org.scala-lang.modules::scala-collection-compat:2.1.2"
+    ivy"org.scala-lang.modules::scala-collection-compat:2.3.1"
   )
   def scalacOptions = super.scalacOptions().filter(!_.contains("acyclic"))
   object test extends Tests


### PR DESCRIPTION
Only version also published for Scala `3.0.0-M2`.