### PR TITLE
Factor package name in Interpreter.Parameters

### DIFF
--- a/amm/compiler/src/main/scala/ammonite/compiler/CodeClassWrapper.scala
+++ b/amm/compiler/src/main/scala/ammonite/compiler/CodeClassWrapper.scala
@@ -67,7 +67,7 @@ object ${indexedWrapperName.backticked}{
         val (l, reqVals0) = imports
           .value
           .map { data =>
-            val prefix = Seq(Name("_root_"), Name("ammonite"), Name("$sess"))
+            val prefix = Seq(Name("_root_")) ++ source.pkgName
             if (data.prefix.startsWith(prefix) && data.prefix.endsWith(wrapperPath)) {
               val name = data.prefix.drop(prefix.length).dropRight(wrapperPath.length).last
               (data.copy(prefix = Seq(name)), Seq(name -> data.prefix))

--- a/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
@@ -237,7 +237,7 @@ class Interpreter(
     val codeSource = CodeSource(
       wrapperName,
       Seq(),
-      Seq(Name("ammonite"), Name("$sess")),
+      parameters.pkgName,
       Some(wd / "(console)")
     )
     val (hookStmts, importTrees) = parser().parseImportHooks(codeSource, stmts)
@@ -299,6 +299,7 @@ class Interpreter(
         printer,
         indexedWrapperName,
         replCodeWrapper.wrapperPath,
+        parameters.pkgName,
         silent,
         evalClassloader
       )
@@ -456,7 +457,7 @@ class Interpreter(
           CodeSource(
             wrapperName,
             Seq(),
-            Seq(Name("ammonite"), Name("$sess")),
+            parameters.pkgName,
             Some(wd / "(console)")
           ),
           (processed, indexedWrapperName) =>
@@ -755,7 +756,8 @@ object Interpreter {
       alreadyLoadedDependencies: Seq[Dependency] = Nil,
       classPathWhitelist: Set[Seq[String]] = Set.empty,
       wrapperNamePrefix: String = "cmd",
-      warnings: Boolean = false
+      warnings: Boolean = false,
+      pkgName: Seq[Name] = Seq(Name("ammonite"), Name("$sess"))
   )
 
   val predefImports = Imports(

--- a/amm/repl/src/test/scala/ammonite/DualTestRepl.scala
+++ b/amm/repl/src/test/scala/ammonite/DualTestRepl.scala
@@ -1,7 +1,7 @@
 package ammonite
 
 import ammonite.compiler.CodeClassWrapper
-import ammonite.util.{Evaluated, Res}
+import ammonite.util.{Evaluated, Name, Res}
 
 /**
  * Wraps several [[TestRepl]], and runs its tests against all of them.
@@ -10,6 +10,7 @@ class DualTestRepl { dual =>
 
   def predef: (String, Option[os.Path]) = ("", None)
   def wrapperNamePrefix = Option.empty[String]
+  def pkgName = Option.empty[Seq[Name]]
 
   def warnings = true
 
@@ -18,12 +19,14 @@ class DualTestRepl { dual =>
     new TestRepl(compilerBuilder) {
       override def predef = dual.predef
       override def wrapperNamePrefix = dual.wrapperNamePrefix
+      override def pkgName = dual.pkgName
       override def warnings = dual.warnings
     },
     new TestRepl(compilerBuilder) {
       override def predef = dual.predef
       override def codeWrapper = CodeClassWrapper
       override def wrapperNamePrefix = dual.wrapperNamePrefix
+      override def pkgName = dual.pkgName
       override def warnings = dual.warnings
     }
   )

--- a/amm/repl/src/test/scala/ammonite/TestRepl.scala
+++ b/amm/repl/src/test/scala/ammonite/TestRepl.scala
@@ -30,6 +30,7 @@ class TestRepl(compilerBuilder: ICompilerBuilder = CompilerBuilder()) { self =>
   def predef: (String, Option[os.Path]) = ("", None)
   def codeWrapper: CodeWrapper = DefaultCodeWrapper
   def wrapperNamePrefix = Option.empty[String]
+  def pkgName = Option.empty[Seq[Name]]
   def warnings = true
 
   val tempDir = os.Path(
@@ -80,7 +81,8 @@ class TestRepl(compilerBuilder: ICompilerBuilder = CompilerBuilder()) { self =>
     importHooks = ImportHook.defaults,
     classPathWhitelist = ammonite.repl.Repl.getClassPathWhitelist(thin = true),
     wrapperNamePrefix = wrapperNamePrefix.getOrElse(Interpreter.Parameters().wrapperNamePrefix),
-    warnings = warnings
+    warnings = warnings,
+    pkgName = pkgName.getOrElse(Interpreter.Parameters().pkgName)
   )
   val interp =
     try {

--- a/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
@@ -2,7 +2,7 @@ package ammonite.session
 
 import ammonite.TestUtils._
 import ammonite.{DualTestRepl, TestRepl}
-import ammonite.util.Res
+import ammonite.util.{Name, Res}
 import utest._
 
 object AdvancedTests extends TestSuite {
@@ -778,6 +778,33 @@ object AdvancedTests extends TestSuite {
       check.session(
         """
           @ val clsName = getClass.getName.stripPrefix("ammonite.$sess.").stripSuffix("Helper")
+          clsName: String = "cell0$"
+        """
+      )
+    }
+
+    test("custom package name") {
+      val check = new DualTestRepl {
+        override def pkgName = Some(Seq(Name("ammonite"), Name("$thing")))
+      }
+      // Helper suffix stripped for class-based code wrapping
+      check.session(
+        """
+          @ val clsName = getClass.getName.stripPrefix("ammonite.$thing.").stripSuffix("Helper")
+          clsName: String = "cmd0$"
+        """
+      )
+    }
+
+    test("longer custom package name and custom wrapper") {
+      val check = new DualTestRepl {
+        override def pkgName = Some(Seq(Name("ammonite"), Name("foo"), Name("$other"), Name("$thing")))
+        override def wrapperNamePrefix = Some("cell")
+      }
+      // Helper suffix stripped for class-based code wrapping
+      check.session(
+        """
+          @ val clsName = getClass.getName.stripPrefix("ammonite.foo.$other.$thing.").stripSuffix("Helper")
           clsName: String = "cell0$"
         """
       )

--- a/amm/runtime/src/main/scala/ammonite/runtime/Evaluator.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/Evaluator.scala
@@ -27,6 +27,7 @@ trait Evaluator {
       printer: Printer,
       indexedWrapperName: Name,
       wrapperPath: Seq[Name],
+      pkgName: Seq[Name],
       silent: Boolean,
       contextClassLoader: ClassLoader
   ): Res[Evaluated]
@@ -114,11 +115,12 @@ object Evaluator {
         printer: Printer,
         indexedWrapperName: Name,
         wrapperPath: Seq[Name],
+        pkgName: Seq[Name],
         silent: Boolean,
         contextClassLoader: ClassLoader
     ) = {
       for {
-        cls <- loadClass("ammonite.$sess." + indexedWrapperName.backticked, classFiles)
+        cls <- loadClass(pkgName.map(_.backticked + ".").mkString + indexedWrapperName.backticked, classFiles)
         _ <- Catching { userCodeExceptionHandler }
       } yield {
         headFrame.usedEarlierDefinitions = usedEarlierDefinitions
@@ -132,7 +134,7 @@ object Evaluator {
 
         // "" Empty string as cache tag of repl code
         evaluationResult(
-          Seq(Name("ammonite"), Name("$sess"), indexedWrapperName),
+          pkgName ++ Seq(indexedWrapperName),
           wrapperPath,
           newImports
         )


### PR DESCRIPTION
This allows users of Ammonite as a library to customize that package name if they want to.

This should be useful in certain uses of [Almond](https://github.com/almond-sh/almond) in particular, where, in the context of Spark, some users run several sessions with little isolation between sessions, as a given Spark context assumes the user class path is a single flat class path. Using different package names in different sessions should make the session classes not clash with each other.